### PR TITLE
Fix policy-report-api alignment: query params, URL paths, and response

### DIFF
--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -12,20 +12,30 @@ from ..utils.response import extract_list as _extract_list
 
 
 def _summarize_run(run: Mapping[str, Any]) -> dict[str, Any]:
-    """Extract key fields from a policy run record."""
+    """Extract key fields from a policy run record.
+
+    The policy-report-api returns snake_case JSON via @JsonNaming(SnakeCaseStrategy).
+    Fields: policy_uuid, policy_id, org_uuid, policy_name, policy_type,
+    policy_deleted_at, pending, success, remediation_not_applicable, failed,
+    not_included, run_time, execution_token, run_count, blocked (v2 only).
+    """
     entry: dict[str, Any] = {}
     for key in (
-        "uuid",
         "policy_uuid",
+        "policy_id",
+        "org_uuid",
         "policy_name",
         "policy_type",
-        "status",
-        "result_status",
-        "started_at",
-        "completed_at",
-        "device_count",
-        "success_count",
-        "failure_count",
+        "policy_deleted_at",
+        "pending",
+        "success",
+        "remediation_not_applicable",
+        "failed",
+        "not_included",
+        "run_time",
+        "execution_token",
+        "run_count",
+        "blocked",
     ):
         val = run.get(key)
         if val is not None:
