### PR TITLE
Release v1.0.22: silent-wrong-answer cluster (#5, #7, #8, #9 from #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2026-05-07
+
+### Fixed
+
+- **`devices_needing_attention` returned all-null diagnostic fields (#43)** — The wrapper looked for snake_case fields (`device_id`, `server_group_id`, `last_check_in`, `policy_status`, `pending_updates`) that the `/reports/needs-attention` endpoint does not return. The endpoint emits camelCase Automox console fields (`id`, `groupId`, `lastRefreshTime`, `compliant`, `policies`), so every device came back with `policy_status=null`, `pending_patches=null`, `last_check_in=null`, `server_group_id=null`. Field mapping corrected. The bogus `pending_patches` field (no per-device patch count exists in this endpoint) was replaced with `failing_policies_count` and a compact `failing_policies` summary derived from the `policies` list. Added `needs_reboot`, `os_family`, `connected` for context. The legacy snake_case fallback path is retained for backwards-compatibility with hypothetical future API shapes.
+
+- **`policy_run_results` ignored `result_status` filter (#43)** — The Automox `/policy-history/policies/{policy_uuid}/{exec_token}` endpoint silently ignores the `result_status` query parameter (verified live: `result_status`, `resultStatus`, and `status` all return the unfiltered set). The wrapper was forwarding it and trusting the upstream filter. Now the filter is applied **client-side** after the page is fetched, and the metadata block surfaces this with `result_status_filter.applied = "client_side"`, pre/post counts, and a note explaining that `pagination` counts reflect the unfiltered upstream response. Pagination across pages still works; the caller just sees fewer results per page when the filter excludes most of them.
+
+- **`audit_trail_user_activity` cursor advance was ambiguous when filter excluded the page (#43)** — When an actor filter was applied and the page returned 0 matches but `next_cursor` was set, callers had no way to distinguish "actor was inactive" from "actor's events live on later pages of the org-wide stream." The org-wide audit endpoint does not filter by actor — the wrapper does it client-side after fetching — so a cursor with 0 returned events meant "keep paginating," not "stop." Callers stopped, silently missing later events. The metadata now surfaces `filter_pagination_state` with `no_matches_in_page`, `more_pages_available`, `events_in_unfiltered_page`, and an explicit `advice` string when this state arises. The data shape is unchanged; the new key is additive.
+
+- **`policy_health_overview` sample size mismatch was not surfaced (#43)** — `total_policy_runs` (from `/policy-history/policy-run-count?days=N`) honors the requested window, but `/policy-history/policy-runs` is server-capped at the most recent ~100 events (≈last 24h) regardless of `limit`, `days`, or `start_time`/`end_time` parameters. So `total_runs_considered < total_policy_runs` is the *normal* state for active orgs, not a math error. The wrapper now sets `data.sample_is_truncated`, mirrors it in `metadata.sample_is_truncated`, and includes a `metadata.sample_note` explaining the cap when truncation is detected. The numerical fields are unchanged.
+
 ## [1.0.21] - 2026-05-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.21"
+version = "1.0.22"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/workflows/audit.py
+++ b/src/automox_mcp/workflows/audit.py
@@ -786,7 +786,9 @@ async def audit_trail_user_activity(
     if resolved_actor:
         data["resolved_actor"] = resolved_actor
 
-    metadata = {
+    filter_applied = bool(normalized_email_filter or normalized_uuid_filter or actor_name_text)
+
+    metadata: dict[str, Any] = {
         "org_id": org_id,
         "org_uuid": resolved_org_uuid,
         "date": query_date,
@@ -798,6 +800,30 @@ async def audit_trail_user_activity(
         "events_returned": len(filtered_events),
         "applied_filters": applied_filters,
     }
+    # When an actor filter is applied, the upstream audit API returns
+    # org-wide events and we filter them client-side. If this page had
+    # zero matches but more pages exist (next_cursor set), the caller
+    # MUST keep paginating to find any actor activity later in the day.
+    # Earlier revisions left this ambiguous: callers seeing
+    # `events_returned=0` would assume "no activity" and stop, silently
+    # missing events on later pages. Surface the state explicitly so it
+    # cannot be confused with "no activity for this actor".
+    if filter_applied and len(filtered_events) == 0 and next_cursor:
+        metadata["filter_pagination_state"] = {
+            "no_matches_in_page": True,
+            "more_pages_available": True,
+            "events_in_unfiltered_page": (
+                api_result_count if isinstance(api_result_count, int) else len(events)
+            ),
+            "advice": (
+                "The actor filter is applied client-side because the audit "
+                "endpoint does not filter by actor. This page returned no "
+                "matching events but more pages exist; pass `cursor=next_cursor` "
+                "and re-query until both `events_returned=0` AND "
+                "`next_cursor=null`. A non-null `next_cursor` with "
+                "`events_returned=0` does NOT mean the actor was inactive."
+            ),
+        }
     if api_next_link:
         metadata["api_next_link"] = api_next_link
     if lookup_metadata:

--- a/src/automox_mcp/workflows/devices.py
+++ b/src/automox_mcp/workflows/devices.py
@@ -423,18 +423,56 @@ async def list_devices_needing_attention(
     elif isinstance(report, Sequence):
         devices = [item for item in report if isinstance(item, Mapping)]
 
+    # Field-name mapping for /reports/needs-attention. The endpoint returns
+    # camelCase Automox console fields (`id`, `groupId`, `lastRefreshTime`,
+    # `compliant`, `policies`); earlier revisions of this wrapper looked for
+    # snake_case fields that the endpoint does not produce, so every
+    # diagnostic field came back null.
     curated_devices = []
     for item in devices:
+        compliant = item.get("compliant")
+        if compliant is False:
+            policy_status: Any = "non_compliant"
+        elif compliant is True:
+            policy_status = "compliant"
+        else:
+            # Defensive fallback for older snake_case payloads or future
+            # additions to the report shape.
+            policy_status = item.get("policy_status") or item.get("status")
+
+        policies = item.get("policies")
+        failing_policies: list[dict[str, Any]] = []
+        if isinstance(policies, Sequence) and not isinstance(policies, (str, bytes, bytearray)):
+            for pol in policies[:5]:
+                if not isinstance(pol, Mapping):
+                    continue
+                failing_policies.append(
+                    {
+                        "policy_id": pol.get("id"),
+                        "policy_name": pol.get("name"),
+                        "policy_type": pol.get("type"),
+                    }
+                )
+        failing_policies_count = (
+            len(policies)
+            if isinstance(policies, Sequence) and not isinstance(policies, (str, bytes, bytearray))
+            else None
+        )
+
         curated_devices.append(
             {
                 "device_id": item.get("device_id") or item.get("id"),
                 "device_name": _format_device_display_name(item),
-                "policy_status": item.get("policy_status") or item.get("status"),
-                "pending_patches": item.get("pending_updates")
-                if item.get("pending_updates") is not None
-                else item.get("pending"),
-                "last_check_in": item.get("last_check_in") or item.get("last_seen"),
-                "server_group_id": item.get("server_group_id"),
+                "policy_status": policy_status,
+                "failing_policies_count": failing_policies_count,
+                "failing_policies": failing_policies or None,
+                "last_check_in": item.get("lastRefreshTime")
+                or item.get("last_check_in")
+                or item.get("last_seen"),
+                "server_group_id": item.get("groupId") or item.get("server_group_id"),
+                "needs_reboot": item.get("needsReboot"),
+                "os_family": item.get("os_family"),
+                "connected": item.get("connected"),
             }
         )
 

--- a/src/automox_mcp/workflows/policy.py
+++ b/src/automox_mcp/workflows/policy.py
@@ -120,25 +120,47 @@ async def summarize_policy_activity(
         reverse=True,
     )[:top_failures]
 
-    # PolicyRunCount returns {"policy_runs": N} directly
+    # PolicyRunCount returns {"policy_runs": N} directly. This counts ALL
+    # runs in the last `window_days` days. The /policy-runs endpoint we
+    # used above is server-capped at roughly the most-recent 100 events
+    # (or last ~24 hours), regardless of `limit`, `days`, or
+    # `start_time`/`end_time` parameters. So `total_policy_runs` and
+    # `total_runs_considered` measure different things and may legitimately
+    # disagree when the org runs more than ~100 policy runs per day.
     total_policy_runs = None
     if isinstance(run_counts, Mapping):
         total_policy_runs = run_counts.get("policy_runs")
 
+    runs_considered = len(runs)
+    sample_is_truncated = isinstance(total_policy_runs, int) and total_policy_runs > runs_considered
+
     overview = {
         "window_days": window_days,
         "total_policy_runs": total_policy_runs,
-        "total_runs_considered": len(runs),
+        "total_runs_considered": runs_considered,
+        "sample_is_truncated": sample_is_truncated,
         "status_breakdown": dict(status_counter),
         "top_failing_policies": top_failures_list,
     }
 
-    metadata = {
+    metadata: dict[str, Any] = {
         "deprecated_endpoint": False,
         "org_uuid": str(org_uuid),
         "window_days": window_days,
-        "total_runs_considered": len(runs),
+        "total_runs_considered": runs_considered,
+        "sample_is_truncated": sample_is_truncated,
     }
+    if sample_is_truncated:
+        metadata["sample_note"] = (
+            f"Org had {total_policy_runs} policy runs over the {window_days}-day "
+            f"window, but the /policy-history/policy-runs endpoint is server-capped "
+            f"at the most recent {runs_considered} events (≈last 24 hours) "
+            f"regardless of limit/days/start_time params. The status_breakdown "
+            f"and top_failing_policies in this response reflect that recent "
+            f"sample only — they are NOT a window-wide aggregate. Use "
+            f"policy_runs_for_policy with a specific policy_uuid to get full "
+            f"per-policy history within the window."
+        )
 
     return {
         "data": overview,
@@ -626,8 +648,11 @@ async def describe_policy_run_result(
     params: dict[str, Any] = {"org": str(org_uuid)}
     if sort:
         params["sort"] = sort
-    if result_status:
-        params["result_status"] = result_status
+    # NOTE: result_status is intentionally NOT forwarded to the API. The
+    # /policy-history/policies/{uuid}/{token} endpoint silently ignores
+    # this filter regardless of name (`result_status`, `resultStatus`,
+    # `status` all return the unfiltered set), so we apply the filter
+    # client-side below to honor the documented contract.
     if device_name:
         params["device_name"] = device_name
     if page is not None:
@@ -652,6 +677,9 @@ async def describe_policy_run_result(
     elif isinstance(payload, Sequence):
         devices_raw = payload  # type: ignore[assignment]
 
+    requested_status = _normalize_status(result_status) if result_status else None
+    pre_filter_total = sum(1 for entry in devices_raw if isinstance(entry, Mapping))
+
     status_counter: Counter[str] = Counter()
     device_results: list[dict[str, Any]] = []
 
@@ -659,6 +687,8 @@ async def describe_policy_run_result(
         if not isinstance(entry, Mapping):
             continue
         status = _normalize_status(entry.get("result_status"))
+        if requested_status is not None and status != requested_status:
+            continue
         status_counter[status] += 1
         device_results.append(
             {
@@ -681,7 +711,7 @@ async def describe_policy_run_result(
             }
         )
 
-    data = {
+    data: dict[str, Any] = {
         "policy_uuid": str(policy_uuid),
         "exec_token": str(exec_token),
         "result_summary": {
@@ -692,7 +722,7 @@ async def describe_policy_run_result(
         "pagination": pagination_meta,
     }
 
-    metadata = {
+    metadata: dict[str, Any] = {
         "deprecated_endpoint": False,
         "org_uuid": str(org_uuid),
         "policy_uuid": str(policy_uuid),
@@ -703,6 +733,20 @@ async def describe_policy_run_result(
         "limit": pagination_meta.get("limit") if pagination_meta else limit,
         "total_count": pagination_meta.get("total_count") if pagination_meta else None,
     }
+
+    if requested_status is not None:
+        metadata["result_status_filter"] = {
+            "applied": "client_side",
+            "requested_status": requested_status,
+            "pre_filter_count": pre_filter_total,
+            "post_filter_count": len(device_results),
+            "note": (
+                "Upstream policy-history API ignores the result_status query "
+                "parameter and returns mixed statuses; this wrapper filters "
+                "the page client-side. Pagination counts in `pagination` "
+                "reflect the unfiltered upstream response."
+            ),
+        }
 
     return {
         "data": data,

--- a/tests/test_workflows_audit.py
+++ b/tests/test_workflows_audit.py
@@ -119,6 +119,119 @@ async def test_audit_trail_filters_actor_and_resolves_org_uuid() -> None:
 
 
 @pytest.mark.asyncio
+async def test_audit_trail_filter_no_match_in_page_metadata() -> None:
+    """When an actor filter is applied and the page returns 0 matches but
+    `next_cursor` is set, metadata must explicitly flag the state.
+
+    Without this flag (bug #8 from issue #43), callers see
+    `events_returned=0` and stop, missing actor activity that lives on
+    later pages of the org-wide event stream.
+    """
+    org_uuid = "00000000-0000-0000-0000-000000000888"
+    audit_path = f"/audit-service/v1/orgs/{org_uuid}/events"
+    responses = {
+        (audit_path, "console"): [
+            {
+                "metadata": {"count": 5, "next": "https://example.test/next?cursor=cursor-5"},
+                "data": [
+                    {
+                        "activity": "User Login",
+                        "message": "User logged in",
+                        "time": 1718213009419,
+                        "metadata": {"uid": "cursor-x"},
+                        "actor": {
+                            "user": {
+                                "user": {
+                                    "email_addr": "someone-else@example.com",
+                                    "uid": "99999999-9999-9999-9999-999999999999",
+                                }
+                            }
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+    client = StubClient(responses, org_id=888, org_uuid=org_uuid)
+
+    result = await audit_trail_user_activity(
+        cast(AutomoxClient, client),
+        org_id=888,
+        date=date(2026, 4, 29),
+        actor_email="alice@example.com",
+        limit=5,
+    )
+
+    assert result["data"]["events_returned"] == 0
+    metadata = result["metadata"]
+    assert metadata["next_cursor"] == "cursor-x"
+    flag = metadata["filter_pagination_state"]
+    assert flag["no_matches_in_page"] is True
+    assert flag["more_pages_available"] is True
+    assert flag["events_in_unfiltered_page"] == 5
+    assert "advice" in flag
+
+
+@pytest.mark.asyncio
+async def test_audit_trail_no_filter_pagination_flag_when_match() -> None:
+    """The filter_pagination_state flag must NOT appear when matches were
+    found, even if next_cursor is set."""
+    org_uuid = "00000000-0000-0000-0000-000000000777"
+    audit_path = f"/audit-service/v1/orgs/{org_uuid}/events"
+    responses = {
+        (audit_path, "console"): [
+            {
+                "metadata": {"count": 2, "next": "https://example.test/next?cursor=cursor-2"},
+                "data": [
+                    {
+                        "activity": "User Login",
+                        "message": "User logged in",
+                        "time": 1718213009419,
+                        "metadata": {"uid": "cursor-1"},
+                        "actor": {
+                            "user": {
+                                "user": {
+                                    "email_addr": "alice@example.com",
+                                    "uid": "11111111-1111-1111-1111-111111111111",
+                                }
+                            }
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+    client = StubClient(responses, org_id=777, org_uuid=org_uuid)
+    result = await audit_trail_user_activity(
+        cast(AutomoxClient, client),
+        org_id=777,
+        date=date(2026, 4, 29),
+        actor_email="alice@example.com",
+    )
+    assert result["data"]["events_returned"] == 1
+    assert "filter_pagination_state" not in result["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_audit_trail_no_filter_pagination_flag_when_no_filter() -> None:
+    """No filter applied + 0 events returned + next_cursor set → no flag.
+    The ambiguity only arises when a filter is being applied."""
+    org_uuid = "00000000-0000-0000-0000-000000000666"
+    audit_path = f"/audit-service/v1/orgs/{org_uuid}/events"
+    responses = {
+        (audit_path, "console"): [{"metadata": {"count": 0, "next": None}, "data": []}],
+    }
+    client = StubClient(responses, org_id=666, org_uuid=org_uuid)
+    result = await audit_trail_user_activity(
+        cast(AutomoxClient, client),
+        org_id=666,
+        date=date(2026, 4, 29),
+        actor_email=None,
+    )
+    assert "filter_pagination_state" not in result["metadata"]
+
+
+@pytest.mark.asyncio
 async def test_audit_trail_includes_sanitized_raw_event() -> None:
     org_uuid = "00000000-0000-0000-0000-000000000999"
     long_message = "A" * 900

--- a/tests/test_workflows_devices_extended.py
+++ b/tests/test_workflows_devices_extended.py
@@ -1277,18 +1277,34 @@ async def test_summarize_device_health_large_response_sets_truncation_flag() -> 
 
 
 @pytest.mark.asyncio
-async def test_list_devices_needing_attention_basic() -> None:
+async def test_list_devices_needing_attention_basic_camelcase() -> None:
+    """The /reports/needs-attention endpoint returns camelCase fields.
+
+    `groupId`, `lastRefreshTime`, `compliant`, `policies` need to be
+    mapped to the wrapper's snake_case output. Earlier revisions looked
+    for `server_group_id`/`last_check_in`/`policy_status`/`pending_updates`
+    that the API never returns, so every diagnostic field was null.
+    """
     report = {
-        "data": [
-            {
-                "id": 10,
-                "name": "trouble-host",
-                "policy_status": "failed",
-                "pending_updates": 3,
-                "last_check_in": "2024-05-10T12:00:00Z",
-                "server_group_id": 99,
-            }
-        ]
+        "nonCompliant": {
+            "total": 1,
+            "devices": [
+                {
+                    "id": 10,
+                    "name": "trouble-host",
+                    "compliant": False,
+                    "groupId": 99,
+                    "lastRefreshTime": "2026-05-07T12:00:00+0000",
+                    "needsReboot": True,
+                    "os_family": "Mac",
+                    "connected": True,
+                    "policies": [
+                        {"id": 1, "name": "Patch All", "type": "patch"},
+                        {"id": 2, "name": "Reboot Nightly", "type": "custom"},
+                    ],
+                }
+            ],
+        }
     }
     client = StubClient(get_responses={"/reports/needs-attention": [report]})
     result = await list_devices_needing_attention(cast(AutomoxClient, client), org_id=42)
@@ -1298,9 +1314,39 @@ async def test_list_devices_needing_attention_basic() -> None:
     device = data["devices"][0]
     assert device["device_id"] == 10
     assert device["device_name"] == "trouble-host"
-    assert device["policy_status"] == "failed"
-    assert device["pending_patches"] == 3
+    assert device["policy_status"] == "non_compliant"
     assert device["server_group_id"] == 99
+    assert device["last_check_in"] == "2026-05-07T12:00:00+0000"
+    assert device["needs_reboot"] is True
+    assert device["os_family"] == "Mac"
+    assert device["connected"] is True
+    assert device["failing_policies_count"] == 2
+    assert device["failing_policies"][0]["policy_name"] == "Patch All"
+
+
+@pytest.mark.asyncio
+async def test_list_devices_needing_attention_legacy_snakecase() -> None:
+    """Defensive fallback: tolerate snake_case payloads if the API ever
+    starts emitting them. Pre-fix tests exercised this shape directly."""
+    report = {
+        "data": [
+            {
+                "id": 10,
+                "name": "trouble-host",
+                "policy_status": "failed",
+                "last_check_in": "2024-05-10T12:00:00Z",
+                "server_group_id": 99,
+            }
+        ]
+    }
+    client = StubClient(get_responses={"/reports/needs-attention": [report]})
+    result = await list_devices_needing_attention(cast(AutomoxClient, client), org_id=42)
+
+    device = result["data"]["devices"][0]
+    assert device["device_id"] == 10
+    assert device["policy_status"] == "failed"
+    assert device["server_group_id"] == 99
+    assert device["last_check_in"] == "2024-05-10T12:00:00Z"
 
 
 @pytest.mark.asyncio
@@ -1346,7 +1392,12 @@ async def test_list_devices_needing_attention_metadata() -> None:
 
 @pytest.mark.asyncio
 async def test_list_devices_needing_attention_with_group_id() -> None:
-    report = {"data": [{"id": 5, "name": "host", "server_group_id": 77}]}
+    report = {
+        "nonCompliant": {
+            "total": 1,
+            "devices": [{"id": 5, "name": "host", "compliant": False, "groupId": 77}],
+        }
+    }
     client = StubClient(get_responses={"/reports/needs-attention": [report]})
     result = await list_devices_needing_attention(
         cast(AutomoxClient, client), org_id=42, group_id=77
@@ -1354,6 +1405,7 @@ async def test_list_devices_needing_attention_with_group_id() -> None:
 
     assert result["data"]["group_id"] == 77
     assert result["metadata"]["group_id"] == 77
+    assert result["data"]["devices"][0]["server_group_id"] == 77
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflows_policy.py
+++ b/tests/test_workflows_policy.py
@@ -396,6 +396,75 @@ async def test_describe_policy_run_result_summarizes_and_normalizes() -> None:
     assert params["page"] == 0
 
 
+@pytest.mark.asyncio
+async def test_describe_policy_run_result_filters_status_client_side() -> None:
+    """The /policy-history endpoint silently ignores `result_status`; the
+    wrapper filters client-side and surfaces that fact in metadata.
+
+    Verified live during v1.0.20 triage: passing `result_status=failed`
+    returned the unfiltered set with mixed `failed`/`not_included` entries.
+    See bug #7 in issue #43.
+    """
+    org_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    policy_uuid = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    exec_token = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    api_path = f"/policy-history/policies/{policy_uuid}/{exec_token}"
+    response_payload = {
+        "metadata": {"current_page": 0, "total_pages": 1, "total_count": 3, "limit": 25},
+        "data": [
+            {"device_id": 1, "result_status": "FAILED"},
+            {"device_id": 2, "result_status": "not_included"},
+            {"device_id": 3, "result_status": "SUCCESS"},
+        ],
+    }
+
+    client = StubClient(get_responses={api_path: [response_payload]})
+    result = await describe_policy_run_result(
+        cast(AutomoxClient, client),
+        org_uuid=org_uuid,
+        policy_uuid=policy_uuid,
+        exec_token=exec_token,
+        result_status="failed",
+    )
+
+    devices = result["data"]["devices"]
+    assert [d["device_id"] for d in devices] == [1]
+    assert all(d["result_status"] == "failed" for d in devices)
+
+    # The filter must NOT be sent upstream — the API ignores it anyway,
+    # and forwarding it would imply server-side filtering that doesn't
+    # happen.
+    _, _, params, _ = client.calls[0]
+    assert params is not None
+    assert "result_status" not in params
+
+    filter_meta = result["metadata"]["result_status_filter"]
+    assert filter_meta["applied"] == "client_side"
+    assert filter_meta["requested_status"] == "failed"
+    assert filter_meta["pre_filter_count"] == 3
+    assert filter_meta["post_filter_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_describe_policy_run_result_no_filter_metadata_when_unset() -> None:
+    """When no `result_status` is requested, metadata should not include
+    the client-side filter block."""
+    org_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    policy_uuid = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    exec_token = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    api_path = f"/policy-history/policies/{policy_uuid}/{exec_token}"
+    client = StubClient(
+        get_responses={api_path: [{"data": [{"device_id": 1, "result_status": "SUCCESS"}]}]}
+    )
+    result = await describe_policy_run_result(
+        cast(AutomoxClient, client),
+        org_uuid=org_uuid,
+        policy_uuid=policy_uuid,
+        exec_token=exec_token,
+    )
+    assert "result_status_filter" not in result["metadata"]
+
+
 # ---------------------------------------------------------------------------
 # _normalize_status
 # ---------------------------------------------------------------------------
@@ -532,6 +601,62 @@ async def test_summarize_policy_activity_runs_as_list() -> None:
     # The run has no failed/success → classified as unknown
     assert result["data"]["status_breakdown"].get("unknown", 0) >= 1
     assert result["data"]["total_policy_runs"] == 10
+
+
+@pytest.mark.asyncio
+async def test_summarize_policy_activity_flags_sample_truncation() -> None:
+    """When the org has more runs in the window than /policy-runs can
+    return (server-capped at ~100), surface the truncation explicitly.
+
+    Bug #9 from issue #43: callers were comparing `total_policy_runs`
+    (window-wide count) to `total_runs_considered` (capped sample) and
+    treating the discrepancy as a math error.
+    """
+    org_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    runs_list = [
+        {"policy_uuid": "p1", "policy_name": "P1", "failed": 1, "success": 0, "device_count": 1},
+    ]
+    client = FlexibleStubClient(
+        get_responses={
+            "/policy-history/policy-run-count": [{"policy_runs": 720}],
+            "/policy-history/policy-runs": [runs_list],
+        },
+    )
+
+    result = await summarize_policy_activity(
+        cast(AutomoxClient, client),
+        org_uuid=org_uuid,
+        window_days=7,
+    )
+
+    assert result["data"]["total_policy_runs"] == 720
+    assert result["data"]["total_runs_considered"] == 1
+    assert result["data"]["sample_is_truncated"] is True
+    assert result["metadata"]["sample_is_truncated"] is True
+    assert "sample_note" in result["metadata"]
+    assert "720" in result["metadata"]["sample_note"]
+
+
+@pytest.mark.asyncio
+async def test_summarize_policy_activity_no_truncation_flag_when_full_sample() -> None:
+    """When all window runs fit in the sample, the truncation flag is False."""
+    org_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    runs_list = [
+        {"policy_uuid": "p1", "policy_name": "P1", "failed": 0, "success": 1, "device_count": 1},
+        {"policy_uuid": "p2", "policy_name": "P2", "failed": 0, "success": 1, "device_count": 1},
+    ]
+    client = FlexibleStubClient(
+        get_responses={
+            "/policy-history/policy-run-count": [{"policy_runs": 2}],
+            "/policy-history/policy-runs": [runs_list],
+        },
+    )
+    result = await summarize_policy_activity(
+        cast(AutomoxClient, client),
+        org_uuid=org_uuid,
+    )
+    assert result["data"]["sample_is_truncated"] is False
+    assert "sample_note" not in result["metadata"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/verify_reported_bugs.py
+++ b/tests/verify_reported_bugs.py
@@ -343,7 +343,11 @@ async def case_8_audit_actor_cursor(session: ClientSession) -> str:
         else data.get("events_returned")
     )
     events_seen = metadata.get("events_seen") or data.get("events_seen")
-    if next_cursor and events_returned == 0:
+    # v1.0.22 fix surfaces this state explicitly via
+    # metadata.filter_pagination_state. If that flag is present, the
+    # state is no longer ambiguous — caller has explicit guidance.
+    filter_state = metadata.get("filter_pagination_state")
+    if next_cursor and events_returned == 0 and not filter_state:
         status(
             "VERIFIED",
             (
@@ -353,6 +357,16 @@ async def case_8_audit_actor_cursor(session: ClientSession) -> str:
             RED,
         )
         return "VERIFIED"
+    if filter_state:
+        status(
+            "NOT_REPRODUCED",
+            (
+                f"state explicitly flagged: filter_pagination_state="
+                f"{filter_state.get('no_matches_in_page')}, advice present"
+            ),
+            GREEN,
+        )
+        return "NOT_REPRODUCED"
     status(
         "NOT_REPRODUCED",
         f"cursor={next_cursor!r}, events_returned={events_returned}, events_seen={events_seen}",
@@ -368,11 +382,27 @@ async def case_9_policy_health_sample(session: ClientSession) -> str:
         status("AMBIGUOUS", f"unexpected shape — {raw[:200]}", YELLOW)
         return "AMBIGUOUS"
     data = parsed.get("data") or parsed
+    metadata = parsed.get("metadata") or {}
     total = data.get("total_policy_runs")
     considered = data.get("total_runs_considered")
     max_runs = data.get("max_runs")
+    # v1.0.22 fix surfaces the discrepancy explicitly via
+    # data.sample_is_truncated and metadata.sample_note. The numerical
+    # mismatch is caused by an Automox API server-side cap (~100 events)
+    # that no client param can override; the wrapper now flags it.
+    sample_truncated = data.get("sample_is_truncated") or metadata.get("sample_is_truncated")
     if total is not None and considered is not None and considered < total:
         if max_runs is None or considered < max_runs:
+            if sample_truncated:
+                status(
+                    "NOT_REPRODUCED",
+                    (
+                        f"discrepancy explicitly flagged via sample_is_truncated="
+                        f"{sample_truncated}; sample_note present in metadata"
+                    ),
+                    GREEN,
+                )
+                return "NOT_REPRODUCED"
             status(
                 "VERIFIED",
                 f"considered={considered} < min(total={total}, max_runs={max_runs})",

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.21"
+version = "1.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Four bugs whose common shape is "tool looks successful but returns wrong/incomplete data." Each was verified against the live tenant via `tests/verify_reported_bugs.py` before any fix; all four are NOT_REPRODUCED on the harness after this change.

- **#5 `devices_needing_attention`** — `/reports/needs-attention` emits camelCase (`id`, `groupId`, `lastRefreshTime`, `compliant`, `policies`). The wrapper looked for snake_case names that the endpoint does not produce, so every diagnostic field returned `null`. Field mapping corrected. The fictional `pending_patches` field replaced with `failing_policies_count` + a compact `failing_policies` summary. Added `needs_reboot`, `os_family`, `connected` for context.
- **#7 `policy_run_results` `result_status` filter** — Verified live: the upstream `/policy-history/policies/{uuid}/{token}` endpoint silently ignores the filter no matter what we name it (`result_status`, `resultStatus`, `status`, `failed`/`failure`). Filter now applied **client-side**, with `metadata.result_status_filter` surfacing pre/post counts and a note that `pagination` reflects the unfiltered upstream response. The param is no longer forwarded upstream.
- **#8 `audit_trail_user_activity` cursor advance** — The audit endpoint does not filter by actor; the wrapper does it client-side. When a page returns 0 actor-matched events but `next_cursor` points to more org-wide events, callers couldn't distinguish "actor inactive" from "actor's events live on later pages." `metadata.filter_pagination_state` now flags this with `no_matches_in_page`, `more_pages_available`, `events_in_unfiltered_page`, and explicit `advice`.
- **#9 `policy_health_overview` sample mismatch** — Verified live: `/policy-run-count?days=N` honors the window (returns 720 for 7-day window), but `/policy-runs` is server-capped at ~100 events / ≈24h regardless of `limit`/`days`/`start_time` params (returns 100). `total_runs_considered < total_policy_runs` is normal for active orgs. `data.sample_is_truncated` and `metadata.sample_is_truncated`/`sample_note` now make this explicit.

## Verification

Live-tenant harness output before / after:

```
                 BEFORE    AFTER
#5 dev_attention VERIFIED  NOT_REPRODUCED  (fields populated)
#7 run_results   VERIFIED  NOT_REPRODUCED  (filter honored)
#8 audit_cursor  VERIFIED  NOT_REPRODUCED  (state explicitly flagged)
#9 health_sample VERIFIED  NOT_REPRODUCED  (truncation explicitly flagged)
```

The harness was updated to recognize the new metadata fields as the "fixed" signal for #8 and #9 — since those fixes surface the truth via metadata rather than changing the underlying numbers, the symptom check alone would still match. The new triage logic is: "symptom present AND no explicit acknowledgment in metadata."

## What's next

**v1.0.23** (final from #43): contract normalization for #6 (Spring wrapper leak), #14 (truncation honesty), #4a/4b (detail no-ops), #13 (pagination shape).

## Test plan

- [x] `uv run pytest tests/` — 1058 passed
- [x] `uv run ruff check .` / `ruff format --check .` / `mypy .` all clean
- [x] Live-tenant verification of all four bugs via `tests/verify_reported_bugs.py`
- [ ] After merge: tag-push `v1.0.22` to trigger PyPI / MCP Registry / MCPB publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)