### PR TITLE
Harden and modernize GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -23,3 +28,8 @@ updates:
       python-deps:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,7 @@ updates:
         patterns:
           - "*"
     cooldown:
-      default-days: 5
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -29,7 +26,7 @@ updates:
         patterns:
           - "*"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,45 +7,107 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
+env:
+  PYTHON_VERSION: "3.13"
+
 jobs:
-  quality:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+
+      - name: Sync project dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Ruff lint
+        run: uv run ruff check --output-format=github .
+
+      - name: Ruff format check
+        run: uv run ruff format --check --diff .
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+
+      - name: Sync project dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Type check
+        run: uv run mypy .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Sync project dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov=automox_mcp --cov-fail-under=90 --cov-report=term-missing
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
 
       - name: Sync project dependencies
         run: uv sync --extra dev --frozen
 
       - name: Ensure pip available in venv
         run: .venv/bin/python -m ensurepip --upgrade
-
-      - name: Ruff lint
-        run: uv run ruff check .
-
-      - name: Ruff format (dry-run)
-        run: uv run ruff format --check .
-
-      - name: Type check
-        run: uv run mypy .
-
-      - name: Run tests with coverage
-        run: uv run pytest --cov=automox_mcp --cov-fail-under=90 --cov-report=term-missing
 
       - name: Build distribution artifacts
         run: uv run python -m build
@@ -55,8 +117,6 @@ jobs:
 
       - name: Export locked requirements
         run: |
-          # pip-audit needs a standard requirements file; drop hashes/editables so the root package
-          # can still be installed for auditing.
           uv export --format requirements.txt --all-extras --no-editable --no-hashes --locked \
             --output-file requirements-ci.txt
 
@@ -66,3 +126,25 @@ jobs:
           inputs: |
             requirements-ci.txt
           virtual-environment: .venv
+
+  ci-pass:
+    if: always()
+    needs: [lint, typecheck, test, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          results=(
+            "${{ needs.lint.result }}"
+            "${{ needs.typecheck.result }}"
+            "${{ needs.test.result }}"
+            "${{ needs.build.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" ]]; then
+              echo "::error::One or more CI jobs did not succeed (got: $r)."
+              exit 1
+            fi
+          done
+          echo "All CI jobs passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,17 +134,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Verify all jobs passed
+        if: >-
+          needs.lint.result != 'success' ||
+          needs.typecheck.result != 'success' ||
+          needs.test.result != 'success' ||
+          needs.build.result != 'success'
         run: |
-          results=(
-            "${{ needs.lint.result }}"
-            "${{ needs.typecheck.result }}"
-            "${{ needs.test.result }}"
-            "${{ needs.build.result }}"
-          )
-          for r in "${results[@]}"; do
-            if [[ "$r" != "success" ]]; then
-              echo "::error::One or more CI jobs did not succeed (got: $r)."
-              exit 1
-            fi
-          done
-          echo "All CI jobs passed."
+          echo "::error::One or more CI jobs did not succeed."
+          exit 1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,22 +3,17 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     continue-on-error: true
     environment: claude-code
     permissions:
@@ -42,6 +37,3 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |
@@ -18,13 +20,14 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: claude-code
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,16 +40,5 @@ jobs:
         uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.13"
+          enable-cache: false  # Don't trust CI caches in a release pipeline
 
       - name: Validate tag matches project version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,16 @@ on:
       - "v*"
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write  # Required for creating GitHub Releases
       id-token: write  # Required for trusted publishing and Sigstore signing
@@ -21,8 +26,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.13"
 
@@ -44,32 +49,28 @@ jobs:
         id: pypi_check
         run: |
           VERSION=$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
-          if pip index versions automox-mcp 2>/dev/null | grep -q "$VERSION"; then
+          if curl -sf "https://pypi.org/pypi/automox-mcp/${VERSION}/json" > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Version $VERSION already exists on PyPI — skipping publish."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install build backend
-        run: python -m pip install --upgrade pip build
+      - name: Sync project dependencies
+        run: uv sync --frozen
 
       - name: Build distribution
-        run: python -m build
+        run: uv build
 
       - name: Generate SBOM
-        run: |
-          pip install cyclonedx-bom
-          cyclonedx-py environment -o sbom.cdx.json --of json
+        run: uv run --with cyclonedx-bom cyclonedx-py environment -o sbom.cdx.json --of json
 
       - name: Publish to PyPI
         if: steps.pypi_check.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Sign artifacts with Sigstore