@@ -34,17 +44,21 @@ def _summarize_run(run: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _summarize_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
-    """Extract key fields from a policy history record."""
+    """Extract key fields from a policy info record.
+
+    The policy-report-api PolicyInfoResource returns snake_case JSON:
+    uuid, id, org_uuid, name, type, deleted_at, updated_at, last_run_time.
+    """
     entry: dict[str, Any] = {}
     for key in (
         "uuid",
+        "id",
+        "org_uuid",
         "name",
-        "policy_type",
-        "policy_type_name",
-        "status",
-        "last_run_at",
-        "run_count",
-        "created_at",
+        "type",
+        "deleted_at",
+        "updated_at",
+        "last_run_time",
     ):
         val = policy.get(key)
         if val is not None:
@@ -74,20 +88,21 @@ async def list_policy_runs_v2(
         org_id=org_id,
     )
 
-    # Policy History v2 requires org UUID as a query parameter
+    # Policy History v2 requires org UUID as a query parameter.
+    # The policy-report-api uses snake_case query parameter names.
     params: dict[str, Any] = {"org": resolved_uuid}
     if start_time:
-        params["startTime"] = start_time
+        params["start_time"] = start_time
     if end_time:
-        params["endTime"] = end_time
+        params["end_time"] = end_time
     if policy_name:
-        params["policyName"] = policy_name
+        params["policy_name"] = policy_name
     if policy_uuid:
-        params["policyUuid"] = policy_uuid
+        params["policy_uuid"] = policy_uuid
     if policy_type:
-        params["policyType"] = policy_type
+        params["policy_type"] = policy_type
     if result_status:
-        params["resultStatus"] = result_status
+        params["result_status"] = result_status
     if sort:
         params["sort"] = sort
     if page is not None:
@@ -226,17 +241,30 @@ async def get_policy_runs_for_policy(
 
     params: dict[str, Any] = {"org": resolved_uuid}
     if report_days is not None:
-        params["reportDays"] = report_days
+        params["report_days"] = report_days
     if sort:
         params["sort"] = sort
 
+    # The correct endpoint for runs-with-stats is /policy-runs/{policyUuid}
+    # (not /policies/{policyUuid}/runs which returns only execution tokens).
+    # Response shape: { data: { runs: [...], banner_stats: {...} }, metadata: {...} }
     response = await client.get(
-        f"/policy-history/policies/{policy_uuid}/runs",
+        f"/policy-history/policy-runs/{policy_uuid}",
         params=params,
     )
 
-    runs = _extract_list(response)
-    summaries = [_summarize_run(r) for r in runs]
+    # Extract runs from the nested response structure
+    if isinstance(response, Mapping) and "data" in response:
+        data_block = response["data"]
+        raw_runs = data_block.get("runs", []) if isinstance(data_block, Mapping) else []
+        banner_stats = data_block.get("banner_stats", {}) if isinstance(data_block, Mapping) else {}
+        metadata = response.get("metadata", {})
+    else:
+        raw_runs = _extract_list(response)
+        banner_stats = {}
+        metadata = {}
+
+    summaries = [_summarize_run(r) for r in raw_runs]
 
     return {
         "data": {
@@ -244,8 +272,9 @@ async def get_policy_runs_for_policy(
             "policy_uuid": policy_uuid,
             "total_runs": len(summaries),
             "runs": summaries,
+            "banner_stats": banner_stats,
         },
-        "metadata": {"deprecated_endpoint": False},
+        "metadata": metadata,
     }
 
 
@@ -269,13 +298,15 @@ async def get_policy_run_detail_v2(
         org_id=org_id,
     )
 
-    params: dict[str, Any] = {"org": resolved_uuid}
+    # The device details endpoint extracts org from JWT, not query params.
+    # Filter params use snake_case names per the policy-report-api.
+    params: dict[str, Any] = {}
     if sort:
         params["sort"] = sort
     if result_status:
-        params["resultStatus"] = result_status
+        params["result_status"] = result_status
     if device_name:
-        params["deviceName"] = device_name
+        params["device_name"] = device_name
     if page is not None:
         params["page"] = page
     if limit is not None:

--- a/tests/test_phase3_edge_cases.py
+++ b/tests/test_phase3_edge_cases.py
@@ -69,9 +69,9 @@ def test_extract_list_filters_non_mappings() -> None:
 
 
 def test_summarize_run_skips_none_fields() -> None:
-    run = {"uuid": "abc", "extra_field": "ignored"}
+    run = {"policy_uuid": "abc", "extra_field": "ignored"}
     result = _summarize_run(run)
-    assert result["uuid"] == "abc"
+    assert result["policy_uuid"] == "abc"
     assert "extra_field" not in result
 
 
@@ -116,10 +116,10 @@ async def test_policy_runs_v2_all_filters() -> None:
         limit=25,
     )
     params = client.calls[0][2]
-    assert params["startTime"] == "2026-01-01"
-    assert params["endTime"] == "2026-03-01"
-    assert params["policyName"] == "Test"
-    assert params["policyUuid"] == "pol-001"
+    assert params["start_time"] == "2026-01-01"
+    assert params["end_time"] == "2026-03-01"
+    assert params["policy_name"] == "Test"
+    assert params["policy_uuid"] == "pol-001"
 
 
 @pytest.mark.asyncio
@@ -164,7 +164,8 @@ async def test_run_detail_v2_all_filters() -> None:
     )
     params = client.calls[0][2]
     assert params["sort"] == "asc"
-    assert params["deviceName"] == "host-1"
+    assert params["device_name"] == "host-1"
+    assert "org" not in params  # org comes from JWT, not query params
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows_policy_history.py
+++ b/tests/test_workflows_policy_history.py
@@ -19,23 +19,33 @@ _ORG_UUID = "11111111-2222-3333-4444-555555555555"
 
 _POLICY_RUNS = [
     {
-        "uuid": "run-001",
         "policy_uuid": "pol-001",
+        "policy_id": 101,
+        "org_uuid": _ORG_UUID,
         "policy_name": "Patch All",
         "policy_type": "patch",
-        "status": "completed",
-        "result_status": "success",
-        "started_at": "2026-03-01T00:00:00Z",
-        "completed_at": "2026-03-01T01:00:00Z",
-        "device_count": 10,
-        "success_count": 9,
-        "failure_count": 1,
+        "pending": 0,
+        "success": 9,
+        "remediation_not_applicable": 0,
+        "failed": 1,
+        "not_included": 0,
+        "run_time": "2026-03-01T00:00:00Z",
+        "execution_token": "exec-001",
+        "run_count": 10,
     },
     {
-        "uuid": "run-002",
         "policy_uuid": "pol-002",
+        "policy_id": 102,
+        "org_uuid": _ORG_UUID,
         "policy_name": "Custom Script",
-        "status": "running",
+        "policy_type": "custom",
+        "pending": 2,
+        "success": 3,
+        "remediation_not_applicable": 0,
+        "failed": 0,
+        "not_included": 0,
+        "run_time": "2026-03-01T01:00:00Z",
+        "execution_token": "exec-002",
     },
 ]
 
@@ -46,11 +56,13 @@ _RUN_DETAIL_RESULTS = [
 
 _POLICY_HISTORY = {
     "uuid": "pol-001",
+    "id": 101,
+    "org_uuid": _ORG_UUID,
     "name": "Patch All",
-    "policy_type": "patch",
-    "status": "active",
-    "last_run_at": "2026-03-01T01:00:00Z",
-    "run_count": 42,
+    "type": "patch",
+    "deleted_at": None,
+    "updated_at": "2026-03-01T00:00:00Z",
+    "last_run_time": "2026-03-01T01:00:00Z",
 }
 
 
@@ -72,8 +84,8 @@ async def test_list_runs_returns_summaries() -> None:
     result = await list_policy_runs_v2(cast(AutomoxClient, client), org_id=42)
 
     assert result["data"]["total_runs"] == 2
-    assert result["data"]["runs"][0]["uuid"] == "run-001"
-    assert result["data"]["runs"][0]["success_count"] == 9
+    assert result["data"]["runs"][0]["policy_uuid"] == "pol-001"
+    assert result["data"]["runs"][0]["success"] == 9
 
 
 @pytest.mark.asyncio
@@ -89,9 +101,9 @@ async def test_list_runs_passes_filters() -> None:
     )
 
     _, path, params = client.calls[0]
-    assert params["startTime"] == "2026-01-01"
-    assert params["policyType"] == "patch"
-    assert params["resultStatus"] == "failure"
+    assert params["start_time"] == "2026-01-01"
+    assert params["policy_type"] == "patch"
+    assert params["result_status"] == "failure"
     assert params["limit"] == 10
 
 
@@ -157,7 +169,7 @@ async def test_history_detail_returns_policy() -> None:
     )
 
     assert result["data"]["uuid"] == "pol-001"
