### PR TITLE
Match server.json description to live registry entry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.automox/automox-mcp",
   "title": "Automox MCP Server",
-  "description": "Official MCP server for Automox. Talk to your Automox console using natural language — manage devices, check compliance, run policies, and more.",
+  "description": "Official MCP server for Automox. Manage devices, patches, and policies in natural language.",
   "repository": {
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary

- The MCP Registry caps `description` at 100 chars; our original 154-char version failed validation with HTTP 422
- The version actually [published to the registry on 2026-04-29](https://registry.modelcontextprotocol.io/v0.1/servers?search=com.automox/automox-mcp) was the trimmed 91-char form
- This syncs the in-repo `server.json` to match what's live, so future republishes (manual or via CI automation per Step 8 of the publish guide) start from the accepted state

## Why no version bump

`server.json` is registry-side metadata only. PyPI v1.0.19 is unchanged. The registry already has the correct content; this PR just reconciles the repo with reality.

## Test plan

- [ ] CI passes
- [ ] `python3 -c "import json; print(len(json.load(open('server.json'))['description']))"` returns `91`
- [ ] `curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.automox/automox-mcp" | jq '.servers[0].server.description'` matches `server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)