### PR TITLE
Release v1.0.21: fix policy_run_detail_v2, scheduled-windows date, drop broken get_action_set_actions (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.21] - 2026-05-06
+
+### Fixed
+
+- **`policy_run_detail_v2` failed with `org=null` (#43)** — The wrapper around `/policy-history/policies/{policy_uuid}/{exec_token}` did not forward the org UUID as a query parameter, despite a stale comment claiming the endpoint extracted org context from the JWT. The Automox policy-report API rejected every call with `400 Invalid or missing org from query parameters org=null`. The org UUID is now resolved and threaded through alongside the existing filter params (`sort`, `result_status`, `device_name`, `page`, `limit`).
+- **Scheduled-windows date param rejected as malformed (#43)** — `get_group_scheduled_windows` and `get_device_scheduled_windows` passed the `date` value through `httpx`'s default params encoder, which percent-encoded the literal colons in `YYYY-MM-DDTHH:mm:ss` to `%3A`. The Automox `/policy-windows/.../scheduled-windows` endpoint validates the raw string and rejected the encoded form with `400 Invalid date-time format`. The query is now appended to the URL with `urllib.parse.quote(..., safe=":")` so colons survive transport intact.
+
+### Removed
+
+- **`get_action_set_actions` tool removed (#43)** — The wrapper hit `GET /orgs/{org_id}/remediations/action-sets/{action_set_id}/actions`, but that endpoint is `POST`-only (it creates actions; `OPTIONS` confirms `Allow: POST`). There is no read endpoint for actions in the Automox public API. Every call returned `405 Method Not Allowed`. Use `get_action_set_issues` and `get_action_set_solutions` for the related read data. Tool count drops from 80 to 79 (read-only tool count drops from 58 to 57).
+
 ## [1.0.20] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ That's it. Start asking questions.
 
 ## What Can I Ask?
 
-The server exposes 80 tools across devices, policies, patches, groups, webhooks, worklets, vulnerability sync, maintenance windows, and more. You don't need to know the tool names — just describe what you want:
+The server exposes 79 tools across devices, policies, patches, groups, webhooks, worklets, vulnerability sync, maintenance windows, and more. You don't need to know the tool names — just describe what you want:
 
 | Ask this | What happens |
 |---|---|
@@ -103,7 +103,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 | `AUTOMOX_API_KEY` | Yes | — | Automox API key |
 | `AUTOMOX_ACCOUNT_UUID` | Yes | — | Account UUID from Secrets & Keys |
 | `AUTOMOX_ORG_ID` | Recommended | — | Numeric organization ID (required by most tools) |
-| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (58 of 80 tools remain) |
+| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (57 of 79 tools remain) |
 | `AUTOMOX_MCP_MODULES` | No | all | Comma-separated list of modules to load (see below) |
 | `AUTOMOX_MCP_TOKEN_BUDGET` | No | `4000` | Max estimated tokens per response before truncation |
 | `AUTOMOX_MCP_SANITIZE_RESPONSES` | No | `true` | Sanitize API data to mitigate prompt injection |
@@ -199,7 +199,7 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 - **Security response headers** — `X-Content-Type-Options`, `X-Frame-Options`, `CSP`, `Cache-Control: no-store`, `Strict-Transport-Security` on all HTTP responses
 - **Authentication rate limiting** — blocks IPs after repeated auth failures to mitigate brute-force attacks
 - **Remote bind protection** — non-loopback HTTP/SSE binding requires explicit `--allow-remote-bind` opt-in
-- **MCP Tool Annotations** on all 80 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
+- **MCP Tool Annotations** on all 79 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
 - **60 security hardening items** (V-001 through V-181, S-001 through S-006) documented in CHANGELOG and SECURITY.md
 
 For vulnerability reporting and the full threat model, see [SECURITY.md](SECURITY.md).

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Complete reference for all 80 tools, 6 workflow prompts, MCP resources, parameters, and enterprise features exposed by the Automox MCP server.
+Complete reference for all 79 tools, 6 workflow prompts, MCP resources, parameters, and enterprise features exposed by the Automox MCP server.
 
 > **Tip:** You don't need to memorize this. Call `discover_capabilities` from your AI assistant to get a live summary of available tools organized by domain.
 
@@ -113,13 +113,12 @@ Richer policy execution reporting via the `/policy-history` API with UUID-based 
 - **`get_data_extract`** - Get details and download information for a specific data extract.
 - **`create_data_extract`** - Request a new data extract for bulk reporting. Returns the extract ID and initial status.
 
-## Vulnerability Sync (7 tools)
+## Vulnerability Sync (6 tools)
 
 Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-based import from vulnerability scanners (Qualys, Tenable, etc.).
 
 - **`list_remediation_action_sets`** - List vulnerability remediation action sets for the organization.
 - **`get_action_set_detail`** - Get details for a specific vulnerability remediation action set.
-- **`get_action_set_actions`** - Get remediation actions for an action set. Shows what patches or changes need to be applied.
 - **`get_action_set_issues`** - Get vulnerability issues (CVEs) associated with an action set.
 - **`get_action_set_solutions`** - Get solutions for an action set. Shows recommended patches or configurations.
 - **`get_upload_formats`** - Get supported CSV upload formats for vulnerability remediation action sets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.20"
+version = "1.0.21"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/tools/meta_tools.py
+++ b/src/automox_mcp/tools/meta_tools.py
@@ -97,7 +97,6 @@ _DOMAIN_CATALOG: dict[str, list[tuple[str, str]]] = {
     "vuln_sync": [
         ("list_remediation_action_sets", "List vulnerability action sets"),
         ("get_action_set_detail", "Action set details"),
-        ("get_action_set_actions", "Remediation actions for an action set"),
         ("get_action_set_issues", "Vulnerability issues for an action set"),
         ("get_action_set_solutions", "Solutions for an action set"),
         ("get_upload_formats", "Supported CSV upload formats"),

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -23,9 +23,6 @@ from ..utils.tooling import (
     store_idempotency,
 )
 from ..workflows.vuln_sync import (
-    get_action_set_actions as _get_action_set_actions,
-)
-from ..workflows.vuln_sync import (
     get_action_set_detail as _get_action_set_detail,
 )
 from ..workflows.vuln_sync import (
@@ -91,31 +88,6 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         result = await call_tool_workflow(
             client,
             _get_action_set_detail,
-            {"action_set_id": action_set_id},
-            params_model=GetActionSetParams,
-        )
-        return maybe_format_markdown(result, output_format)
-
-    @server.tool(
-        name="get_action_set_actions",
-        description=(
-            "Get remediation actions for a vulnerability action set. "
-            "Shows what patches or changes need to be applied."
-        ),
-        annotations={
-            "readOnlyHint": True,
-            "destructiveHint": False,
-            "idempotentHint": True,
-            "openWorldHint": True,
-        },
-    )
-    async def get_action_set_actions(
-        action_set_id: int,
-        output_format: str | None = "json",
-    ) -> dict[str, Any]:
-        result = await call_tool_workflow(
-            client,
-            _get_action_set_actions,
             {"action_set_id": action_set_id},
             params_model=GetActionSetParams,
         )

--- a/src/automox_mcp/workflows/__init__.py
+++ b/src/automox_mcp/workflows/__init__.py
@@ -93,7 +93,6 @@ from .policy_windows import (
 )
 from .reports import get_noncompliant_report, get_prepatch_report
 from .vuln_sync import (
-    get_action_set_actions,
     get_action_set_detail,
     get_action_set_issues,
     get_action_set_solutions,
@@ -150,7 +149,6 @@ __all__ = [
     "describe_policy_run_result",
     "device_search_typeahead",
     "execute_policy",
-    "get_action_set_actions",
     "get_action_set_detail",
     "get_action_set_issues",
     "get_action_set_solutions",

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -298,9 +298,12 @@ async def get_policy_run_detail_v2(
         org_id=org_id,
     )
 
-    # The device details endpoint extracts org from JWT, not query params.
+    # The policy-report-api requires the org UUID as a query param; the JWT
+    # is not used to resolve org context for this endpoint despite a sibling
+    # comment in earlier revisions. Without this param the API rejects the
+    # request with `Invalid or missing org from query parameters org=null`.
     # Filter params use snake_case names per the policy-report-api.
-    params: dict[str, Any] = {}
+    params: dict[str, Any] = {"org": resolved_uuid}
     if sort:
         params["sort"] = sort
     if result_status:

--- a/src/automox_mcp/workflows/policy_windows.py
+++ b/src/automox_mcp/workflows/policy_windows.py
@@ -4,8 +4,24 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import quote
 
 from ..client import AutomoxClient
+
+
+def _scheduled_windows_path(base_path: str, date: str | None) -> str:
+    """Append a date query param without percent-encoding the colons.
+
+    The Automox `/policy-windows/.../scheduled-windows` endpoint validates
+    the `date` query parameter as `YYYY-MM-DDTHH:mm:ss` and rejects the
+    request when colons are encoded as `%3A` (which httpx's default
+    params-encoder produces). We construct the query string manually and
+    keep `:` in the safe set so the literal value survives transport.
+    """
+    if date is None:
+        return base_path
+    encoded = quote(date.rstrip("Z"), safe=":")
+    return f"{base_path}?date={encoded}"
 
 
 def _summarize_window(window: Mapping[str, Any]) -> dict[str, Any]:
@@ -320,12 +336,10 @@ async def get_group_scheduled_windows(
     date: str | None = None,
 ) -> dict[str, Any]:
     """Get upcoming scheduled maintenance periods for a server group."""
-    path = f"/policy-windows/org/{org_uuid}/group/{group_uuid}/scheduled-windows"
-    params: dict[str, Any] = {}
-    if date is not None:
-        params["date"] = date.rstrip("Z")
+    base = f"/policy-windows/org/{org_uuid}/group/{group_uuid}/scheduled-windows"
+    path = _scheduled_windows_path(base, date)
 
-    result = await client.get(path, params=params or None)
+    result = await client.get(path)
 
     periods: list[dict[str, Any]] = []
     if isinstance(result, list):
@@ -368,12 +382,10 @@ async def get_device_scheduled_windows(
     date: str | None = None,
 ) -> dict[str, Any]:
     """Get upcoming scheduled maintenance periods for a specific device."""
-    path = f"/policy-windows/org/{org_uuid}/device/{device_uuid}/scheduled-windows"
-    params: dict[str, Any] = {}
-    if date is not None:
-        params["date"] = date.rstrip("Z")
+    base = f"/policy-windows/org/{org_uuid}/device/{device_uuid}/scheduled-windows"
+    path = _scheduled_windows_path(base, date)
 
-    result = await client.get(path, params=params or None)
+    result = await client.get(path)
 
     periods: list[dict[str, Any]] = []
     if isinstance(result, list):

--- a/src/automox_mcp/workflows/vuln_sync.py
+++ b/src/automox_mcp/workflows/vuln_sync.py
@@ -81,37 +81,6 @@ async def get_action_set_detail(
     }
 
 
-async def get_action_set_actions(
-    client: AutomoxClient,
-    *,
-    org_id: int,
-    action_set_id: int,
-    page: int | None = None,
-    limit: int | None = None,
-) -> dict[str, Any]:
-    """Get remediation actions for an action set."""
-    params: dict[str, Any] = {}
-    if page is not None:
-        params["page"] = page
-    if limit is not None:
-        params["limit"] = limit
-    response = await client.get(
-        f"/orgs/{org_id}/remediations/action-sets/{action_set_id}/actions",
-        params=params or None,
-    )
-
-    actions = _extract_list(response)
-
-    return {
-        "data": {
-            "action_set_id": action_set_id,
-            "total_actions": len(actions),
-            "actions": actions,
-        },
-        "metadata": {"deprecated_endpoint": False},
-    }
-
-
 async def get_action_set_issues(
     client: AutomoxClient,
     *,

--- a/tests/test_phase3_edge_cases.py
+++ b/tests/test_phase3_edge_cases.py
@@ -165,7 +165,9 @@ async def test_run_detail_v2_all_filters() -> None:
     params = client.calls[0][2]
     assert params["sort"] == "asc"
     assert params["device_name"] == "host-1"
-    assert "org" not in params  # org comes from JWT, not query params
+    # The policy-report-api requires the org UUID as a query param;
+    # without it the API rejects the request with `org=null`.
+    assert "org" in params
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_phase3_tool_errors.py
+++ b/tests/test_phase3_tool_errors.py
@@ -305,15 +305,6 @@ async def test_vs_detail_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_vs_actions_success() -> None:
-    client = FakeClient()
-    client._get_response = [{"id": 101}]
-    server = _register(vuln_sync_tools, client)
-    result = await server.tools["get_action_set_actions"](action_set_id=1)
-    assert result["data"]["total_actions"] == 1
-
-
-@pytest.mark.asyncio
 async def test_vs_issues_success() -> None:
     client = FakeClient()
     client._get_response = [{"cve_id": "CVE-1"}]

--- a/tests/test_workflows_policy_history.py
+++ b/tests/test_workflows_policy_history.py
@@ -266,4 +266,6 @@ async def test_run_detail_passes_filters() -> None:
     assert params["result_status"] == "failure"
     assert params["device_name"] == "host-1"
     assert params["limit"] == 5
-    assert "org" not in params  # org comes from JWT, not query params
+    # The policy-report-api requires the org UUID as a query param;
+    # without it the API rejects the request with `org=null`.
+    assert params["org"] == _ORG_UUID

--- a/tests/test_workflows_policy_windows.py
+++ b/tests/test_workflows_policy_windows.py
@@ -379,9 +379,12 @@ async def test_get_group_scheduled_windows_with_date() -> None:
         date="2026-04-30T00:00:00Z",
     )
 
-    # Date is passed via params dict (properly URL-encoded by httpx)
-    assert client.calls[0][1].endswith("/scheduled-windows")
-    assert client.calls[0][2] == {"date": "2026-04-30T00:00:00"}
+    # Date is appended directly to the URL with literal colons; the API
+    # rejects `%3A`-encoded colons that httpx's params encoder would emit.
+    sent_path = client.calls[0][1]
+    assert sent_path.endswith("/scheduled-windows?date=2026-04-30T00:00:00")
+    assert "%3A" not in sent_path
+    assert client.calls[0][2] is None
 
 
 # ---------------------------------------------------------------------------
@@ -423,9 +426,12 @@ async def test_get_device_scheduled_windows_with_date() -> None:
         date="2026-04-30T00:00:00Z",
     )
 
-    # Date is passed via params dict (properly URL-encoded by httpx)
-    assert client.calls[0][1].endswith("/scheduled-windows")
-    assert client.calls[0][2] == {"date": "2026-04-30T00:00:00"}
+    # Date is appended directly to the URL with literal colons; the API
+    # rejects `%3A`-encoded colons that httpx's params encoder would emit.
+    sent_path = client.calls[0][1]
+    assert sent_path.endswith("/scheduled-windows?date=2026-04-30T00:00:00")
+    assert "%3A" not in sent_path
+    assert client.calls[0][2] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows_policy_windows_extended.py
+++ b/tests/test_workflows_policy_windows_extended.py
@@ -250,4 +250,48 @@ async def test_device_scheduled_windows_no_date_param() -> None:
         org_uuid=_ORG_UUID,
         device_uuid=_DEVICE_UUID,
     )
+    assert client.calls[0][1].endswith("/scheduled-windows")
     assert client.calls[0][2] is None
+
+
+@pytest.mark.asyncio
+async def test_group_scheduled_windows_date_keeps_literal_colons() -> None:
+    """The date param must reach the API with literal colons.
+
+    The Automox `/scheduled-windows` endpoint validates the date as
+    `YYYY-MM-DDTHH:mm:ss` and rejects requests where colons have been
+    percent-encoded as `%3A`.
+    """
+    client = StubClient(
+        get_responses={
+            f"/policy-windows/org/{_ORG_UUID}/group/{_GROUP_UUID}/scheduled-windows": [[]],
+        }
+    )
+    await get_group_scheduled_windows(
+        cast(AutomoxClient, client),
+        org_uuid=_ORG_UUID,
+        group_uuid=_GROUP_UUID,
+        date="2026-12-31T00:00:00",
+    )
+    sent_path = client.calls[0][1]
+    assert sent_path.endswith("?date=2026-12-31T00:00:00")
+    assert "%3A" not in sent_path
+    assert client.calls[0][2] is None
+
+
+@pytest.mark.asyncio
+async def test_device_scheduled_windows_date_strips_trailing_z() -> None:
+    """A trailing `Z` is stripped before encoding (the API expects no zone)."""
+    client = StubClient(
+        get_responses={
+            f"/policy-windows/org/{_ORG_UUID}/device/{_DEVICE_UUID}/scheduled-windows": [[]],
+        }
+    )
+    await get_device_scheduled_windows(
+        cast(AutomoxClient, client),
+        org_uuid=_ORG_UUID,
+        device_uuid=_DEVICE_UUID,
+        date="2026-12-31T00:00:00Z",
+    )
+    sent_path = client.calls[0][1]
+    assert sent_path.endswith("?date=2026-12-31T00:00:00")

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -7,7 +7,6 @@ from conftest import StubClient
 
 from automox_mcp.client import AutomoxClient
 from automox_mcp.workflows.vuln_sync import (
-    get_action_set_actions,
     get_action_set_detail,
     get_action_set_issues,
     get_action_set_solutions,
@@ -43,11 +42,6 @@ _ACTION_SET_DETAIL = {
     "issue_count": 50,
     "action_count": 30,
 }
-
-_ACTIONS = [
-    {"id": 101, "type": "patch", "package_name": "openssl", "severity": "critical"},
-    {"id": 102, "type": "patch", "package_name": "curl", "severity": "high"},
-]
 
 _ISSUES = [
     {"id": 201, "cve_id": "CVE-2026-0001", "severity": "critical", "title": "OpenSSL vuln"},
@@ -101,23 +95,6 @@ async def test_detail_returns_info() -> None:
     )
     assert result["data"]["id"] == 1
     assert result["data"]["action_count"] == 30
-
-
-# ---------------------------------------------------------------------------
-# get_action_set_actions
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_actions_returns_list() -> None:
-    client = StubClient(get_responses={"/orgs/42/remediations/action-sets/1/actions": [_ACTIONS]})
-    result = await get_action_set_actions(
-        cast(AutomoxClient, client),
-        org_id=42,
-        action_set_id=1,
-    )
-    assert result["data"]["total_actions"] == 2
-    assert result["data"]["action_set_id"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.19"
+version = "1.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

P0 bug-cluster from the v1.0.20 Claude Desktop test session ([#43](https://github.com/AutomoxCommunity/automox-mcp/issues/43)). Each tool here returned `4xx` on every call — these never worked.

- **`policy_run_detail_v2`** — now forwards the org UUID as a query param. Policy-report-api was rejecting every call with `Invalid or missing org from query parameters org=null`. Stale code comment claimed the endpoint extracted org from the JWT; live API behavior says otherwise.
- **`get_group_scheduled_windows` / `get_device_scheduled_windows`** — date param now reaches the API with literal colons. `httpx`'s default params encoder was emitting `%3A`, which the `/policy-windows/.../scheduled-windows` endpoint rejected with `400 Invalid date-time format`. Fix: append the date directly to the URL via `urllib.parse.quote(value, safe=":")`.
- **`get_action_set_actions` removed.** The endpoint at `/orgs/{org_id}/remediations/action-sets/{id}/actions` is `POST`-only (it creates actions; `OPTIONS` returns `Allow: POST`). There is no read endpoint for actions in the public API. Tool count: 80 → 79; read-only count: 58 → 57. Use `get_action_set_issues` and `get_action_set_solutions` for the related read data.

## Verification

All three bugs reproduced against the live tenant via the harness in #42 (the verification script that flagged them in the first place). Post-fix live-tenant probe:

- `policy_run_detail_v2` → 25 results (was `400 org=null`)
- `get_group_scheduled_windows` → 200 with literal-colon date (was `400 Invalid date-time format`)

`get_action_set_actions` doesn't get a live verification because the tool is gone.

## What's next

Two follow-up release branches per #43's plan:

- **v1.0.22** — silent-wrong-answer cluster: #5 (`devices_needing_attention`), #7 (`policy_run_results` filter), #8 (audit cursor advance), #9 (`policy_health_overview` sample)
- **v1.0.23** — contract normalization: #6 (Spring wrapper leak), #14 (truncation honesty), #4a/4b (detail no-ops), #13 (pagination shape)

## Test plan

- [x] `uv run pytest tests/` — 1050 passed (existing tests updated to reflect new contracts: `org` is now expected in `policy_run_detail_v2` params; `date` is now appended to the URL not in params)
- [x] Live-tenant verification of #3 and the date-encoding fix
- [ ] Reviewer eyeballs the `_scheduled_windows_path` helper — it builds a query string manually, which is unusual; I went this route because httpx percent-encodes `:` even when given pre-encoded input through the `params=` API
- [ ] After merge: tag-push `v1.0.21` to trigger the PyPI / MCP Registry / MCPB publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)