-        run: |
-          pip install sigstore
-          python -m sigstore sign dist/*.whl dist/*.tar.gz
+        run: uvx sigstore sign dist/*.whl dist/*.tar.gz
 
       - name: Create or update GitHub Release
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -66,11 +66,6 @@ jobs:
         run: uv sync --extra dev --frozen
 
       - name: Run mcp-scanner against stdio server
-        env:
-          AUTOMOX_API_KEY: test-api-key
-          AUTOMOX_ACCOUNT_UUID: test-account
-          AUTOMOX_ORG_ID: "1"
-          AUTOMOX_MCP_SKIP_DOTENV: "1"
         run: |
           set -euo pipefail
           uvx --from cisco-ai-mcp-scanner mcp-scanner \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,10 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -30,7 +34,8 @@ jobs:
       - name: Scan working tree for secrets
         run: |
           set -euo pipefail
-          docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:latest \
+          docker run --rm -v "$PWD:/pwd" \
+            trufflesecurity/trufflehog:3.94.3@sha256:8837fd74692f6da826b51bc008b6bcf0dd2d70d31d06792673872a235d9b7e39 \
             filesystem --directory=/pwd --results=verified,unknown --json --fail \
             | tee trufflehog.json
 
@@ -55,6 +60,7 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
 
       - name: Sync project dependencies
         run: uv sync --extra dev --frozen
@@ -67,9 +73,7 @@ jobs:
           AUTOMOX_MCP_SKIP_DOTENV: "1"
         run: |
           set -euo pipefail
-          source .venv/bin/activate
-          uv pip install cisco-ai-mcp-scanner
-          mcp-scanner \
+          uvx --from cisco-ai-mcp-scanner mcp-scanner \
             --analyzers yara \
             --format summary \
             stdio \
@@ -124,15 +128,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.13"
-
-      - name: Install zizmor
-        run: python -m pip install --upgrade pip zizmor
-
       - name: Scan workflows
-        env:
-          ZIZMOR_NO_ONLINE_AUDITS: "true"
-        run: zizmor --collect=workflows --strict-collection --format=github .
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          online-audits: false
+          annotations: true
+          advanced-security: false


### PR DESCRIPTION
## Summary

Audited all six workflow files for security, efficiency, and best-practice gaps and applied fixes across the board.

### Security
- **Pinned TruffleHog Docker image** to `3.94.3@sha256:8837fd...` (was `:latest` — non-reproducible, supply-chain risk)
- **Added top-level `permissions: {}`** to `claude.yml` and `claude-code-review.yml`
- **Eliminated unpinned `pip install`** of `cyclonedx-bom` and `sigstore` in `release.yml`; replaced with `uv run --with` and `uvx` for isolated execution
- **Added `environment: release`** to the publish job for deployment protection
- **Added `concurrency` with `cancel-in-progress: false`** on release to prevent double-publish
- **Replaced manual zizmor pip install** with `zizmorcore/zizmor-action@v0.5.3` (SHA-pinned)
- **Replaced `uv pip install cisco-ai-mcp-scanner`** into project venv with `uvx --from` (no venv pollution)
- **Avoided template-injection pattern** in the new `ci-pass` aggregation job (uses `if` conditions instead of `${{ }}` interpolation in `run:` blocks)

### Efficiency
- **Split monolithic CI `quality` job into 4 parallel jobs** (`lint`, `typecheck`, `test`, `build`) — lint failures no longer block test results, and build/twine/pip-audit run once instead of 3× across the Python matrix
- **Added `ci-pass` aggregation job** for branch protection (single required check)
- **Enabled `enable-cache: true`** on all `setup-uv` steps
- **Added concurrency groups** to `ci.yml`, `security.yml`, and `claude-code-review.yml`
- **Switched ruff to `--output-format=github`** for inline PR annotations and added `--diff` to format check

### Modernization
- **Replaced `setup-python` + `pip install build`** in `release.yml` with `setup-uv` + `uv build`
- **Replaced `pip index versions`** PyPI check with a direct `curl` to the PyPI JSON API (simpler, no pip dependency)
- **Added `timeout-minutes: 30`** to both Claude workflows (was defaulting to 6 hours)
- **Added per-PR concurrency** to `claude-code-review.yml` to deduplicate reviews on rapid pushes
- **Added grouping and labels** to `dependabot.yml` to reduce PR noise
- **Removed commented-out boilerplate** from Claude workflows

## Test plan

- [ ] Verify all workflow YAML parses (`python -c "import yaml; yaml.safe_load(open(f))"` — already validated locally)
- [ ] On PR open: confirm `lint`, `typecheck`, `test (3.11/3.12/3.13)`, `build`, `ci-pass` jobs all run in parallel and pass
- [ ] Confirm `Security Scans` workflow's `trufflehog`, `mcp-scanner`, and `zizmor` jobs all pass against the new workflows
- [ ] Confirm `Claude Code Review` workflow runs on this PR and is non-blocking as before
- [ ] **Branch protection update needed:** if branch protection currently requires the `quality` status check, update it to require `ci-pass` instead
- [ ] **Repo settings note:** if deployment protection rules are desired for releases, configure a `release` environment in repo settings (the workflow now references it)

https://claude.ai/code/session_016LvMhQd8oM8yv94L97E4Kj

---
_Generated by [Claude Code](https://claude.ai/code/session_016LvMhQd8oM8yv94L97E4Kj)_