### PR TITLE
Skip PyPI publish if version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,17 @@ jobs:
               raise SystemExit(f"Tag {ref!r} does not match project version {version!r}")
           PY
 
+      - name: Check if version already exists on PyPI
+        id: pypi_check
+        run: |
+          VERSION=$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          if pip index versions automox-mcp 2>/dev/null | grep -q "$VERSION"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Version $VERSION already exists on PyPI — skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install build backend
         run: python -m pip install --upgrade pip build
 
@@ -52,6 +63,7 @@ jobs:
           cyclonedx-py environment -o sbom.cdx.json --of json
 
       - name: Publish to PyPI
+        if: steps.pypi_check.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Sign artifacts with Sigstore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Release workflow idempotency** — `gh release create` now checks for an existing release first and uploads assets with `--clobber` if one exists, preventing failures on workflow re-runs
+- **Release workflow PyPI check** — Skip PyPI publish step if the version already exists on PyPI, preventing `400 File already exists` errors on re-runs
 
 ## [1.0.13] - 2026-04-11
 


### PR DESCRIPTION
## Summary
- Checks PyPI for the current version before attempting to upload, preventing `400 File already exists` errors on workflow re-runs

## Test plan
- [x] Re-running the release workflow on an already-published version should skip the PyPI step and succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)