### PR TITLE
Fix sanitization bypass and improve test suite (v1.0.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.16] - 2026-04-16
+
+### Security
+
+- **Nested-bracket sanitization bypass fixed** — Updated markdown link/image regexes in `sanitize.py` to handle one level of nested brackets, preventing URL exfiltration via patterns like `[click [here]](https://evil.com)` that previously bypassed the sanitizer entirely
+
+### Added
+
+- **JWT `verify_token()` integration tests** — 9 new tests exercising the actual token verification path (valid tokens, expired tokens, wrong audience/issuer, invalid signatures, missing scopes, garbage input). Previously only JWTVerifier construction was tested
+- **Schema validation tests** (`test_schemas.py`) — 34 new tests covering Pydantic model validators, field constraints, discriminated unions, payload size limits, and command injection prevention via `patch_names` regex
+- **Workflow error-path tests** — 6 new tests across events, groups, reports, and packages workflows verifying `AutomoxAPIError` propagates correctly and is not silently swallowed
+
+### Changed
+
+- **Consolidated duplicate test infrastructure** — Moved `StubServer` and `FakeClient` into `conftest.py`, removing ~170 lines of duplicated code from 4 test files
+- **Removed unnecessary `sys.path` manipulation** — Cleaned up legacy `sys.path.insert()` from `conftest.py`, `test_workflows_policy.py`, and `test_workflows_policy_crud_extended.py`
+
 ## [1.0.15] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Nested-bracket sanitization bypass fixed** — Updated markdown link/image regexes in `sanitize.py` to handle one level of nested brackets, preventing URL exfiltration via patterns like `[click [here]](https://evil.com)` that previously bypassed the sanitizer entirely
+- **CVE-2025-71176 (pytest)** — Bumped `pytest` from >=8.2 to >=9.0.3 to fix a local privilege escalation via predictable `/tmp/pytest-of-{user}` directory names on UNIX
+- **CVE-2026-40347 (python-multipart)** — Bumped `python-multipart` from >=0.0.22 to >=0.0.26 to fix a denial-of-service vulnerability when parsing crafted multipart/form-data requests with large preamble or epilogue sections
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.15"
+version = "1.0.16"
 description = "An MCP server implementation for Automox"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ automox-mcp = "automox_mcp:main"
 
 [project.optional-dependencies]
 dev = [
-  "pytest>=8.2",
+  "pytest>=9.0.3",
   "pytest-asyncio>=0.23",
   "pytest-cov>=6.0",
   "ruff>=0.4",
@@ -88,7 +88,8 @@ constraint-dependencies = [
   "mcp>=1.23.0",          # CVE-2025-66416
   "pygments>=2.20.0",     # CVE-2026-4539
   "pyjwt>=2.12.0",        # CVE-2026-32597
-  "python-multipart>=0.0.22", # CVE-2026-24486
+  "pytest>=9.0.3",            # CVE-2025-71176: /tmp/pytest-of-* privilege escalation
+  "python-multipart>=0.0.26", # CVE-2026-24486, CVE-2026-40347
   "requests>=2.33.0",     # CVE-2026-25645
   "urllib3>=2.6.3",        # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441
 ]

--- a/src/automox_mcp/utils/sanitize.py
+++ b/src/automox_mcp/utils/sanitize.py
@@ -35,11 +35,11 @@ def is_sanitization_enabled() -> bool:
 # Regex patterns
 # ---------------------------------------------------------------------------
 
-# Markdown image: ![alt](url) → alt
-_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)")
+# Markdown image: ![alt](url) → alt  (supports one level of nested brackets)
+_IMAGE_RE = re.compile(r"!\[((?:[^\[\]]|\[[^\]]*\])*)\]\([^)]+\)")
 
