### PR TITLE
Make release workflow idempotent for re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,15 @@ jobs:
           pip install sigstore
           python -m sigstore sign dist/*.whl dist/*.tar.gz
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --generate-notes \
-            dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" --clobber \
+              dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --generate-notes \
+              dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **HTML sanitization hardened** — Replaced regex-based HTML tag filtering in `sanitize.py` with stdlib `html.parser` to properly handle malformed tags, nested content, and edge cases (resolved CodeQL `py/bad-tag-filter`)
 - **5 CodeQL code-scanning alerts resolved** — Fixed weak-hashing false positive in `auth.py` (`usedforsecurity=False`), clear-text-logging false positive in `__init__.py`, and URL substring-matching false positives in tests
 
+### Fixed
+
+- **Release workflow idempotency** — `gh release create` now checks for an existing release first and uploads assets with `--clobber` if one exists, preventing failures on workflow re-runs
+
 ## [1.0.13] - 2026-04-11
 
 ### Security


### PR DESCRIPTION
## Summary
- `gh release create` fails if the release already exists (e.g. on workflow re-run or `workflow_dispatch` after a tag push). Now checks for an existing release first and uploads assets with `--clobber` instead.

## Test plan
- [x] Workflow re-run on existing v1.0.14 tag should succeed instead of failing at the release step

🤖 Generated with [Claude Code](https://claude.com/claude-code)