### PR TITLE
Declare official Automox MCP server status (v1.0.19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ htmlcov/
 build/
 dist/
 automox-mcp-design-guide.md
+
+# MCP Registry tooling — local only, never commit
+mcp-publisher
+mcp-registry-key.pem
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2026-04-28
+
+### Changed
+
+- **Official designation** — `automox-mcp` is now the official Automox MCP server. Support remains community-driven via [GitHub Issues](https://github.com/AutomoxCommunity/automox-mcp/issues) and the Automox Community; the project is not covered by Automox commercial support contracts. README, package description, and Support section updated to reflect the new status.
+- **MCP Registry preparation** — Added `mcp-name: com.automox/automox-mcp` ownership marker to README in advance of publishing to the official [MCP Registry](https://registry.modelcontextprotocol.io/) under the `com.automox/` namespace.
+
 ## [1.0.18] - 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Automox MCP Server
 
+<!-- mcp-name: com.automox/automox-mcp -->
+
 [![CI](https://github.com/AutomoxCommunity/automox-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/AutomoxCommunity/automox-mcp/actions/workflows/ci.yml)
 [![Security Scans](https://github.com/AutomoxCommunity/automox-mcp/actions/workflows/security.yml/badge.svg)](https://github.com/AutomoxCommunity/automox-mcp/actions/workflows/security.yml)
 [![Publish Release](https://github.com/AutomoxCommunity/automox-mcp/actions/workflows/release.yml/badge.svg)](https://github.com/AutomoxCommunity/automox-mcp/actions/workflows/release.yml)
 [![PyPI version](https://badge.fury.io/py/automox-mcp.svg)](https://badge.fury.io/py/automox-mcp)
 
-Talk to your Automox console using natural language. This [MCP server](https://modelcontextprotocol.io/) connects AI assistants like Claude to your Automox environment so you can manage devices, check compliance, run policies, and more — just by asking.
+The official MCP server for Automox. Talk to your Automox console using natural language — this [MCP server](https://modelcontextprotocol.io/) connects AI assistants like Claude to your Automox environment so you can manage devices, check compliance, run policies, and more, just by asking.
 
 ```
 You:   "Are we ready for Patch Tuesday?"
@@ -14,7 +16,7 @@ Claude: Here's your readiness summary — 3 devices need patches,
 ```
 
 > [!IMPORTANT]
-> The project is under active development. Contributions and suggestions are welcome via [GitHub Issues](https://github.com/AutomoxCommunity/automox-mcp/issues).
+> Contributions, bug reports, and feature requests are welcome via [GitHub Issues](https://github.com/AutomoxCommunity/automox-mcp/issues) and the Automox Community.
 
 > [!CAUTION]
 > AI assistants can make mistakes. Data produced by the MCP server may be incorrect or incomplete. If you see this happening consistently, please [open an issue](https://github.com/AutomoxCommunity/automox-mcp/issues).
@@ -294,4 +296,6 @@ MIT License. See [LICENSE](LICENSE).
 
 ## Support
 
-Community-driven project, actively maintained but not officially supported by Automox. For questions, bugs, or feature requests, [open a GitHub Issue](https://github.com/AutomoxCommunity/automox-mcp/issues).
+The official Automox MCP server. Support is community-driven: for questions, bugs, or feature requests, [open a GitHub Issue](https://github.com/AutomoxCommunity/automox-mcp/issues) or post in the Automox Community. This project is not covered by Automox commercial support contracts.
+
+To report a security vulnerability, see [SECURITY.md](SECURITY.md) — please do not open a public issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "automox-mcp"
-version = "1.0.18"
-description = "An MCP server implementation for Automox"
+version = "1.0.19"
+description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [
   { name = "Automox" }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.automox/automox-mcp",
+  "title": "Automox MCP Server",
+  "description": "Official MCP server for Automox. Talk to your Automox console using natural language — manage devices, check compliance, run policies, and more.",
+  "repository": {
+    "url": "https://github.com/AutomoxCommunity/automox-mcp",
+    "source": "github"
+  },
+  "version": "1.0.19",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "automox-mcp",
+      "version": "1.0.19",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "AUTOMOX_API_KEY",
+          "description": "Your Automox API key",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "AUTOMOX_ACCOUNT_UUID",
+          "description": "Account UUID from Automox Settings > Secrets & Keys",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "AUTOMOX_ORG_ID",
+          "description": "Numeric Automox organization ID. Recommended — required by most tools, optional for tools that don't need org context.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Mark `automox-mcp` as the **official Automox MCP server** with community-driven support (GitHub Issues + Automox Community); project remains outside Automox commercial support contracts
- Stage metadata for publishing to the official [MCP Registry](https://registry.modelcontextprotocol.io/) under the `com.automox/automox-mcp` namespace (DNS-verified ownership of `automox.com`)
- Bump to v1.0.19

## Changes

- **README.md** — tagline, IMPORTANT callout, and Support section updated to reflect official status; cross-link SECURITY.md for vulnerability reporting; add `<!-- mcp-name: com.automox/automox-mcp -->` ownership marker so the registry can verify the PyPI listing matches the claimed namespace at publish time
- **pyproject.toml** — bump to 1.0.19; description now reads "Official MCP server for Automox"
- **server.json** (new) — registry metadata: `com.automox/automox-mcp`, PyPI package, stdio transport, env vars matching the README (`AUTOMOX_API_KEY` + `AUTOMOX_ACCOUNT_UUID` required, `AUTOMOX_ORG_ID` recommended)
- **.gitignore** — exclude registry tooling artifacts (`mcp-publisher` binary, `*.pem` signing keys) so they cannot be committed accidentally
- **CHANGELOG.md** — 1.0.19 entry covering the official designation and registry preparation

## Release sequencing

After this PR merges:

1. Tag `v1.0.19` on the merge commit → existing release workflow publishes to PyPI (Sigstore-signed, with SBOM)
2. Once `automox.com` DNS TXT record is live (in flight with IT), authenticate `mcp-publisher` via DNS and run `mcp-publisher publish` to push `server.json` to the MCP Registry

The registry validates the `mcp-name` marker against the live PyPI listing, so PyPI publish must complete before the registry publish.

## Test plan

- [ ] CI passes (lint, type check, pytest, security scans, pip-audit)
- [ ] After merge: tag `v1.0.19`, confirm release workflow publishes to PyPI and creates GitHub Release
- [ ] Confirm PyPI listing for v1.0.19 contains the `mcp-name: com.automox/automox-mcp` marker in the rendered description
- [ ] After DNS propagation: `mcp-publisher publish --dry-run` validates server.json against the schema
- [ ] After registry publish: `curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.automox/automox-mcp"` returns the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)