-# Markdown link: [text](url) → text
-_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]+\)")
+# Markdown link: [text](url) → text  (supports one level of nested brackets)
+_LINK_RE = re.compile(r"\[((?:[^\[\]]|\[[^\]]*\])*)\]\([^)]+\)")
 
 # Fenced code blocks with shell/script content (supports 3+ backtick delimiters)
 _CODE_BLOCK_RE = re.compile(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,7 @@
 import copy
-import sys
-from pathlib import Path
 from typing import Any
 
 import pytest
-
-SRC = Path(__file__).resolve().parents[1] / "src"
-if str(SRC) not in sys.path:
-    sys.path.insert(0, str(SRC))
 
 
 @pytest.fixture(autouse=True)
@@ -20,6 +14,63 @@ def _reset_shared_state():
     yield
     _RATE_LIMITER._timestamps.clear()
     _IDEMPOTENCY_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Shared StubServer for tool registration tests
+# ---------------------------------------------------------------------------
+
+
+class StubServer:
+    """Lightweight FastMCP lookalike that captures registered tool functions.
+
+    Used by tool-registration and tool-dispatch tests to avoid importing
+    the full FastMCP server.
+    """
+
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str, description: str = "", **kwargs):
+        def decorator(func):
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+# ---------------------------------------------------------------------------
+# Shared FakeClient for tool tests
+# ---------------------------------------------------------------------------
+
+
+class FakeClient:
+    """Minimal client stub with configurable responses.
+
+    Used by tool-dispatch and tool-registration tests where the full
+    StubClient request/response infrastructure is not needed.
+    """
+
+    def __init__(
+        self,
+        *,
+        org_id: int | None = 42,
+        org_uuid: str | None = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        account_uuid: str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    ) -> None:
+        self.org_id = org_id
+        self.org_uuid = org_uuid
+        self.account_uuid = account_uuid
+        self._get_response: Any = []
+        self._post_response: Any = {}
+
+    async def get(self, path: str, *, params: Any = None, headers: Any = None) -> Any:
+        return self._get_response
+
+    async def post(
+        self, path: str, *, json_data: Any = None, params: Any = None, headers: Any = None
+    ) -> Any:
+        return self._post_response
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import patch
 
 import httpx
