### PR TITLE
Auto-publish to MCP Registry on tag (Step 8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI and MCP Registry
 
 on:
   push:
@@ -83,3 +83,39 @@ jobs:
               --generate-notes \
               dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json
           fi
+
+      # ---------------------------------------------------------------
+      # MCP Registry publish (Step 8 of publish-automox-mcp-to-registry.md)
+      #
+      # Skipped when PyPI publish was skipped (version already on PyPI),
+      # because the registry validates the `mcp-name` marker against the
+      # live PyPI listing — backfills should be done manually.
+      #
+      # TODO(supply chain): pin mcp-publisher to a specific release once
+      # the registry GAs. Currently uses `latest` to match the upstream
+      # quickstart. Tracked alongside other supply-chain items.
+      # ---------------------------------------------------------------
+      - name: Install mcp-publisher
+        if: steps.pypi_check.outputs.exists != 'true'
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher --help > /dev/null
+
+      - name: Set version in server.json from tag
+        if: steps.pypi_check.outputs.exists != 'true'
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          echo "server.json version set to $VERSION"
+
+      - name: Authenticate to MCP Registry
+        if: steps.pypi_check.outputs.exists != 'true'
+        env:
+          MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
+        run: ./mcp-publisher login dns --domain automox.com --private-key "$MCP_REGISTRY_PRIVATE_KEY"
+
+      - name: Publish to MCP Registry
+        if: steps.pypi_check.outputs.exists != 'true'
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary

Closes the loop on registry publishing: every future `v*` tag will publish to PyPI **and** to the official MCP Registry under `com.automox/automox-mcp` automatically. Implements [Step 8 of `publish-automox-mcp-to-registry.md`](https://github.com/AutomoxCommunity/automox-mcp/blob/main/server.json) so we don't have to run `mcp-publisher` by hand on every release.

## Changes

Four new workflow steps in `.github/workflows/release.yml`, all gated by `steps.pypi_check.outputs.exists != 'true'` so they match the existing PyPI publish guard:

1. **Install `mcp-publisher`** — downloads the Linux binary from GitHub releases (`curl -fsSL` to fail fast on HTTP errors)
2. **Set version in `server.json` from tag** — `jq` overrides both `.version` and `.packages[0].version` from `${GITHUB_REF_NAME#v}`, so contributors don't have to remember to bump `server.json` on every release
3. **Authenticate to MCP Registry** — `mcp-publisher login dns --domain automox.com --private-key <secret>`
4. **Publish to MCP Registry** — `mcp-publisher publish`

Also retitles the workflow (`Publish to PyPI` → `Publish to PyPI and MCP Registry`) to reflect what it now does.

## Required before merge / next tag

**A new repo secret `MCP_REGISTRY_PRIVATE_KEY` must be added before the next tag is pushed.** The value is the same Ed25519 private key hex string used in the successful 2026-04-29 manual publish. Extract it from your local `mcp-registry-key.pem` with:

```bash
openssl pkey -in mcp-registry-key.pem -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n'
```

(Use the Homebrew OpenSSL on macOS — LibreSSL can't read Ed25519 keys.)

Then add it to the repo:

```bash
gh secret set MCP_REGISTRY_PRIVATE_KEY < /path/to/extracted-hex.txt
```

The matching public key is already published in the `automox.com` apex DNS TXT record, so no DNS changes are needed.

## Behavior on edge cases

- **Tag re-pushed for a version already on PyPI**: PyPI step skips; all four registry steps also skip via the same guard. No spurious "duplicate version" registry errors.
- **Manual backfill needed**: still possible — run `mcp-publisher` locally as before. The CI guard intentionally does not handle this case because it would require fetching the artifact rather than building it.
- **mcp-publisher upstream changes**: pinned to `latest` for now to match the upstream quickstart. Inline TODO calls out that we should pin once the registry GAs.

## Test plan

- [ ] Add `MCP_REGISTRY_PRIVATE_KEY` repo secret (instructions above)
- [ ] CI passes on this PR (workflow YAML lint, no functional run yet — release.yml only fires on tags)
- [ ] After merge, on next release tag (e.g., v1.0.20): verify the four new steps run, all succeed, and `curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.automox/automox-mcp" | jq '.servers[0].server.version'` returns the new version

## Out of scope

- Pinning `mcp-publisher` to a specific release (TODO in inline comment)
- Extending automation to npm/other registries (not applicable here)
- Notifications on registry publish failure (rely on standard GitHub Actions failure email for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)