### PR TITLE
Fix flaky CI: rate-limit tests, mcp-scanner, zizmor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          files: |
-            dist/*
-            dist/*.sigstore
-            sbom.cdx.json
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --generate-notes \
+            dist/* dist/*.sigstore sbom.cdx.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -69,9 +69,10 @@ jobs:
           set -euo pipefail
           source .venv/bin/activate
           uv pip install cisco-ai-mcp-scanner
-          mcp-scanner \
+          mcp-scanner stdio \
             --stdio-command uv \
-            --stdio-args run automox-mcp \
+            --stdio-arg run \
+            --stdio-arg automox-mcp \
             --stdio-env AUTOMOX_API_KEY=test-api-key \
             --stdio-env AUTOMOX_ACCOUNT_UUID=test-account \
             --stdio-env AUTOMOX_ORG_ID=0 \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -93,16 +93,18 @@ jobs:
           import pathlib, re, sys
 
           summary = pathlib.Path("mcp-scanner.txt").read_text()
-          match = re.search(r"Unsafe tools:\s*(\d+)", summary)
+          match = re.search(r"Unsafe (?:tools|items):\s*(\d+)", summary)
           if match is None:
-              print("Unable to locate 'Unsafe tools' line in MCP scanner output.")
+              print("Unable to locate 'Unsafe tools/items' line in MCP scanner output.")
+              print("Output was:")
+              print(summary)
               sys.exit(1)
           unsafe_count = int(match.group(1))
           if unsafe_count > 0:
               print(summary)
-              print(f"Unsafe tools detected: {unsafe_count}")
+              print(f"Unsafe items detected: {unsafe_count}")
               sys.exit(1)
-          print("MCP Scanner reported no unsafe tools.")
+          print("MCP Scanner reported no unsafe items.")
           PY
 
       - name: Upload MCP Scanner report

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -69,7 +69,10 @@ jobs:
           set -euo pipefail
           source .venv/bin/activate
           uv pip install cisco-ai-mcp-scanner
-          mcp-scanner stdio \
+          mcp-scanner \
+            --analyzers yara \
+            --format summary \
+            stdio \
             --stdio-command uv \
             --stdio-arg run \
             --stdio-arg automox-mcp \
@@ -77,8 +80,6 @@ jobs:
             --stdio-env AUTOMOX_ACCOUNT_UUID=test-account \
             --stdio-env AUTOMOX_ORG_ID=0 \
             --stdio-env AUTOMOX_MCP_SKIP_DOTENV=1 \
-            --analyzers yara \
-            --format summary \
             | tee mcp-scanner.txt
 
       - name: Fail if MCP Scanner reports unsafe tools

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           AUTOMOX_API_KEY: test-api-key
           AUTOMOX_ACCOUNT_UUID: test-account
-          AUTOMOX_ORG_ID: "0"
+          AUTOMOX_ORG_ID: "1"
           AUTOMOX_MCP_SKIP_DOTENV: "1"
         run: |
           set -euo pipefail
@@ -78,7 +78,7 @@ jobs:
             --stdio-arg automox-mcp \
             --stdio-env AUTOMOX_API_KEY=test-api-key \
             --stdio-env AUTOMOX_ACCOUNT_UUID=test-account \
-            --stdio-env AUTOMOX_ORG_ID=0 \
+            --stdio-env AUTOMOX_ORG_ID=1 \
             --stdio-env AUTOMOX_MCP_SKIP_DOTENV=1 \
             | tee mcp-scanner.txt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MCP Scanner CI failure** — `mcp-scanner` v4.x requires the `stdio` subcommand and `--stdio-arg` (singular, repeatable) instead of `--stdio-args` (which consumed only one token, causing `automox-mcp` to be misinterpreted as a subcommand)
 - **MCP Scanner arg ordering** — Moved `--analyzers` and `--format` global options before the `stdio` subcommand where the CLI parser expects them, and changed dummy `AUTOMOX_ORG_ID` from `0` to `1` to pass server validation (positive integer required)
+- **MCP Scanner output parsing** — Updated the CI check script regex to match `Unsafe items:` (mcp-scanner v4.4.0 output) in addition to `Unsafe tools:`
 - **Zizmor `superfluous-actions` warning** — Replaced `softprops/action-gh-release` action in `release.yml` with a `gh release create` script step, since the `gh` CLI is pre-installed on GitHub runners
 - **4 flaky rate-limit tests failing on fresh CI runners** — Tests now create explicit `AuthRateLimitMiddleware` instances instead of relying on shared module-level state that could carry over between test runs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **MCP Scanner CI failure** — `mcp-scanner` v4.x requires the `stdio` subcommand and `--stdio-arg` (singular, repeatable) instead of `--stdio-args` (which consumed only one token, causing `automox-mcp` to be misinterpreted as a subcommand)
+- **MCP Scanner arg ordering** — Moved `--analyzers` and `--format` global options before the `stdio` subcommand where the CLI parser expects them, and changed dummy `AUTOMOX_ORG_ID` from `0` to `1` to pass server validation (positive integer required)
 - **Zizmor `superfluous-actions` warning** — Replaced `softprops/action-gh-release` action in `release.yml` with a `gh release create` script step, since the `gh` CLI is pre-installed on GitHub runners
 - **4 flaky rate-limit tests failing on fresh CI runners** — Tests now create explicit `AuthRateLimitMiddleware` instances instead of relying on shared module-level state that could carry over between test runs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Applied `ruff format` to fix formatting in `src/automox_mcp/tools/__init__.py` and `tests/test_prompts.py`
 
+### Fixed
+
+- **MCP Scanner CI failure** — `mcp-scanner` v4.x requires the `stdio` subcommand and `--stdio-arg` (singular, repeatable) instead of `--stdio-args` (which consumed only one token, causing `automox-mcp` to be misinterpreted as a subcommand)
+- **Zizmor `superfluous-actions` warning** — Replaced `softprops/action-gh-release` action in `release.yml` with a `gh release create` script step, since the `gh` CLI is pre-installed on GitHub runners
+- **4 flaky rate-limit tests failing on fresh CI runners** — Tests now create explicit `AuthRateLimitMiddleware` instances instead of relying on shared module-level state that could carry over between test runs
+
 ## [1.0.10] - 2026-04-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -241,16 +241,17 @@ uv run python tests/smoke_production.py
 Static analysis with [Cisco's MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner):
 
 ```bash
-mcp-scanner stdio \
+mcp-scanner \
+  --analyzers yara \
+  --format summary \
+  stdio \
   --stdio-command uv \
   --stdio-arg run \
   --stdio-arg automox-mcp \
   --stdio-env AUTOMOX_API_KEY=test-api-key \
   --stdio-env AUTOMOX_ACCOUNT_UUID=test-account \
   --stdio-env AUTOMOX_ORG_ID=1 \
-  --stdio-env AUTOMOX_MCP_SKIP_DOTENV=1 \
-  --analyzers yara \
-  --format summary
+  --stdio-env AUTOMOX_MCP_SKIP_DOTENV=1
 ```
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -241,9 +241,10 @@ uv run python tests/smoke_production.py
 Static analysis with [Cisco's MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner):
 
 ```bash
-mcp-scanner \
+mcp-scanner stdio \
   --stdio-command uv \
-  --stdio-args run automox-mcp \
+  --stdio-arg run \
+  --stdio-arg automox-mcp \
   --stdio-env AUTOMOX_API_KEY=test-api-key \
   --stdio-env AUTOMOX_ACCOUNT_UUID=test-account \
   --stdio-env AUTOMOX_ORG_ID=1 \

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.10"
+version = "1.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- **Fix 4 flaky rate-limit tests** — create explicit `AuthRateLimitMiddleware` instances instead of relying on shared module-level state
- **Fix MCP Scanner CI failure** — add `stdio` subcommand and use `--stdio-arg` (singular, repeatable) for mcp-scanner v4.x CLI
- **Fix zizmor `superfluous-actions` warning** — replace `softprops/action-gh-release` with `gh release create` script step

## Test plan
- [ ] CI passes: rate-limit tests no longer flaky on fresh runners
- [ ] Security workflow: mcp-scanner stdio invocation succeeds
- [ ] Security workflow: zizmor audit passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)