+import pytest
 
 from automox_mcp.auth import (
     _create_jwt_auth,
@@ -226,3 +228,145 @@ class TestIsAuthConfiguredJwt:
         monkeypatch.delenv("AUTOMOX_MCP_API_KEY_FILE", raising=False)
         monkeypatch.delenv("AUTOMOX_MCP_OAUTH_ISSUER", raising=False)
         assert is_auth_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# JWT verify_token() integration tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_ec_key_pair() -> tuple[str, str]:
+    """Generate an EC P-256 key pair and return (private_pem, public_pem)."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+def _make_jwt(
+    private_pem: str,
+    *,
+    issuer: str = "https://auth.example.com",
+    audience: str = "https://mcp.example.com",
+    subject: str = "test-client",
+    scopes: str = "",
+    exp_offset: int = 3600,
+) -> str:
+    """Sign a minimal JWT with the given private key."""
+    import jwt as pyjwt
+
+    now = int(time.time())
+    payload: dict = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": subject,
+        "iat": now,
+        "exp": now + exp_offset,
+    }
+    if scopes:
+        payload["scope"] = scopes
+    return pyjwt.encode(payload, private_pem, algorithm="ES256")
+
+
+class TestJWTVerifyToken:
+    """Integration tests for the actual verify_token() path."""
+
+    @pytest.fixture(autouse=True)
+    def _keys(self):
+        self.private_pem, self.public_pem = _generate_ec_key_pair()
+
+    def _make_verifier(
+        self,
+        *,
+        audience: str = "https://mcp.example.com",
+        issuer: str = "https://auth.example.com",
+        required_scopes: list[str] | None = None,
+    ):
+        from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+        return JWTVerifier(
+            public_key=self.public_pem,
+            issuer=issuer,
+            audience=audience,
+            algorithm="ES256",
+            required_scopes=required_scopes,
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_token_accepted(self):
+        verifier = self._make_verifier()
+        token = _make_jwt(self.private_pem)
+        result = await verifier.verify_token(token)
+        assert result is not None
+        assert result.client_id == "test-client"
+
+    @pytest.mark.asyncio
+    async def test_expired_token_rejected(self):
+        verifier = self._make_verifier()
+        token = _make_jwt(self.private_pem, exp_offset=-3600)
+        result = await verifier.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wrong_audience_rejected(self):
+        verifier = self._make_verifier(audience="https://other.example.com")
+        token = _make_jwt(self.private_pem, audience="https://mcp.example.com")
+        result = await verifier.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wrong_issuer_rejected(self):
+        verifier = self._make_verifier(issuer="https://legit.example.com")
+        token = _make_jwt(self.private_pem, issuer="https://evil.example.com")
+        result = await verifier.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_signature_rejected(self):
+        verifier = self._make_verifier()
+        # Sign with a different key
+        other_private, _ = _generate_ec_key_pair()
+        token = _make_jwt(other_private)
+        result = await verifier.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_required_scopes_rejected(self):
+        verifier = self._make_verifier(required_scopes=["mcp:admin", "mcp:read"])
+        token = _make_jwt(self.private_pem, scopes="mcp:read")
+        result = await verifier.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sufficient_scopes_accepted(self):
+        verifier = self._make_verifier(required_scopes=["mcp:read"])
+        token = _make_jwt(self.private_pem, scopes="mcp:read mcp:write")
+        result = await verifier.verify_token(token)
+        assert result is not None
+        assert "mcp:read" in result.scopes
+
+    @pytest.mark.asyncio
+    async def test_garbage_token_rejected(self):
+        verifier = self._make_verifier()
+        result = await verifier.verify_token("not.a.jwt")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_token_rejected(self):
+        verifier = self._make_verifier()
+        result = await verifier.verify_token("")
+        assert result is None

--- a/tests/test_phase3_tool_errors.py
+++ b/tests/test_phase3_tool_errors.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
+from conftest import FakeClient, StubServer
 from fastmcp.exceptions import ToolError
 
 from automox_mcp.client import AutomoxAPIError
@@ -19,47 +18,8 @@ from automox_mcp.tools import (
 )
 
 # ---------------------------------------------------------------------------
-# Shared test infrastructure (matches test_tool_dispatch.py pattern)
+# Shared test infrastructure
 # ---------------------------------------------------------------------------
-
-
-class StubServer:
-    """Lightweight FastMCP lookalike that captures registered tool functions."""
-
-    def __init__(self) -> None:
-        self.tools: dict[str, Any] = {}
-
-    def tool(self, name: str, description: str = "", **kwargs):
-        def decorator(func):
-            self.tools[name] = func
-            return func
-
-        return decorator
-
-
-class FakeClient:
-    """Minimal client stub with configurable responses."""
-
-    def __init__(
-        self,
-        *,
-        org_id: int | None = 42,
-        org_uuid: str | None = "11111111-2222-3333-4444-555555555555",
-        account_uuid: str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    ) -> None:
-        self.org_id = org_id
-        self.org_uuid = org_uuid
-        self.account_uuid = account_uuid
-        self._get_response: Any = []
-        self._post_response: Any = {}
-
-    async def get(self, path: str, *, params: Any = None, headers: Any = None) -> Any:
-        return self._get_response
-
-    async def post(
-        self, path: str, *, json_data: Any = None, params: Any = None, headers: Any = None
-    ) -> Any:
-        return self._post_response
 
 
 def _register(module, client: FakeClient, read_only: bool = False) -> StubServer:

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -74,8 +74,10 @@ class TestMarkdownStripping:
         # Nested brackets aren't valid markdown link syntax, so the outer
         # link won't match — but the inner [here](https://evil.com) will.
         result = sanitize_for_llm(text)
-        # Should not crash; partial stripping is acceptable
+        # Should not crash; partial stripping is acceptable but the URL
+        # must always be neutralized regardless of bracket nesting.
         assert isinstance(result, str)
+        assert "https://evil.com" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,279 @@
+"""Tests for Pydantic schema validation boundaries in automox_mcp.schemas."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from automox_mcp.schemas import (
+    AdvancedDeviceSearchParams,
+    CreateDataExtractParams,
+    CreatePolicyOperation,
+    DeviceSearchParams,
+    ForbidExtraModel,
+    InviteUserParams,
+    IssueDeviceCommandParams,
+    PolicyChangeRequestParams,
+    PolicyDefinition,
+    UpdatePolicyOperation,
+    UploadActionSetParams,
+)
+
+# ---------------------------------------------------------------------------
+# ForbidExtraModel — extra fields rejected
+# ---------------------------------------------------------------------------
+
+
+class TestForbidExtraModel:
+    def test_rejects_unknown_fields(self):
+        class MyModel(ForbidExtraModel):
+            name: str
+
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            MyModel(name="ok", unknown_field="bad")
+
+    def test_accepts_known_fields(self):
+        class MyModel(ForbidExtraModel):
+            name: str
+
+        m = MyModel(name="ok")
+        assert m.name == "ok"
+
+
+# ---------------------------------------------------------------------------
+# PolicyDefinition — extra="ignore" silently drops unknown fields
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyDefinition:
+    def test_ignores_unknown_fields(self):
+        p = PolicyDefinition(name="Test", unrecognized_key="dropped")
+        assert p.name == "Test"
+        assert not hasattr(p, "unrecognized_key")
+
+    def test_schedule_time_valid_format(self):
+        p = PolicyDefinition(schedule_time="14:30")
+        assert p.schedule_time == "14:30"
+
+    def test_schedule_time_invalid_format(self):
+        with pytest.raises(ValidationError, match="schedule_time"):
+            PolicyDefinition(schedule_time="25:00")
+
+    def test_schedule_time_no_seconds(self):
+        with pytest.raises(ValidationError, match="schedule_time"):
+            PolicyDefinition(schedule_time="14:30:00")
+
+    def test_scheduled_timezone_valid(self):
+        p = PolicyDefinition(scheduled_timezone="UTC+0530")
+        assert p.scheduled_timezone == "UTC+0530"
+
+    def test_scheduled_timezone_invalid(self):
+        with pytest.raises(ValidationError):
+            PolicyDefinition(scheduled_timezone="EST")
+
+    def test_schedule_days_bitmask_range(self):
+        p = PolicyDefinition(schedule_days=254)
+        assert p.schedule_days == 254
+
+    def test_schedule_days_bitmask_too_large(self):
+        with pytest.raises(ValidationError):
+            PolicyDefinition(schedule_days=255)
+
+
+# ---------------------------------------------------------------------------
+# InviteUserParams — model_validator for zone assignments
+# ---------------------------------------------------------------------------
+
+_VALID_ACCOUNT_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+class TestInviteUserParams:
+    def test_global_admin_no_zones_ok(self):
+        p = InviteUserParams(
+            account_id=_VALID_ACCOUNT_ID,
+            email="user@example.com",
+            account_rbac_role="global-admin",
+        )
+        assert p.zone_assignments is None
+
+    def test_no_global_access_requires_zones(self):
+        with pytest.raises(ValidationError, match="Zone assignments are required"):
+            InviteUserParams(
+                account_id=_VALID_ACCOUNT_ID,
+                email="user@example.com",
+                account_rbac_role="no-global-access",
+            )
+
+    def test_no_global_access_with_zones_ok(self):
+        p = InviteUserParams(
+            account_id=_VALID_ACCOUNT_ID,
+            email="user@example.com",
+            account_rbac_role="no-global-access",
+            zone_assignments=[{"zone_id": "zone-1", "rbac_role": "read-only"}],
+        )
+        assert len(p.zone_assignments) == 1
+
+    def test_invalid_email_rejected(self):
+        with pytest.raises(ValidationError, match="email"):
+            InviteUserParams(
+                account_id=_VALID_ACCOUNT_ID,
+                email="not-an-email",
+                account_rbac_role="global-admin",
+            )
+
+    def test_invalid_rbac_role_rejected(self):
+        with pytest.raises(ValidationError):
+            InviteUserParams(
+                account_id=_VALID_ACCOUNT_ID,
+                email="user@example.com",
+                account_rbac_role="superadmin",
+            )
+
+
+# ---------------------------------------------------------------------------
+# CreateDataExtractParams — payload size validator
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDataExtractParams:
+    def test_small_payload_accepted(self):
+        p = CreateDataExtractParams(org_id=1, extract_data={"type": "devices"})
+        assert p.extract_data["type"] == "devices"
+
+    def test_oversized_payload_rejected(self):
+        huge = {"data": "x" * 60_000}
+        with pytest.raises(ValidationError, match="50 KB"):
+            CreateDataExtractParams(org_id=1, extract_data=huge)
+
+
+# ---------------------------------------------------------------------------
+# UploadActionSetParams — payload size validator
+# ---------------------------------------------------------------------------
+
+
+class TestUploadActionSetParams:
+    def test_small_payload_accepted(self):
+        p = UploadActionSetParams(org_id=1, action_set_data={"format": "qualys"})
+        assert p.action_set_data["format"] == "qualys"
+
+    def test_oversized_payload_rejected(self):
+        huge = {"data": "x" * 60_000}
+        with pytest.raises(ValidationError, match="50 KB"):
+            UploadActionSetParams(org_id=1, action_set_data=huge)
+
+
+# ---------------------------------------------------------------------------
+# AdvancedDeviceSearchParams — query size validator
+# ---------------------------------------------------------------------------
+
+
+class TestAdvancedDeviceSearchParams:
+    def test_no_query_ok(self):
+        p = AdvancedDeviceSearchParams()
+        assert p.query is None
+
+    def test_small_query_accepted(self):
+        p = AdvancedDeviceSearchParams(query={"filter": "os=linux"})
+        assert p.query["filter"] == "os=linux"
+
+    def test_oversized_query_rejected(self):
+        huge = {"filter": "x" * 60_000}
+        with pytest.raises(ValidationError, match="50 KB"):
+            AdvancedDeviceSearchParams(query=huge)
+
+
+# ---------------------------------------------------------------------------
+# PolicyChangeRequestParams — discriminated union
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyChangeRequestParams:
+    def test_create_operation_parsed(self):
+        p = PolicyChangeRequestParams(
+            org_id=42,
+            operations=[
+                {"action": "create", "policy": {"name": "New Policy"}},
+            ],
+        )
+        assert len(p.operations) == 1
+        assert isinstance(p.operations[0], CreatePolicyOperation)
+
+    def test_update_operation_parsed(self):
+        p = PolicyChangeRequestParams(
+            org_id=42,
+            operations=[
+                {
+                    "action": "update",
+                    "policy_id": 123,
+                    "policy": {"name": "Updated"},
+                },
+            ],
+        )
+        assert isinstance(p.operations[0], UpdatePolicyOperation)
+
+    def test_empty_operations_rejected(self):
+        with pytest.raises(ValidationError, match="operations"):
+            PolicyChangeRequestParams(org_id=42, operations=[])
+
+    def test_too_many_operations_rejected(self):
+        ops = [{"action": "create", "policy": {"name": f"p{i}"}} for i in range(51)]
+        with pytest.raises(ValidationError):
+            PolicyChangeRequestParams(org_id=42, operations=ops)
+
+
+# ---------------------------------------------------------------------------
+# IssueDeviceCommandParams — command_type and patch_names validation
+# ---------------------------------------------------------------------------
+
+
+class TestIssueDeviceCommandParams:
+    def test_scan_command_accepted(self):
+        p = IssueDeviceCommandParams(org_id=1, device_id=10, command_type="scan")
+        assert p.command_type == "scan"
+
+    def test_invalid_command_rejected(self):
+        with pytest.raises(ValidationError):
+            IssueDeviceCommandParams(org_id=1, device_id=10, command_type="format")
+
+    def test_patch_names_valid_chars(self):
+        p = IssueDeviceCommandParams(
+            org_id=1,
+            device_id=10,
+            command_type="patch_specific",
+            patch_names="KB12345,Chrome Update",
+        )
+        assert "KB12345" in p.patch_names
+
+    def test_patch_names_rejects_shell_chars(self):
+        with pytest.raises(ValidationError, match="patch_names"):
+            IssueDeviceCommandParams(
+                org_id=1,
+                device_id=10,
+                command_type="patch_specific",
+                patch_names="$(whoami)",
+            )
+
+
+# ---------------------------------------------------------------------------
+# DeviceSearchParams — field constraints
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceSearchParams:
+    def test_limit_lower_bound(self):
+        p = DeviceSearchParams(org_id=1, limit=1)
+        assert p.limit == 1
+
+    def test_limit_upper_bound(self):
+        p = DeviceSearchParams(org_id=1, limit=500)
+        assert p.limit == 500
+
+    def test_limit_exceeds_max(self):
+        with pytest.raises(ValidationError):
+            DeviceSearchParams(org_id=1, limit=501)
+
+    def test_limit_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            DeviceSearchParams(org_id=1, limit=0)

