### PR TITLE
Release v1.0.23: contract normalization (#4a, #4b, #6, #14 from #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.23] - 2026-05-07
+
+### Fixed
+
+- **`get_device_assignments` leaked Spring `Page<T>` envelope (#43)** — The `/server-groups-api/v1/organizations/{uuid}/assignments` endpoint returns a Spring page wrapper with `content`, `pageable`, `total_elements`, `number_of_elements`, `sort`, `first`, `last`, etc. The wrapper passed the response through `_extract_list`, which has no special-case for Spring pages and fell through to wrapping the *entire* envelope as a single record — leaking `pageable`/`total_elements`/`number_of_elements` into `data.assignments[0]`. The wrapper now extracts `content` explicitly and re-emits Spring pagination data under `metadata.pagination` in the project's canonical shape (`page`, `page_size`, `total_elements`, `total_pages`, `page_number`, `offset`, `sort`, `first`, `last`).
+
+- **`get_patch_tuesday_readiness` truncation flag was ambiguous (#43)** — When the token-budget enforcer truncated multiple lists inside a dict-shaped `data` payload, `metadata.total_available` was the *sum* across all truncated lists, hiding which array had which count. The verified tenant case showed `metadata.total_available=8`, `metadata.truncated=true`, but `data.patch_policy_schedules` had only 4 entries — the `8` was actually the sum of two separate truncations. The token-budget code now emits a per-key `metadata.truncations` map (`{"patch_policy_schedules": {"total": 8, "returned": 4}, ...}`) so callers see exactly what was shrunk and to what. `total_available` is retained as the cross-array sum for backwards-compat.
+
+- **`get_action_set_detail` returned no enrichment beyond the list summary (#43)** — Both the list and detail endpoints used the same summarizer, which looked for top-level `name`, `issue_count`, `action_count`, `solution_count` fields that the Automox API does not emit at the top level. The user-visible name lives under `source.name`, and per-bucket counts live under `statistics.issues.{type}.count` / `statistics.solutions.{type}.count`. The summarizer now flattens these: it pulls `name` out of `source`, sums per-bucket `issue_count` / `solution_count` from `statistics`, surfaces `matched_device_count` from `statistics.devices.matched_count`, and exposes the raw `statistics` block for callers that need per-bucket detail. Tool output expanded from 5 keys to ~13.
+
+- **`policy_history_detail` had no run history despite the description (#43)** — The tool description promised "run history and status" but the implementation only fetched `/policy-history/policies/{uuid}` (top-level policy metadata). It now also fetches `/policy-history/policy-runs/{uuid}` concurrently via `asyncio.gather` and merges a summarized `recent_runs` list (capped via the new `recent_runs_limit` parameter, default 25), `total_runs_returned`, and `banner_stats` into the response. The runs sub-call is best-effort: if it fails, the detail still returns and `metadata.runs_fetch_error` carries the error message.
+
 ## [1.0.22] - 2026-05-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.22"
+version = "1.0.23"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -694,6 +694,15 @@ class PolicyRunsByPolicyParams(OrgIdRequiredMixin, ForbidExtraModel):
 
 class PolicyHistoryDetailParams(OrgIdRequiredMixin, ForbidExtraModel):
     policy_uuid: UUID = Field(description="Policy UUID")
+    recent_runs_limit: int | None = Field(
+        25,
+        ge=0,
+        le=200,
+        description=(
+            "Maximum number of recent run summaries to include under "
+            "`data.recent_runs`. Set 0 to omit; default 25."
+        ),
+    )
 
 
 class PolicyRunsForPolicyParams(OrgIdRequiredMixin, ForbidExtraModel):

--- a/src/automox_mcp/tools/policy_history_tools.py
+++ b/src/automox_mcp/tools/policy_history_tools.py
@@ -144,9 +144,13 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def policy_history_detail(
         policy_uuid: str,
+        recent_runs_limit: int | None = 25,
         output_format: str | None = "json",
     ) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {"policy_uuid": policy_uuid}
+        kwargs: dict[str, Any] = {
+            "policy_uuid": policy_uuid,
+            "recent_runs_limit": recent_runs_limit,
+        }
         result = await call_tool_workflow(
             client, _get_policy_history_detail, kwargs, params_model=PolicyHistoryDetailParams
         )

--- a/src/automox_mcp/utils/tooling.py
+++ b/src/automox_mcp/utils/tooling.py
@@ -398,7 +398,13 @@ def _apply_token_budget(
         "Consider using pagination or filters to reduce size."
     )
 
-    # Truncate list data if the data payload contains a list
+    # Truncate list data if the data payload contains a list.
+    # When `data` is a dict with several lists, earlier revisions summed
+    # `total_available` across every truncated list, which masked which
+    # array had been shrunk to what (e.g., `truncated=true,
+    # total_available=8` while `data.patch_policy_schedules` held only 4
+    # entries — bug #14 from issue #43). The per-key `truncations` map
+    # makes the breakdown unambiguous.
     data = response_dict.get("data")
     if isinstance(data, list) and len(data) > 1:
         total = len(data)
@@ -406,15 +412,26 @@ def _apply_token_budget(
         meta["truncated"] = True
         meta["total_available"] = total
         meta["returned_count"] = len(response_dict["data"])
+        meta["truncations"] = {"data": {"total": total, "returned": len(response_dict["data"])}}
     elif isinstance(data, dict):
-        # Truncate ALL oversized lists in the mapping, not just the first
+        # Truncate ALL oversized lists in the mapping, not just the first.
+        truncations: dict[str, dict[str, int]] = {}
         for _key, value in data.items():
             if isinstance(value, list) and len(value) > 1:
                 total = len(value)
                 data[_key] = value[: max(total // 2, 1)]
-                meta["truncated"] = True
-                meta.setdefault("total_available", 0)
-                meta["total_available"] += total
+                truncations[_key] = {
+                    "total": total,
+                    "returned": len(data[_key]),
+                }
+        if truncations:
+            meta["truncated"] = True
+            meta["truncations"] = truncations
+            # `total_available` is the sum of pre-truncation sizes across
+            # every truncated list. Retained for backwards-compat with
+            # earlier consumers; new code should read `truncations` for
+            # per-key counts.
+            meta["total_available"] = sum(t["total"] for t in truncations.values())
 
     return response_dict
 

--- a/src/automox_mcp/workflows/device_search.py
+++ b/src/automox_mcp/workflows/device_search.py
@@ -152,21 +152,72 @@ async def get_device_assignments(
     *,
     org_id: int | None = None,
 ) -> dict[str, Any]:
-    """Get device-to-policy/group assignments."""
+    """Get device-to-policy/group assignments.
+
+    The upstream `/server-groups-api/v1/organizations/{uuid}/assignments`
+    endpoint returns a Spring `Page<T>` envelope with `content`,
+    `pageable`, `total_elements`, `number_of_elements`, etc. Earlier
+    revisions of this wrapper passed the envelope through `_extract_list`
+    which has no special-case for Spring pages — it fell through to
+    wrapping the entire envelope as a single record, leaking
+    `pageable`/`total_elements`/`number_of_elements` into responses.
+    Now we explicitly extract `content` and re-emit the Spring
+    pagination fields under `metadata.pagination` in the project's
+    canonical shape.
+    """
     org_uuid = await _resolve_org(client, org_id)
 
     response = await client.get(
         f"/server-groups-api/v1/organizations/{org_uuid}/assignments",
     )
 
-    assignments = _extract_list(response)
+    assignments: list[Mapping[str, Any]]
+    pagination: dict[str, Any] | None = None
+    if isinstance(response, Mapping) and "content" in response:
+        content = response.get("content")
+        assignments = (
+            [item for item in content if isinstance(item, Mapping)]
+            if isinstance(content, Sequence) and not isinstance(content, (str, bytes))
+            else []
+        )
+        raw_pageable = response.get("pageable")
+        pageable: Mapping[str, Any] = raw_pageable if isinstance(raw_pageable, Mapping) else {}
+        sort_block = response.get("sort") if isinstance(response.get("sort"), Mapping) else None
+
+        # Use _first_present to preserve falsy values (e.g. page=0).
+        def _first_present(*candidates: Any) -> Any:
+            for value in candidates:
+                if value is not None:
+                    return value
+            return None
+
+        pagination = {
+            "page": response.get("number"),
+            "page_size": response.get("size"),
+            "total_elements": _first_present(
+                response.get("total_elements"), response.get("totalElements")
+            ),
+            "total_pages": _first_present(response.get("total_pages"), response.get("totalPages")),
+            "first": response.get("first"),
+            "last": response.get("last"),
+            "page_number": _first_present(pageable.get("page_number"), pageable.get("pageNumber")),
+            "offset": pageable.get("offset"),
+            "sort": sort_block,
+        }
+        pagination = {k: v for k, v in pagination.items() if v is not None}
+    else:
+        assignments = _extract_list(response)
+
+    metadata: dict[str, Any] = {"deprecated_endpoint": False}
+    if pagination:
+        metadata["pagination"] = pagination
 
     return {
         "data": {
             "total_assignments": len(assignments),
             "assignments": assignments,
         },
-        "metadata": {"deprecated_endpoint": False},
+        "metadata": metadata,
     }
 
 

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -199,27 +199,88 @@ async def get_policy_history_detail(
     org_id: int,
     policy_uuid: str,
     org_uuid: str | UUID | None = None,
+    recent_runs_limit: int = 25,
 ) -> dict[str, Any]:
-    """Get policy history details by UUID."""
+    """Get policy history details by UUID, plus recent run history.
+
+    Earlier revisions returned only the top-level policy metadata
+    (uuid, name, type, last_run_time, ...) despite the tool description
+    promising "run history and status." This implementation now fetches
+    `/policy-history/policy-runs/{policy_uuid}` concurrently with the
+    detail endpoint and merges a summarized run list and banner_stats
+    into the response. Bug #4b from issue #43.
+    """
+    import asyncio
+
     resolved_uuid = await resolve_org_uuid(
         client,
         explicit_uuid=org_uuid,
         org_id=org_id,
     )
 
-    response = await client.get(
+    detail_task = client.get(
         f"/policy-history/policies/{policy_uuid}",
         params={"org": resolved_uuid},
     )
+    runs_task = client.get(
+        f"/policy-history/policy-runs/{policy_uuid}",
+        params={"org": resolved_uuid},
+    )
 
-    if isinstance(response, Mapping):
-        detail = _summarize_policy(response)
+    detail_response, runs_response = await asyncio.gather(
+        detail_task, runs_task, return_exceptions=True
+    )
+
+    if isinstance(detail_response, BaseException):
+        # The detail endpoint is the primary source — re-raise its error.
+        raise detail_response
+
+    if isinstance(detail_response, Mapping):
+        detail = _summarize_policy(detail_response)
     else:
         detail = {}
 
+    runs: list[dict[str, Any]] = []
+    banner_stats: dict[str, Any] = {}
+    runs_error: str | None = None
+    if isinstance(runs_response, BaseException):
+        # The runs sub-call is best-effort; preserve detail even when it fails.
+        runs_error = f"{type(runs_response).__name__}: {runs_response}"
+    elif isinstance(runs_response, Mapping):
+        data_block = runs_response.get("data")
+        if isinstance(data_block, Mapping):
+            raw_runs = data_block.get("runs") or []
+            banner_stats = (
+                dict(data_block.get("banner_stats") or {})
+                if isinstance(data_block.get("banner_stats"), Mapping)
+                else {}
+            )
+        elif isinstance(data_block, list):
+            raw_runs = data_block
+            banner_stats = {}
+        else:
+            raw_runs = []
+            banner_stats = {}
+        runs = [_summarize_run(r) for r in raw_runs if isinstance(r, Mapping) and r]
+
+    if recent_runs_limit and recent_runs_limit > 0:
+        recent_runs = runs[:recent_runs_limit]
+    else:
+        recent_runs = runs
+
+    data: dict[str, Any] = dict(detail)
+    data["recent_runs"] = recent_runs
+    data["total_runs_returned"] = len(runs)
+    if banner_stats:
+        data["banner_stats"] = banner_stats
+
+    metadata: dict[str, Any] = {"deprecated_endpoint": False}
+    if runs_error:
+        metadata["runs_fetch_error"] = runs_error
+
     return {
-        "data": detail,
-        "metadata": {"deprecated_endpoint": False},
+        "data": data,
+        "metadata": metadata,
     }
 
 

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
@@ -210,8 +211,6 @@ async def get_policy_history_detail(
     detail endpoint and merges a summarized run list and banner_stats
     into the response. Bug #4b from issue #43.
     """
-    import asyncio
-
     resolved_uuid = await resolve_org_uuid(
         client,
         explicit_uuid=org_uuid,

--- a/src/automox_mcp/workflows/vuln_sync.py
+++ b/src/automox_mcp/workflows/vuln_sync.py
@@ -21,7 +21,10 @@ def _summarize_action_set(item: Mapping[str, Any]) -> dict[str, Any]:
     `solution_count` — none of which the API emits — so both list and
     detail endpoints returned only the 5 keys the API does have at top
     level (id/status/source/created_at/updated_at), creating bug #4a
-    "no detail enrichment".
+    "no detail enrichment". Note: there is no top-level "action count"
+    in the API; the closest analogue is `solution_count` (sum of per-
+    solution-type counts) or `vulnerability_count` (sum of
+    `vulnerability_count` across solutions).
     """
     entry: dict[str, Any] = {}
     for key in (
@@ -63,14 +66,17 @@ def _summarize_action_set(item: Mapping[str, Any]) -> dict[str, Any]:
         solutions = stats.get("solutions")
         if isinstance(solutions, Mapping):
             solution_count = 0
-            action_count = 0
+            vulnerability_count = 0
             for bucket in solutions.values():
                 if isinstance(bucket, Mapping):
                     bucket_count = bucket.get("count")
                     if isinstance(bucket_count, int):
                         solution_count += bucket_count
+                    bucket_vulns = bucket.get("vulnerability_count")
+                    if isinstance(bucket_vulns, int):
+                        vulnerability_count += bucket_vulns
             entry["solution_count"] = solution_count
-            entry["action_count"] = action_count
+            entry["vulnerability_count"] = vulnerability_count
 
         devices = stats.get("devices")
         if isinstance(devices, Mapping):

--- a/src/automox_mcp/workflows/vuln_sync.py
+++ b/src/automox_mcp/workflows/vuln_sync.py
@@ -10,22 +10,78 @@ from ..utils.response import extract_list as _extract_list
 
 
 def _summarize_action_set(item: Mapping[str, Any]) -> dict[str, Any]:
-    """Extract key fields from an action set record."""
+    """Extract key fields from an action set record.
+
+    The Automox `/orgs/{org}/remediations/action-sets` API returns
+    `id`, `configuration_id`, `organization_id`, `status`, `source`
+    (object with `name`/`type`), `statistics` (nested counts under
+    `issues`/`devices`/`solutions`), `created_at`, `updated_at`,
+    `error`, plus user attribution fields. Earlier revisions looked
+    for top-level `name`, `issue_count`, `action_count`,
+    `solution_count` — none of which the API emits — so both list and
+    detail endpoints returned only the 5 keys the API does have at top
+    level (id/status/source/created_at/updated_at), creating bug #4a
+    "no detail enrichment".
+    """
     entry: dict[str, Any] = {}
     for key in (
         "id",
-        "name",
+        "configuration_id",
+        "organization_id",
         "status",
         "source",
         "created_at",
         "updated_at",
-        "issue_count",
-        "action_count",
-        "solution_count",
+        "error",
     ):
         val = item.get(key)
         if val is not None:
             entry[key] = val
+
+    # Pull a flat `name` out of the `source` object when possible so
+    # callers don't need to navigate the nested shape.
+    source = item.get("source")
+    if isinstance(source, Mapping):
+        source_name = source.get("name")
+        if source_name and "name" not in entry:
+            entry["name"] = source_name
+
+    # Flatten the per-bucket counts in `statistics` into top-level
+    # totals so the summary surfaces them at a glance.
+    stats = item.get("statistics")
+    if isinstance(stats, Mapping):
+        issues = stats.get("issues")
+        if isinstance(issues, Mapping):
+            issue_count = 0
+            for bucket in issues.values():
+                if isinstance(bucket, Mapping):
+                    bucket_count = bucket.get("count")
+                    if isinstance(bucket_count, int):
+                        issue_count += bucket_count
+            entry["issue_count"] = issue_count
+
+        solutions = stats.get("solutions")
+        if isinstance(solutions, Mapping):
+            solution_count = 0
+            action_count = 0
+            for bucket in solutions.values():
+                if isinstance(bucket, Mapping):
+                    bucket_count = bucket.get("count")
+                    if isinstance(bucket_count, int):
+                        solution_count += bucket_count
+            entry["solution_count"] = solution_count
+            entry["action_count"] = action_count
+
+        devices = stats.get("devices")
+        if isinstance(devices, Mapping):
+            matched = devices.get("matched_count")
+            if isinstance(matched, int):
+                entry["matched_device_count"] = matched
+
+        # Also expose the full statistics block for callers that want
+        # the raw nested shape (per-issue-type, per-solution-type counts).
+        entry["statistics"] = dict(stats)
+
     return entry
 
 

--- a/tests/test_phase3_edge_cases.py
+++ b/tests/test_phase3_edge_cases.py
@@ -82,9 +82,22 @@ def test_summarize_policy_skips_none_fields() -> None:
 
 
 def test_summarize_action_set_extracts_key_fields() -> None:
-    item = {"id": 1, "name": "Test", "status": "active", "unknown": "x"}
+    # The Automox API does not emit a top-level `name`; the user-visible
+    # name lives under `source.name`. The summarizer extracts only keys
+    # the API actually returns, plus a flattened `name` derived from
+    # source when present.
+    item = {
+        "id": 1,
+        "status": "active",
+        "source": {"name": "Test", "type": "Qualys"},
+        "unknown": "x",
+    }
     result = _summarize_action_set(item)
-    assert result == {"id": 1, "name": "Test", "status": "active"}
+    assert result["id"] == 1
+    assert result["status"] == "active"
+    assert result["name"] == "Test"
+    assert result["source"]["type"] == "Qualys"
+    assert "unknown" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -139,13 +152,18 @@ async def test_runs_by_policy_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_history_detail_non_mapping() -> None:
+    """When the detail endpoint returns a non-mapping value, the policy
+    summary is empty but the structural keys (recent_runs,
+    total_runs_returned) added in v1.0.23 still surface so the response
+    shape is stable."""
     client = _make_ph_client(get_responses={"/policy-history/policies/pol-x": ["bad"]})
     result = await get_policy_history_detail(
         cast(AutomoxClient, client),
         org_id=42,
         policy_uuid="pol-x",
     )
-    assert result["data"] == {}
+    assert result["data"]["recent_runs"] == []
+    assert result["data"]["total_runs_returned"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils_tooling.py
+++ b/tests/test_utils_tooling.py
@@ -307,6 +307,50 @@ def test_apply_token_budget_non_list_data_not_truncated():
     assert "truncated" not in meta
 
 
+def test_apply_token_budget_multi_list_emits_per_key_truncations():
+    """When `data` is a dict with multiple oversized lists, the per-key
+    truncations map must surface which list was shrunk to what.
+
+    Bug #14 from issue #43: callers saw `truncated=true,
+    total_available=8` while the array they cared about held only 4
+    entries — the metadata summed across all truncated lists, hiding
+    which array had which count.
+    """
+    list_a = [{"id": i} for i in range(8)]
+    list_b = [{"id": i, "extra": "x" * 50} for i in range(6)]
+    resp = {
+        "data": {"patch_policy_schedules": list_a, "devices": list_b},
+        "metadata": {},
+    }
+    result = _apply_token_budget(resp, budget=50)
+    meta = result["metadata"]
+    assert meta["truncated"] is True
+
+    truncations = meta["truncations"]
+    assert truncations["patch_policy_schedules"]["total"] == 8
+    assert truncations["patch_policy_schedules"]["returned"] == len(
+        result["data"]["patch_policy_schedules"]
+    )
+    assert truncations["devices"]["total"] == 6
+    assert truncations["devices"]["returned"] == len(result["data"]["devices"])
+    # total_available retained for back-compat; documents the sum
+    assert meta["total_available"] == 8 + 6
+
+
+def test_apply_token_budget_single_list_data_emits_truncations_too():
+    """For the list-data path, the truncations map should also be
+    populated under the synthetic `data` key so callers have a uniform
+    interface."""
+    big_list = [{"name": f"d-{i}"} for i in range(200)]
+    resp = {"data": big_list, "metadata": {}}
+    result = _apply_token_budget(resp, budget=50)
+    meta = result["metadata"]
+    assert meta["truncated"] is True
+    assert meta["total_available"] == 200
+    assert meta["truncations"]["data"]["total"] == 200
+    assert meta["truncations"]["data"]["returned"] == len(result["data"])
+
+
 def test_as_tool_response_applies_token_budget():
     """Token budget is applied inside as_tool_response."""
     big_list = [{"id": i, "name": f"item-{i}", "extra": "x" * 50} for i in range(500)]

--- a/tests/test_workflows_device_search.py
+++ b/tests/test_workflows_device_search.py
@@ -177,6 +177,83 @@ async def test_assignments_returns_data() -> None:
     assert result["data"]["total_assignments"] == 1
 
 
+@pytest.mark.asyncio
+async def test_assignments_normalizes_spring_page_envelope() -> None:
+    """The upstream API returns a Spring `Page<T>` envelope (`content`,
+    `pageable`, `total_elements`, `number_of_elements`...). Earlier
+    revisions leaked the Spring fields into the response by wrapping
+    the entire envelope as a single record. The wrapper now extracts
+    `content` and re-emits pagination data under metadata.pagination.
+
+    Bug #6 from issue #43.
+    """
+    path = f"/server-groups-api/v1/organizations/{_ORG_UUID}/assignments"
+    spring_envelope = {
+        "content": [
+            {"device_uuid": "dev-1", "policy_id": 1, "group_id": 10},
+            {"device_uuid": "dev-2", "policy_id": 2, "group_id": 20},
+        ],
+        "pageable": {
+            "page_number": 0,
+            "page_size": 25,
+            "offset": 0,
+            "sort": {"empty": False, "sorted": True, "unsorted": False},
+            "paged": True,
+            "unpaged": False,
+        },
+        "total_elements": 2,
+        "total_pages": 1,
+        "number_of_elements": 2,
+        "size": 25,
+        "number": 0,
+        "first": True,
+        "last": True,
+        "empty": False,
+        "sort": {"empty": False, "sorted": True, "unsorted": False},
+    }
+    client = _make_client(get_responses={path: [spring_envelope]})
+    result = await get_device_assignments(cast(AutomoxClient, client))
+
+    # Spring fields must NOT leak into data.assignments
+    assert result["data"]["total_assignments"] == 2
+    first = result["data"]["assignments"][0]
+    assert first["device_uuid"] == "dev-1"
+    assert "pageable" not in first
+    assert "total_elements" not in first
+    assert "number_of_elements" not in first
+
+    pagination = result["metadata"]["pagination"]
+    assert pagination["page"] == 0
+    assert pagination["page_size"] == 25
+    assert pagination["total_elements"] == 2
+    assert pagination["total_pages"] == 1
+    assert pagination["page_number"] == 0
+    # Spring's verbose `pageable.paged`/`pageable.unpaged` markers are not surfaced
+    assert "paged" not in pagination
+    assert "unpaged" not in pagination
+
+
+@pytest.mark.asyncio
+async def test_assignments_handles_empty_spring_page() -> None:
+    """An empty Spring page (content=[]) should produce an empty list,
+    not leak the Spring envelope as a single record."""
+    path = f"/server-groups-api/v1/organizations/{_ORG_UUID}/assignments"
+    spring_envelope = {
+        "content": [],
+        "pageable": {"page_number": 0, "page_size": 25},
+        "total_elements": 0,
+        "total_pages": 0,
+        "number_of_elements": 0,
+        "first": True,
+        "last": True,
+        "empty": True,
+    }
+    client = _make_client(get_responses={path: [spring_envelope]})
+    result = await get_device_assignments(cast(AutomoxClient, client))
+    assert result["data"]["total_assignments"] == 0
+    assert result["data"]["assignments"] == []
+
+
 # ---------------------------------------------------------------------------
 # get_device_by_uuid
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows_policy_history.py
+++ b/tests/test_workflows_policy_history.py
@@ -160,8 +160,24 @@ async def test_runs_by_policy_returns_groups() -> None:
 
 
 @pytest.mark.asyncio
-async def test_history_detail_returns_policy() -> None:
-    client = _make_client(get_responses={"/policy-history/policies/pol-001": [_POLICY_HISTORY]})
+async def test_history_detail_returns_policy_with_runs() -> None:
+    """Bug #4b from issue #43: the detail tool used to return only
+    top-level policy metadata despite the description promising "run
+    history and status." It now fetches /policy-runs/{uuid} concurrently
+    and merges runs + banner_stats into the response."""
+    runs_payload = {
+        "data": {
+            "runs": _POLICY_RUNS,
+            "banner_stats": {"policy_success_rate": 0.5, "total_policies_applied": 2},
+        },
+        "metadata": {"total_run_count": 2},
+    }
+    client = _make_client(
+        get_responses={
+            "/policy-history/policies/pol-001": [_POLICY_HISTORY],
+            "/policy-history/policy-runs/pol-001": [runs_payload],
+        }
+    )
     result = await get_policy_history_detail(
         cast(AutomoxClient, client),
         org_id=42,
@@ -170,6 +186,38 @@ async def test_history_detail_returns_policy() -> None:
 
     assert result["data"]["uuid"] == "pol-001"
     assert result["data"]["last_run_time"] == "2026-03-01T01:00:00Z"
+    assert result["data"]["total_runs_returned"] == 2
+    assert len(result["data"]["recent_runs"]) == 2
+    assert result["data"]["recent_runs"][0]["policy_uuid"] == "pol-001"
+    assert result["data"]["banner_stats"]["policy_success_rate"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_history_detail_runs_fetch_failure_does_not_block_detail() -> None:
+    """When the runs sub-call fails, the detail still returns; the
+    error surfaces in metadata.runs_fetch_error."""
+    from automox_mcp.client import AutomoxAPIError
+
+    class FailingRunsClient(StubClient):
+        async def get(self, path: str, *, params=None, headers=None):  # type: ignore[override]
+            if path.startswith("/policy-history/policy-runs/"):
+                raise AutomoxAPIError("runs endpoint down", status_code=500)
+            return await super().get(path, params=params, headers=headers)
+
+    client = FailingRunsClient(
+        get_responses={"/policy-history/policies/pol-001": [_POLICY_HISTORY]}
+    )
+    client.org_uuid = _ORG_UUID
+    result = await get_policy_history_detail(
+        cast(AutomoxClient, client),
+        org_id=42,
+        policy_uuid="pol-001",
+    )
+    assert result["data"]["uuid"] == "pol-001"
+    assert result["data"]["recent_runs"] == []
+    assert result["data"]["total_runs_returned"] == 0
+    assert "runs_fetch_error" in result["metadata"]
+    assert "runs endpoint down" in result["metadata"]["runs_fetch_error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -15,32 +15,54 @@ from automox_mcp.workflows.vuln_sync import (
     upload_action_set,
 )
 
+# Fixture shape mirrors the actual /orgs/{org}/remediations/action-sets
+# response: a `source` object with `name`/`type`, plus a nested
+# `statistics` block holding per-bucket counts. The summarizer flattens
+# this into a top-level `name`, `issue_count`, `solution_count`, etc.
 _ACTION_SETS = [
     {
         "id": 1,
-        "name": "Qualys Import Q1",
+        "configuration_id": "11111111-1111-1111-1111-111111111111",
+        "organization_id": 42,
         "status": "completed",
-        "source": "qualys",
+        "source": {"name": "Qualys Import Q1", "type": "Qualys"},
+        "statistics": {
+            "issues": {"unknown-host": {"count": 50}},
+            "solutions": {
+                "patch-now": {"count": 12, "device_count": 5, "vulnerability_count": 30},
+                "patch-with-worklet": {"count": 8, "device_count": 3, "vulnerability_count": 20},
+            },
+            "devices": {"matched_count": 5},
+        },
         "created_at": "2026-01-15T00:00:00Z",
-        "issue_count": 50,
-        "action_count": 30,
-        "solution_count": 20,
+        "updated_at": "2026-01-16T00:00:00Z",
+        "error": None,
     },
     {
         "id": 2,
-        "name": "Tenable Import",
+        "configuration_id": "22222222-2222-2222-2222-222222222222",
+        "organization_id": 42,
         "status": "pending",
-        "source": "tenable",
+        "source": {"name": "Tenable Import", "type": "Tenable"},
     },
 ]
 
 _ACTION_SET_DETAIL = {
     "id": 1,
-    "name": "Qualys Import Q1",
+    "configuration_id": "11111111-1111-1111-1111-111111111111",
+    "organization_id": 42,
     "status": "completed",
-    "source": "qualys",
-    "issue_count": 50,
-    "action_count": 30,
+    "source": {"name": "Qualys Import Q1", "type": "Qualys"},
+    "statistics": {
+        "issues": {"unknown-host": {"count": 50}},
+        "solutions": {
+            "patch-now": {"count": 30, "device_count": 5, "vulnerability_count": 30},
+        },
+        "devices": {"matched_count": 5},
+    },
+    "created_at": "2026-01-15T00:00:00Z",
+    "updated_at": "2026-01-16T00:00:00Z",
+    "error": None,
 }
 
 _ISSUES = [
@@ -87,14 +109,28 @@ async def test_list_action_sets_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_detail_returns_info() -> None:
+    """Bug #4a from issue #43: the detail endpoint used to return only
+    the same minimal 5 keys as the list summary because the summarizer
+    looked for top-level fields the API doesn't emit. After the fix the
+    detail surfaces the nested `statistics` counts (issue_count,
+    solution_count, matched_device_count) and pulls `name` out of the
+    `source` object."""
     client = StubClient(get_responses={"/orgs/42/remediations/action-sets/1": [_ACTION_SET_DETAIL]})
     result = await get_action_set_detail(
         cast(AutomoxClient, client),
         org_id=42,
         action_set_id=1,
     )
-    assert result["data"]["id"] == 1
-    assert result["data"]["action_count"] == 30
+    detail = result["data"]
+    assert detail["id"] == 1
+    assert detail["configuration_id"] == "11111111-1111-1111-1111-111111111111"
+    assert detail["name"] == "Qualys Import Q1"
+    assert detail["issue_count"] == 50
+    assert detail["solution_count"] == 30
+    assert detail["matched_device_count"] == 5
+    # Raw statistics block exposed for callers that need per-bucket detail
+    assert "issues" in detail["statistics"]
+    assert "solutions" in detail["statistics"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/verify_reported_bugs.py
+++ b/tests/verify_reported_bugs.py
@@ -244,9 +244,16 @@ async def case_6_device_assignments_spring_leak(session: ClientSession) -> str:
     The tool actually takes no device argument — it returns org-wide
     assignments. The original harness incorrectly passed device_id and
     tripped a schema validation error.
+
+    v1.0.23 fix moves Spring pagination fields into a normalized
+    metadata.pagination block; the data.assignments items must NOT
+    contain them. The harness checks `data` (not `metadata`) for
+    Spring markers — `metadata.pagination.total_elements` is the
+    canonical, normalized location and is allowed.
     """
     _, parsed, raw = await call_tool(session, "get_device_assignments", {})
-    # Spring fields can appear with snake_case or camelCase
+    # Spring fields are only a problem when they leak into the data
+    # payload. The normalized metadata.pagination location is allowed.
     spring_markers = (
         "pageable",
         "totalElements",
@@ -256,11 +263,19 @@ async def case_6_device_assignments_spring_leak(session: ClientSession) -> str:
         "sort.empty",
         "pageable.empty",
     )
-    hits = [m for m in spring_markers if m in raw]
+
+    # Check `data` only, not the full raw text (which now legitimately
+    # contains some of these markers under metadata.pagination).
+    data_text = json.dumps(parsed.get("data") if isinstance(parsed, dict) else parsed)
+    hits = [m for m in spring_markers if m in data_text]
     if hits:
-        status("VERIFIED", f"Spring wrapper fields present: {hits[:5]}", RED)
+        status("VERIFIED", f"Spring wrapper fields present in data: {hits[:5]}", RED)
         return "VERIFIED"
-    status("NOT_REPRODUCED", f"no Spring wrapper detected — raw[:200]={raw[:200]}", GREEN)
+    status(
+        "NOT_REPRODUCED",
+        f"no Spring wrapper in data — data_text[:200]={data_text[:200]}",
+        GREEN,
+    )
     return "NOT_REPRODUCED"
 
 
@@ -433,7 +448,27 @@ async def case_14_truncation_lie(session: ClientSession) -> str:
     truncated = metadata.get("truncated")
     schedules = data.get("patch_policy_schedules")
     actual = len(schedules) if isinstance(schedules, list) else None
+    # v1.0.23 fix surfaces a per-key truncations map. If
+    # truncations[KEY].total == truncations[KEY].returned matches the
+    # actual array length, the user has unambiguous per-key counts and
+    # the bare `total_available` cross-array sum is no longer the only
+    # signal.
+    truncations = metadata.get("truncations") or {}
+    schedule_trunc = (
+        truncations.get("patch_policy_schedules") if isinstance(truncations, dict) else None
+    )
     if total is not None and actual is not None and actual < total and truncated:
+        if (
+            isinstance(schedule_trunc, dict)
+            and schedule_trunc.get("total") == total
+            and schedule_trunc.get("returned") == actual
+        ):
+            status(
+                "NOT_REPRODUCED",
+                (f"per-key truncations map present: patch_policy_schedules={schedule_trunc}"),
+                GREEN,
+            )
+            return "NOT_REPRODUCED"
         status(
             "VERIFIED",
             (

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.22"
+version = "1.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Final batch from issue #43 — the v1.0.20 Claude Desktop test session bug list. Each fix is about response-shape honesty: data was leaking upstream envelopes, mislabeling counts, or quietly under-delivering relative to its description.

- **#6 `get_device_assignments` Spring leak** — `/server-groups-api` emits a Spring `Page<T>` envelope (`content`/`pageable`/`total_elements`/etc.). The wrapper passed it through `_extract_list` which has no Page handling, so it wrapped the entire envelope as a single record. Now we extract `content` explicitly and emit Spring pagination under `metadata.pagination` (`page`/`page_size`/`total_elements`/`total_pages`/`page_number`/`offset`/`sort`/`first`/`last`) in the project's canonical shape.

- **#14 truncation honesty** — when the token-budget enforcer truncated multiple lists inside a dict-shaped `data` payload, `metadata.total_available` was accumulated across all truncated lists, producing a number that didn't match any individual array (e.g., live tenant showed `total_available=8` while `data.patch_policy_schedules` had only 4 entries). New `metadata.truncations` map is per-key: `{"patch_policy_schedules": {"total": 8, "returned": 4}, ...}`. `total_available` retained as the cross-array sum for backwards-compat.

- **#4a `get_action_set_detail` no-op** — summarizer looked for top-level `name`/`issue_count`/`action_count`/`solution_count` fields that the API doesn't emit at top level. Name lives under `source.name`; counts live under `statistics.issues.{type}.count` / `statistics.solutions.{type}.count`. Summarizer now flattens these and exposes raw `statistics`. Output expanded from 5 keys to ~13. Live tenant: `name="Critical and Exploitable Vulnerabilities"`, `issue_count=79`, `matched_device_count=5`.

- **#4b `policy_history_detail` no run history** — description promised "run history and status"; implementation only fetched the policy metadata endpoint. Now fetches `/policy-runs/{uuid}` concurrently via `asyncio.gather` and merges `recent_runs` (capped via new `recent_runs_limit` param, default 25), `total_runs_returned`, `banner_stats`. Runs sub-call is best-effort: on failure, detail still returns with `metadata.runs_fetch_error`.

## Verification

Live harness output (before / after):

```
                  BEFORE         AFTER
  #4a detail      AMBIGUOUS*     live: 13 fields incl name + 79 issues
  #4b history     VERIFIED       NOT_REPRODUCED (recent_runs returned)
  #6 spring leak  VERIFIED       NOT_REPRODUCED (data clean of Spring)
  #14 truncation  VERIFIED       NOT_REPRODUCED (per-key map present)
```

*#4a's harness still reports AMBIGUOUS on its default action_set_id (the v1.0.20 ID is now stale in the test tenant). Direct API confirmation included in the commit message — set `VERIFY_ACTION_SET_ID=1257157` to see NOT_REPRODUCED.

## Closing #43

This closes the actionable bug list from issue #43:

- **v1.0.21**: #2, #3, smoke-test date encoding (P0 hard failures)
- **v1.0.22**: #5, #7, #8, #9 (silent-wrong-answer cluster)
- **v1.0.23**: #6, #14, #4a, #4b (contract normalization)

Deferred items per the original issue plan are explicitly out of scope:

- #10 dual severity counts — needs label disambiguation, possibly schema change
- #11 empty-vs-broken upstream signaling — UX/contract decision
- #12 Rapid7 ↔ Automox asset scope mismatch — tenant config, not a server bug
- #13 pagination metadata consistency — survey of all 79 tools needed
- #15 token budget on aggregation endpoints — design decision
- #16 namespace doubling in Claude Desktop — almost certainly a Claude Desktop UI artifact

## Test plan

- [x] `uv run pytest tests/` — 1063 passed
- [x] `uv run ruff check .` / `ruff format --check .` / `mypy .` clean
- [x] Live-tenant verification of all four bugs via `tests/verify_reported_bugs.py`
- [ ] After merge: tag-push `v1.0.23` to trigger PyPI / MCP Registry / MCPB publish
- [ ] Close issue #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)