### PR TITLE
Make pypa/gh-action-pypi-publish skip-existing to suppress duplicate-trigger failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,15 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.pypi_check.outputs.exists != 'true'
+        # `skip-existing` is a defense against race conditions when two
+        # workflow runs are scheduled for the same tag (we have observed
+        # GitHub deliver the same `push: tags:` event twice on a multi-
+        # tag push). The earlier `pypi_check` gate handles the common
+        # case; this turns the loser of any race into a no-op success
+        # instead of a noisy `400 File already exists` failure.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
 
       - name: Sign artifacts with Sigstore
         run: uvx sigstore sign dist/*.whl dist/*.tar.gz


### PR DESCRIPTION
## Summary

When v1.0.22 and v1.0.23 were pushed yesterday, each `git push origin vX.Y.Z` produced **two** runs of `release.yml` from a single event. One succeeded; the other failed loudly with `400 File already exists` from PyPI because both runs raced past the existing `pypi_check` gate before either had completed the upload.

`skip-existing: true` on the publish action turns the loser of that race into a no-op success instead of a noisy failure. Doesn't change happy-path behavior, doesn't replace the fast-path `pypi_check` step (which still short-circuits the docker pull when re-running an old release).

## Why not deduplicate the trigger instead?

The duplicate event is opaque — `gh run view` shows both runs are `event: push`, same `headBranch`, same workflow, same commit. Could be a webhook delivery quirk on multi-tag pushes (we did `git push origin v1.0.22 v1.0.23` atomically). `concurrency: cancel-in-progress: false` allows both to run. Switching to `cancel-in-progress: true` would mid-publish-cancel one of them, which is worse than letting the redundant one no-op.

## Test plan

- [ ] Next tag push: confirm both runs (if duplicate trigger persists) report `success`, not one `success` + one `failure`
- [ ] If a single run fires: behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)