--- a/tests/test_tool_defaults.py
+++ b/tests/test_tool_defaults.py
@@ -1,39 +1,10 @@
-from collections.abc import Callable
-from typing import Any
 from uuid import UUID
 
 import pytest
+from conftest import FakeClient, StubServer
 from fastmcp.exceptions import ToolError
 
 from automox_mcp.tools import account_tools, device_tools, policy_tools
-
-
-class StubServer:
-    def __init__(self) -> None:
-        self.tools: dict[str, Callable[..., Any]] = {}
-
-    def tool(self, name: str, description: str, **kwargs):
-        def decorator(func):
-            self.tools[name] = func
-            return func
-
-        return decorator
-
-
-class FakeClient:
-    """Minimal client stub for tool registration tests."""
-
-    def __init__(
-        self, *, org_id=42, org_uuid=None, account_uuid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-    ):
-        self.org_id = org_id
-        self.org_uuid = org_uuid
-        self.account_uuid = account_uuid
-
-    async def get(self, path, *, params=None, headers=None):
-        if path == "/orgs":
-            return [{"id": self.org_id, "org_uuid": "cccccccc-cccc-cccc-cccc-cccccccccccc"}]
-        return {}
 
 
 def success_result():

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from conftest import FakeClient, StubServer
 
 from automox_mcp.tools import (
     audit_tools,
@@ -26,38 +27,6 @@ from automox_mcp.utils import tooling as _utils_tooling
 # ---------------------------------------------------------------------------
 # Shared test infrastructure
 # ---------------------------------------------------------------------------
-
-
-class StubServer:
-    """Lightweight FastMCP lookalike that captures registered tool functions."""
-
-    def __init__(self) -> None:
-        self.tools: dict[str, Any] = {}
-
-    def tool(self, name: str, description: str = "", **kwargs):
-        def decorator(func):
-            self.tools[name] = func
-            return func
-
-        return decorator
-
-
-class FakeClient:
-    """Minimal client stub used across all tool module tests."""
-
-    def __init__(
-        self,
-        *,
-        org_id: int | None = 42,
-        org_uuid: str | None = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        account_uuid: str | None = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-    ) -> None:
-        self.org_id = org_id
-        self.org_uuid = org_uuid
-        self.account_uuid = account_uuid
-
-    async def get(self, path: str, *, params=None, headers=None) -> Any:
-        return {}
 
 
 def _success() -> dict[str, Any]:

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,41 +1,10 @@
 """Tests for new tool registration (compound tools, policy CRUD gaps)."""
 
-from typing import Any
-
 import pytest
+from conftest import FakeClient, StubServer
 from fastmcp.exceptions import ToolError
 
 from automox_mcp.tools import compound_tools, policy_tools
-
-
-class StubServer:
-    """Lightweight FastMCP stub that captures tool registrations."""
-
-    def __init__(self) -> None:
-        self.tools: dict[str, Any] = {}
-
-    def tool(self, name: str, description: str, **kwargs):
-        def decorator(func):
-            self.tools[name] = func
-            return func
-
-        return decorator
-
-
-class FakeClient:
-    """Minimal client stub for registration tests."""
-
-    def __init__(
-        self, *, org_id=42, org_uuid=None, account_uuid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-    ):
-        self.org_id = org_id
-        self.org_uuid = org_uuid
-        self.account_uuid = account_uuid
-
-    async def get(self, path, *, params=None, headers=None):
-        if path == "/orgs":
-            return [{"id": self.org_id, "org_uuid": "cccccccc-cccc-cccc-cccc-cccccccccccc"}]
-        return {}
 
 
 def success_result():

--- a/tests/test_workflows_events.py
+++ b/tests/test_workflows_events.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from conftest import StubClient
 
-from automox_mcp.client import AutomoxClient
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
 from automox_mcp.workflows.events import list_events
 
 
@@ -187,3 +187,21 @@ async def test_list_events_none_response():
     result = await list_events(cast(AutomoxClient, client), org_id=1)
     assert result["data"]["total_events"] == 0
     assert result["data"]["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# Error path tests — API errors propagate through the workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_events_api_error_propagates():
+    """AutomoxAPIError from the client must not be swallowed."""
+    client = StubClient()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise AutomoxAPIError("server error", status_code=500)
+
+    client.get = _raise  # type: ignore[assignment]
+    with pytest.raises(AutomoxAPIError, match="server error"):
+        await list_events(cast(AutomoxClient, client), org_id=1)

--- a/tests/test_workflows_groups.py
+++ b/tests/test_workflows_groups.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pytest
 from conftest import StubClient
 
-from automox_mcp.client import AutomoxClient
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
 from automox_mcp.workflows.groups import (
     create_server_group,
     delete_server_group,
@@ -324,3 +324,33 @@ async def test_update_server_group_with_optional_fields() -> None:
     assert body["ui_color"] == "#00FF00"
     assert body["notes"] == "updated"
     assert result["data"]["updated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Error path tests — API errors propagate through the workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_server_groups_api_error_propagates():
+    """AutomoxAPIError from the client must not be swallowed."""
+    client = StubClient()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise AutomoxAPIError("forbidden", status_code=403)
+
+    client.get = _raise  # type: ignore[assignment]
+    with pytest.raises(AutomoxAPIError, match="forbidden"):
+        await list_server_groups(cast(AutomoxClient, client), org_id=1)
+
+
+@pytest.mark.asyncio
+async def test_get_server_group_api_error_propagates():
+    client = StubClient()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise AutomoxAPIError("not found", status_code=404)
+
+    client.get = _raise  # type: ignore[assignment]
+    with pytest.raises(AutomoxAPIError, match="not found"):
+        await get_server_group(cast(AutomoxClient, client), org_id=1, group_id=999)

--- a/tests/test_workflows_packages.py
+++ b/tests/test_workflows_packages.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pytest
 from conftest import StubClient
 
-from automox_mcp.client import AutomoxClient
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
 from automox_mcp.workflows.packages import (
     list_device_packages,
     search_org_packages,
@@ -206,3 +206,32 @@ async def test_search_org_packages_omits_none_filters() -> None:
     params = client.calls[0][2]
     assert "includeUnmanaged" not in params
     assert "awaiting" not in params
+
+
+# ---------------------------------------------------------------------------
+# Error path tests — API errors propagate through the workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_device_packages_api_error_propagates() -> None:
+    client = StubClient()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise AutomoxAPIError("internal error", status_code=500)
+
+    client.get = _raise  # type: ignore[assignment]
+    with pytest.raises(AutomoxAPIError, match="internal error"):
+        await list_device_packages(cast(AutomoxClient, client), org_id=1, device_id=42)
+
+
+@pytest.mark.asyncio
+async def test_search_org_packages_api_error_propagates() -> None:
+    client = StubClient()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise AutomoxAPIError("rate limited", status_code=429)
+
+    client.get = _raise  # type: ignore[assignment]
+    with pytest.raises(AutomoxAPIError, match="rate limited"):
+        await search_org_packages(cast(AutomoxClient, client), org_id=1)

--- a/tests/test_workflows_policy.py
+++ b/tests/test_workflows_policy.py
@@ -1,16 +1,11 @@
 import copy
-import pathlib
-import sys
 from typing import Any, cast
 from uuid import UUID
 
 import pytest
 
-PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
-
-from automox_mcp.client import AutomoxAPIError, AutomoxClient  # noqa: E402
-from automox_mcp.workflows.policy import (  # noqa: E402
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
+from automox_mcp.workflows.policy import (
     _decode_schedule_days_bitmask,
     _normalize_status,
     describe_policy,
@@ -19,7 +14,7 @@ from automox_mcp.workflows.policy import (  # noqa: E402
     summarize_policy_activity,
     summarize_policy_execution_history,
 )
-from automox_mcp.workflows.policy_crud import apply_policy_changes  # noqa: E402
+from automox_mcp.workflows.policy_crud import apply_policy_changes
 
 
 class StubClient:

--- a/tests/test_workflows_policy_crud_extended.py
+++ b/tests/test_workflows_policy_crud_extended.py
@@ -3,19 +3,13 @@
 from __future__ import annotations
 
 import copy
-import pathlib
-import sys
 from typing import Any, cast
 
 import pytest
+from fastmcp.exceptions import ToolError
 
-PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
-
-from fastmcp.exceptions import ToolError  # noqa: E402
-
-from automox_mcp.client import AutomoxClient  # noqa: E402
-from automox_mcp.workflows.policy_crud import (  # noqa: E402
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.policy_crud import (
     _coerce_policy_payload_defaults,
     _deep_merge_dicts,
     _normalize_filters,

--- a/tests/test_workflows_reports.py
+++ b/tests/test_workflows_reports.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import pytest
 from conftest import StubClient
 
-from automox_mcp.client import AutomoxClient
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
 from automox_mcp.workflows.reports import (
     _extract_devices,
     _highest_patch_severity,
@@ -452,3 +452,20 @@ async def test_get_noncompliant_report_uses_len_when_total_absent() -> None:
     )
 
     assert result["data"]["total_devices"] == 2
+
+
+# ===========================================================================
+# Error path tests — API errors propagate through the workflow
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_prepatch_report_api_error_propagates():
+    client = StubClient()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise AutomoxAPIError("timeout", status_code=504)
+
+    client.get = _raise  # type: ignore[assignment]
+    with pytest.raises(AutomoxAPIError, match="timeout"):
+        await get_prepatch_report(cast(AutomoxClient, client), org_id=1)

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,8 @@ constraints = [
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -73,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -102,7 +103,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9" },
     { name = "pydantic", specifier = ">=2.12" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-dotenv", specifier = ">=1.1" },
@@ -1328,7 +1329,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1337,9 +1338,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1380,11 +1381,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Fix nested-bracket sanitization bypass** — Markdown link/image regexes now handle nested brackets, preventing URL exfiltration via patterns like `[click [here]](https://evil.com)` that previously passed through unsanitized
- **Fix CVE-2025-71176 (pytest)** — Bump to >=9.0.3 to fix local privilege escalation via predictable `/tmp/pytest-of-*` directories on UNIX
- **Fix CVE-2026-40347 (python-multipart)** — Bump to >=0.0.26 to fix DoS via crafted multipart/form-data requests with large preamble/epilogue
- **Add 49 new tests** covering JWT token verification, Pydantic schema validation, and workflow error propagation — areas with zero prior test coverage
- **Consolidate duplicate test infrastructure** and remove legacy `sys.path` hacks, reducing maintenance burden by ~170 lines

### Details

| Category | Change | Files |
|----------|--------|-------|
| Security fix | Nested-bracket regex bypass in `sanitize_for_llm()` | `src/automox_mcp/utils/sanitize.py` |
| CVE fix | pytest >=9.0.3 (CVE-2025-71176) | `pyproject.toml`, `uv.lock` |
| CVE fix | python-multipart >=0.0.26 (CVE-2026-40347) | `pyproject.toml`, `uv.lock` |
| Security tests | 9 JWT `verify_token()` integration tests (valid, expired, wrong aud/iss, bad sig, missing scopes) | `tests/test_auth_jwt.py` |
| Coverage | 34 schema validation tests (model validators, field constraints, discriminated unions, payload size limits) | `tests/test_schemas.py` (new) |
| Coverage | 6 workflow error-path tests (events, groups, reports, packages) | `tests/test_workflows_*.py` |
| Maintenance | Deduplicate `StubServer`/`FakeClient` into `conftest.py` | `tests/conftest.py`, 4 test files |
| Cleanup | Remove `sys.path.insert()` hacks | `tests/conftest.py`, 2 test files |
| Version | Bump to 1.0.16 | `pyproject.toml`, `CHANGELOG.md` |

All **1048 tests pass** with **90.62% coverage**. Linter, formatter, mypy, build, twine check, and pip-audit all clean.

## Test plan

- [x] `uv sync --extra dev --frozen` — lockfile resolves cleanly
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 116 files already formatted
- [x] `uv run mypy .` — no issues found in 65 source files
- [x] `uv run pytest --cov=automox_mcp --cov-fail-under=90 --cov-report=term-missing` — 1048 passed, 90.62% coverage
- [x] `uv run python -m build` — sdist and wheel built successfully
- [x] `uv run python -m twine check dist/*` — PASSED
- [x] `pip-audit -r requirements-ci.txt` — no known vulnerabilities found
- [ ] CI passes on Python 3.11, 3.12, 3.13

https://claude.ai/code/session_01BdBajQJ2xktReN16hBWyKw