### PR TITLE
Release v1.0.20: ship MCPB Desktop Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2026-04-29
+
+### Added
+
+- **MCPB Desktop Extension** — `automox-mcp` is now installable as a one-click [MCPB (MCP Bundle)](https://github.com/modelcontextprotocol/mcpb) Desktop Extension. Claude Desktop users can drag the `automox-mcp-1.0.20.mcpb` archive (attached to this GitHub Release) into Settings → Extensions instead of editing JSON config files. The bundle is a uvx shim — `manifest.json` + a one-line Python entry point + a `pyproject.toml` that pins `automox-mcp>=1.0.20` — so source code is not bundled and `uv` pulls the matching PyPI release on first run. The install form prompts for API key (sensitive), Account UUID, Org ID (optional), and a read-only mode toggle.
+
+### Changed
+
+- **Release workflow now publishes to three channels.** Every `v*` tag now publishes to PyPI (Sigstore-signed, with SBOM), to the MCP Registry under the DNS-verified `com.automox/automox-mcp` namespace, and as a `.mcpb` archive attached to the GitHub Release. v1.0.20 is the first release exercising the latter two paths in CI.
+
 ## [1.0.19] - 2026-04-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.19"
+version = "1.0.20"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

First release exercising both new release-channel paths in CI:

1. **MCP Registry auto-publish** (added in #39, pushed manually for v1.0.19) — v1.0.20 is the first version flowing through the new workflow steps.
2. **MCPB build & GitHub Release upload** (added in #40) — produces the first `automox-mcp-1.0.20.mcpb` artifact, attached to the GitHub Release alongside the PyPI wheels and SBOM.

No source code in `src/` changes between v1.0.19 and v1.0.20. The release ships a new install channel (Claude Desktop one-click) rather than new functionality. CHANGELOG entry is framed as such.

## What's in the release

| Artifact | Channel | Trigger |
|---|---|---|
| `automox_mcp-1.0.20-py3-none-any.whl` | PyPI | Existing workflow |
| `automox_mcp-1.0.20.tar.gz` | PyPI | Existing workflow |
| `*.sigstore.json` + `sbom.cdx.json` | GitHub Release | Existing workflow |
| `com.automox/automox-mcp@1.0.20` | MCP Registry | **New (auto from #39)** |
| `automox-mcp-1.0.20.mcpb` | GitHub Release asset | **New (auto from #40)** |

## Why no MCPB source changes

`mcpb/manifest.json` and `mcpb/pyproject.toml` retain the v1.0.19 source values. The release workflow overrides both from the tag (`v1.0.20` → `1.0.20`) before `mcpb pack` runs. Same pattern as `server.json`. Contributors don't have to remember to bump three files for every release.

## Test plan

- [ ] CI passes on this PR (lint, type check, pytest, security scans)
- [ ] After merge: tag `v1.0.20` and verify the workflow run completes all five output paths above
- [ ] Confirm `pip install automox-mcp==1.0.20` works
- [ ] Confirm `curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=com.automox/automox-mcp" | jq '.servers[0].server.version'` returns `"1.0.20"`
- [ ] Download the `.mcpb` from the v1.0.20 release, drag into Claude Desktop, verify the user_config form renders, paste real credentials, confirm the server starts and `discover_capabilities` returns the 80 tools
- [ ] Repeat the Claude Desktop install on Windows if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)