### PR TITLE
Fix prepatch report total field mislabel (#28) for v1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.18] - 2026-04-25
+
+### Fixed
+
+- **`get_prepatch_report` field mislabel (#28)** — The `total_org_devices` field in the response was sourced from the `/reports/prepatch` API's `total` key, which actually counts **pending patches**, not devices. Renamed to `total_pending_patches` (both in the top-level `data` and inside `summary`) to match what the value represents. This corrects the prior interpretation noted in v1.0.13 ("`total` field from API means org device count"). Callers needing a true org device count should use `device_health_metrics.total_devices` or `list_devices`.
+- **`get_prepatch_report` pagination heuristic** — Removed an early-exit condition that compared `len(device_list) >= summary["total"]` to terminate pagination. Because `total` is a patch count rather than a device count, the comparison was meaningless. Pagination now relies solely on the empty-page sentinel, which already worked in practice.
+
 ## [1.0.17] - 2026-04-25
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.17"
+version = "1.0.18"
 description = "An MCP server implementation for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/workflows/reports.py
+++ b/src/automox_mcp/workflows/reports.py
@@ -152,10 +152,10 @@ async def get_prepatch_report(
         if single_page:
             break
 
-        total = summary.get("total")
+        # Note: summary["total"] reports pending-patch count, not device count,
+        # so it cannot be used to short-circuit pagination. Rely on the
+        # empty-page check below.
         if not page_devices:
-            break
-        if total is not None and len(device_list) >= total:
             break
 
         params["offset"] = params["offset"] + page_size
@@ -188,10 +188,10 @@ async def get_prepatch_report(
         }
         devices.append(entry)
 
-    total_org_devices = summary.get("total") or 0
+    total_pending_patches = summary.get("total") or 0
     devices_needing_patches = len(devices)
     device_severity_summary = {
-        "total_org_devices": total_org_devices,
+        "total_pending_patches": total_pending_patches,
         "devices_needing_patches": devices_needing_patches,
         "critical": severity_counter.get("critical", 0),
         "high": severity_counter.get("high", 0),
@@ -203,7 +203,7 @@ async def get_prepatch_report(
 
     return {
         "data": {
-            "total_org_devices": total_org_devices,
+            "total_pending_patches": total_pending_patches,
             "total_devices": devices_needing_patches,
             "summary": device_severity_summary,
             "api_summary": summary,

--- a/tests/test_workflows_reports.py
+++ b/tests/test_workflows_reports.py
@@ -167,16 +167,17 @@ async def test_get_prepatch_report_single_page_explicit_limit() -> None:
 
 @pytest.mark.asyncio
 async def test_get_prepatch_report_auto_pagination() -> None:
-    """When total > page results, auto-pagination issues multiple GETs."""
+    """Auto-pagination issues multiple GETs and terminates on the first empty page."""
     page1_devices = [{"id": i, "name": f"host{i}", "patches": []} for i in range(1, 4)]
     page2_devices = [{"id": 4, "name": "host4", "patches": []}]
 
-    # First page reports total=4 so the loop continues for page 2.
     page1_response = {"prepatch": {"total": 4, "devices": page1_devices}}
     page2_response = {"prepatch": {"total": 4, "devices": page2_devices}}
+    # Pagination stops when a page returns no devices.
+    page3_response = {"prepatch": {"total": 4, "devices": []}}
 
     client = StubClient(
-        get_responses={"/reports/prepatch": [page1_response, page2_response]},
+        get_responses={"/reports/prepatch": [page1_response, page2_response, page3_response]},
     )
 
     result = await get_prepatch_report(
@@ -186,7 +187,7 @@ async def test_get_prepatch_report_auto_pagination() -> None:
 
     assert result["data"]["total_devices"] == 4
     get_calls = [c for c in client.calls if c[0] == "GET"]
-    assert len(get_calls) == 2
+    assert len(get_calls) == 3
 
     # Second request should have an incremented offset
     second_params = get_calls[1][2]
@@ -280,6 +281,67 @@ async def test_get_prepatch_report_stops_when_page_empty() -> None:
     get_calls = [c for c in client.calls if c[0] == "GET"]
     assert len(get_calls) == 2
     assert result["data"]["total_devices"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_prepatch_report_total_is_pending_patches_not_devices() -> None:
+    """The API's `total` field counts pending patches, not devices.
+
+    Regression test for #28. The response field is `total_pending_patches`
+    (matching the underlying value), not `total_org_devices`.
+    """
+    # 2 devices with a combined 7 pending patches → API reports total=7.
+    devices = [
+        {"id": 1, "name": "host1", "patches": [{"severity": "high"}] * 4},
+        {"id": 2, "name": "host2", "patches": [{"severity": "low"}] * 3},
+    ]
+    response = {"prepatch": {"total": 7, "devices": devices}}
+    client = StubClient(get_responses={"/reports/prepatch": [response]})
+
+    result = await get_prepatch_report(cast(AutomoxClient, client), org_id=42, limit=500)
+
+    data = result["data"]
+    # `total_pending_patches` reflects the API's total verbatim.
+    assert data["total_pending_patches"] == 7
+    assert data["summary"]["total_pending_patches"] == 7
+    # `total_devices` is the count of devices in this report (devices needing patches).
+    assert data["total_devices"] == 2
+    # The mislabeled key from prior versions is gone.
+    assert "total_org_devices" not in data
+    assert "total_org_devices" not in data["summary"]
+
+
+@pytest.mark.asyncio
+async def test_get_prepatch_report_pagination_does_not_short_circuit_on_total() -> None:
+    """Pagination must not terminate based on `summary.total` (which is patch count, not devices).
+
+    Regression test for #28: if `total` (patches) is small relative to actual
+    device count, the loop must continue until an empty page is returned.
+    """
+    # First page returns 2 devices; API reports total=2 (patches), but more devices exist.
+    page1 = {
+        "prepatch": {
+            "total": 2,
+            "devices": [{"id": 1, "name": "h1", "patches": [{"severity": "high"}]}],
+        }
+    }
+    page2 = {
+        "prepatch": {
+            "total": 2,
+            "devices": [{"id": 2, "name": "h2", "patches": [{"severity": "low"}]}],
+        }
+    }
+    page3 = {"prepatch": {"total": 2, "devices": []}}  # empty page → terminate
+    client = StubClient(
+        get_responses={"/reports/prepatch": [page1, page2, page3]},
+    )
+
+    result = await get_prepatch_report(cast(AutomoxClient, client), org_id=42)
+
+    get_calls = [c for c in client.calls if c[0] == "GET"]
+    # Three calls means we kept paginating past `total`, then stopped on empty page.
+    assert len(get_calls) == 3
+    assert result["data"]["total_devices"] == 2
 
 
 # ===========================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.17"
+version = "1.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Fixes #28.

## Summary

- `get_prepatch_report` was exposing `summary["total"]` from `/reports/prepatch` as `total_org_devices` — but that API field actually counts **pending patches**, not devices. This caused output like "35 / 140 devices" when reality was "35 devices have a combined 140 pending patches" (per @mhansen-automox's bug report).
- Field renamed to `total_pending_patches` (both top-level and inside `summary`) to match what the value represents.
- Removed a pagination short-circuit (`len(device_list) >= summary["total"]`) that was meaningless once you accept `total` is a patch count, not a device count. Pagination now relies on the existing empty-page sentinel.
- This corrects the prior interpretation noted in v1.0.13 ("`total` field from API means org device count") — that change replaced one wrong interpretation with another. Callers needing a true org device count should use `device_health_metrics.total_devices` or `list_devices`.

## Breaking change note

The response key `total_org_devices` is gone. Anything reading that key (e.g. an LLM working from prior tool output) will need to switch to `total_pending_patches` for the patch count, or to a different endpoint for the actual device count. Internal compound consumer (`compound.py`'s `get_patch_tuesday_readiness`) was already using `total_devices`, so it's unaffected.

## Test plan

- [x] `uv run pytest -q --cov=automox_mcp --cov-fail-under=90` — 1050 passed, 90.61% coverage
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — clean
- [x] Two regression tests added in `test_workflows_reports.py`:
  - `test_get_prepatch_report_total_is_pending_patches_not_devices` — pins the new field name and asserts the old one is gone
  - `test_get_prepatch_report_pagination_does_not_short_circuit_on_total` — verifies pagination keeps fetching past `summary.total` until an empty page
- [ ] CI passes on Python 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)