### PR TITLE
Bump urllib3 floor to 2.7.0 (CVE-2026-44431, CVE-2026-44432)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ constraint-dependencies = [
   "pytest>=9.0.3",            # CVE-2025-71176: /tmp/pytest-of-* privilege escalation
   "python-multipart>=0.0.27", # CVE-2026-24486, CVE-2026-40347, CVE-2026-42561
   "requests>=2.33.0",     # CVE-2026-25645
-  "urllib3>=2.6.3",        # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441
+  "urllib3>=2.7.0",        # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441, CVE-2026-44431, CVE-2026-44432
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ constraints = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "requests", specifier = ">=2.33.0" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -1852,11 +1852,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `urllib3` floor in `pyproject.toml` from `>=2.6.3` to `>=2.7.0`; regenerates `uv.lock` (resolves `urllib3` 2.6.3 → 2.7.0).
- Closes two open Dependabot alerts and clears the failing `Dependency vulnerability audit` step in CI on \`main\`.

## Vulnerabilities

| Advisory | Severity | Affected | Patched | Description |
|---|---|---|---|---|
| [GHSA-qccp-gfcp-xxvc](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) (CVE-2026-44431) | High | `>=1.23, <2.7.0` | `2.7.0` | Sensitive headers (`Authorization`, `Cookie`, `Proxy-Authorization`) forwarded across origins on low-level redirects via `ProxyManager.connection_from_url().urlopen(..., assert_same_host=False)`. |
| [GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j) (CVE-2026-44432) | High | `>=2.6.0, <2.7.0` | `2.7.0` | Decompression-bomb safeguards bypassed on the streaming API for the second `HTTPResponse.read(amt=N)` with brotli, and for `HTTPResponse.drain_conn()` after a partial read. |

## Impact on this project
`urllib3` is a transitive dep through `requests`, `twine`, and `id`. We are unlikely to hit either bug path directly (we don't use `ProxyManager.connection_from_url().urlopen(assert_same_host=False)` and don't stream brotli responses from untrusted sources), but the floor pin closes the alerts and unblocks CI.

## Test plan
- [x] `uv lock --upgrade-package urllib3` → `urllib3 v2.6.3 -> v2.7.0`
- [x] `uv export --format requirements.txt --all-extras --no-editable --no-hashes --locked` produces `urllib3==2.7.0`
- [ ] CI \`build\` (pip-audit on requirements-ci.txt) goes green
- [ ] Dependabot alerts #6 and #7 auto-close on merge

## Release notes
No version bump. The fix will be folded into the next release's CHANGELOG section, matching the convention used for prior dep/workflow-only changes (#48, #51, #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)