### PR TITLE
Bump authlib to >=1.6.11 (GHSA-jj8c-mmj3-mmgv) for v1.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.17] - 2026-04-25
+
+### Security
+
+- **GHSA-jj8c-mmj3-mmgv (authlib)** — Bumped `authlib` constraint from >=1.6.6 to >=1.6.11 to fix a CSRF vulnerability in OAuth integrations using the cache parameter for state storage. Without `SessionMiddleware` tying the client to auth state, attackers could initiate an OAuth flow and trick a victim into completing it, binding the attacker's account to the victim's session
+
 ## [1.0.16] - 2026-04-16
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.16"
+version = "1.0.17"
 description = "An MCP server implementation for Automox"
 readme = "README.md"
 authors = [
@@ -81,7 +81,7 @@ exclude_dirs = ["tests", ".venv"]
 
 [tool.uv]
 constraint-dependencies = [
-  "authlib>=1.6.6",       # CVE-2025-68158: CSRF in cache-backed state storage
+  "authlib>=1.6.11",      # CVE-2025-68158, GHSA-jj8c-mmj3-mmgv: CSRF in cache-backed state storage
   "cryptography>=46.0.6", # CVE-2026-26007, CVE-2026-34073
   "fastmcp>=3.2.0",       # CVE-2025-69196, CVE-2025-64340, CVE-2026-27124, GHSA-rcfx-77hg-w2wv
   "jaraco-context>=6.1.0",# CVE-2026-23949

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [manifest]
 constraints = [
-    { name = "authlib", specifier = ">=1.6.6" },
+    { name = "authlib", specifier = ">=1.6.11" },
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
@@ -62,19 +62,20 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.16"
+version = "1.0.17"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -760,6 +761,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **GHSA-jj8c-mmj3-mmgv (authlib)** — Bumps `authlib` constraint from `>=1.6.6` to `>=1.6.11`. Fixes a CSRF vulnerability in OAuth integrations using the cache parameter for state storage. Without `SessionMiddleware` tying the client to auth state, an attacker can initiate an OAuth flow and trick a victim into completing it, binding the attacker's account to the victim's session.
- Bumps version to **1.0.17** and updates CHANGELOG.
- Lockfile resolves authlib to 1.7.0 (newer than the constraint minimum).

This unblocks the open Dependabot PRs (#27, #30, #31) which were failing `pip-audit` against this newly-published advisory.

## Test plan

- [x] `uv sync --extra dev --frozen` — lockfile resolves cleanly
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — clean (65 source files)
- [x] `uv run pytest` — 1048 passed
- [x] `pip-audit` — no vulnerabilities in project deps
- [ ] CI passes on Python 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)