-    assert result["data"]["run_count"] == 42
+    assert result["data"]["last_run_time"] == "2026-03-01T01:00:00Z"
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +179,19 @@ async def test_history_detail_returns_policy() -> None:
 
 @pytest.mark.asyncio
 async def test_runs_for_policy_returns_runs() -> None:
-    client = _make_client(get_responses={"/policy-history/policies/pol-001/runs": [_POLICY_RUNS]})
+    # /policy-runs/{policyUuid} returns RunsByPolicyResponse shape
+    runs_response = {
+        "data": {
+            "runs": _POLICY_RUNS,
+            "banner_stats": {
+                "policy_success_rate": 0.9,
+                "total_policies_applied": 2,
+                "total_successful_devices": 12,
+            },
+        },
+        "metadata": {"total_run_count": 2, "last_run_time": "2026-03-01T01:00:00Z"},
+    }
+    client = _make_client(get_responses={"/policy-history/policy-runs/pol-001": [runs_response]})
     result = await get_policy_runs_for_policy(
         cast(AutomoxClient, client),
         org_id=42,
@@ -176,12 +200,18 @@ async def test_runs_for_policy_returns_runs() -> None:
 
     assert result["data"]["total_runs"] == 2
     assert result["data"]["policy_uuid"] == "pol-001"
+    assert result["data"]["banner_stats"]["policy_success_rate"] == 0.9
+    assert result["metadata"]["total_run_count"] == 2
 
 
 @pytest.mark.asyncio
 async def test_runs_for_policy_passes_params() -> None:
+    empty_response = {
+        "data": {"runs": [], "banner_stats": {}},
+        "metadata": {"total_run_count": 0},
+    }
     client = _make_client(
-        get_responses={"/policy-history/policies/pol-001/runs": [[]]},
+        get_responses={"/policy-history/policy-runs/pol-001": [empty_response]},
     )
     await get_policy_runs_for_policy(
         cast(AutomoxClient, client),
@@ -192,7 +222,7 @@ async def test_runs_for_policy_passes_params() -> None:
     )
 
     params = client.calls[0][2]
-    assert params["reportDays"] == 30
+    assert params["report_days"] == 30
     assert params["sort"] == "desc"
 
 
@@ -233,6 +263,7 @@ async def test_run_detail_passes_filters() -> None:
     )
 
     params = client.calls[0][2]
-    assert params["resultStatus"] == "failure"
-    assert params["deviceName"] == "host-1"
+    assert params["result_status"] == "failure"
+    assert params["device_name"] == "host-1"
     assert params["limit"] == 5
+    assert "org" not in params  # org comes from JWT, not query params


### PR DESCRIPTION
The MCP was sending camelCase query params (startTime, policyName, etc.) but the policy-report-api expects snake_case (start_time, policy_name). Also fixes wrong URL path for policy runs by policy, removes erroneous org query param from device details endpoint (uses JWT), and corrects response field extraction to match actual API DTOs.