### PR TITLE
Release v1.0.24: #57 policy_catalog + policy_runs_v2 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Bump `idna` floor to 3.15 (CVE-2026-45409)** — `idna.encode()` could consume disproportionate CPU on arbitrarily long inputs (`"٠" * N`, `"・" * N + "漢"`), enabling a DoS. The original 2024 fix (CVE-2024-3651) was incomplete; the 3.15 fix extends the early length-rejection to lesser-used per-label conversions and codec helpers. Constrained via `tool.uv.constraint-dependencies`. (Closes the same CVE that dependabot PR #58 addressed; that PR can be closed once this lands.)
 - **Bump `starlette` floor to 1.0.1 (PYSEC-2026-161)** — Starlette reconstructed the requested URL from the HTTP `Host` header without validating its value, allowing path injection into the host portion. Routing still uses the actual request path, so the inconsistency can lead to authentication bypass when auth depends on the reconstructed URL. Constrained via `tool.uv.constraint-dependencies` (alongside the existing `urllib3` floor). Affects the HTTP/SSE transport path; stdio transport is unaffected.
 
 ## [1.0.23] - 2026-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.24] - 2026-05-26
+
+### Fixed
+
+- **`policy_catalog` pagination stalled past page 2 at `limit=10` (#57.1)** — The wrapper over-fetched `min(limit*3, 500)` from `/policies` while passing the user's `page` directly, so the upstream offset was `page * (limit*3)` instead of `page * limit`. With `limit=10, page=3` against a 79-policy tenant the wrapper asked upstream for offset 90, got zero results, and still reported `has_more=true` (computed from the stats-derived total). The over-fetch and multi-page walk are gone: user `page` and `limit` now map 1:1 to upstream `/policies` params. A page may return fewer than `limit` active policies when some entries on that page are inactive and `include_inactive=False`, but the cursor remains correct and `has_more` reflects the actual upstream state.
+
+- **`policy_runs_v2` silently ignored `policy_name` and `policy_type` filters (#57.2)** — Verified directly against the upstream `/policy-history/policy-runs` endpoint: the policy-report-api list endpoint silently ignores **every** filter query parameter (`policy_name`, `policy_uuid`, `policy_type`, `start_time`, `end_time`, `result_status`) regardless of param casing (`snake_case`, `camelCase`, or short forms). The wrapper now applies filters client-side after fetching a large pool (up to 5000 runs, matching the schema cap). `policy_name` matches as a case-insensitive substring; `policy_type` and `policy_uuid` match exactly; `start_time`/`end_time` filter on `run_time`; `result_status` is reinterpreted against the aggregated counter model (include runs where the named counter — `success`/`failed`/`pending`/`not_included`/`remediation_not_applicable`/`blocked`, plus `failure`/`successful` aliases — is non-zero). When any filter is active, `metadata.filter_strategy="client_side"`, `metadata.filters_applied`, `metadata.upstream_pool_size`, `metadata.filtered_count`, and a `metadata.pagination` block (`page`, `limit`, `total_count`, `has_more`) describe the local pagination. Pagination is pass-through when no filter is set.
+
+- **`policy_catalog` truncated the `policies` array because `policy_stats` filled the budget (#57.3)** — Every response auto-fetched `/policystats` and embedded the full per-policy stats array under `data.policy_stats`. On the verified tenant, this 79-entry array consumed ~80% of the 4000-token response budget, leaving the `policies` array truncated to whatever fit. One real policy was invisible across ~20 catalog queries because the truncation always cut the alphabetical slot before reaching it. `policy_stats` is now opt-in via `include_stats=true` (default `false`); callers needing the per-policy compliance breakdown can use the dedicated `policy_compliance_stats` tool. `metadata.notes` includes a hint when stats are omitted. `total_policies_available` (derived from the stats payload) is now only present when `include_stats=true`.
+
+### Added
+
+- **Upstream HTTP observability** — The `AutomoxClient._request` path now emits one structured log line per upstream call with `method`, `path`, `status`, `latency_ms`, `correlation_id`, and (on 429/5xx) `retry_after`. Network failures (`httpx.RequestError`) log the exception type and elapsed time. The previous DEBUG line is retained. No retry policy is introduced; this is groundwork for diagnosing the intermittent multi-minute hangs reported in #57 issue 4.
+
 ## [1.0.23] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Upstream HTTP observability** — The `AutomoxClient._request` path now emits one structured log line per upstream call with `method`, `path`, `status`, `latency_ms`, `correlation_id`, and (on 429/5xx) `retry_after`. Network failures (`httpx.RequestError`) log the exception type and elapsed time. The previous DEBUG line is retained. No retry policy is introduced; this is groundwork for diagnosing the intermittent multi-minute hangs reported in #57 issue 4.
 
+### Security
+
+- **Bump `starlette` floor to 1.0.1 (PYSEC-2026-161)** — Starlette reconstructed the requested URL from the HTTP `Host` header without validating its value, allowing path injection into the host portion. Routing still uses the actual request path, so the inconsistency can lead to authentication bypass when auth depends on the reconstructed URL. Constrained via `tool.uv.constraint-dependencies` (alongside the existing `urllib3` floor). Affects the HTTP/SSE transport path; stdio transport is unaffected.
+
 ## [1.0.23] - 2026-05-07
 
 ### Fixed

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -57,7 +57,7 @@ Uses the Server Groups API v2 for structured device queries, saved searches, and
 - **`policy_health_overview`** - Summarize recent Automox policy activity. Omit `org_uuid` to let the server resolve it from `AUTOMOX_ORG_ID` / `AUTOMOX_ORG_UUID`.
 - **`policy_execution_timeline`** - Review recent executions for a policy.
 - **`policy_run_results`** - Fetch per-device results (stdout, stderr, exit codes) for a specific execution token returned by `policy_execution_timeline`.
-- **`policy_catalog`** - List Automox policies with type and status summaries. Supports `page` (0-indexed) and `limit` pagination; inspect `metadata.pagination.has_more`, read `metadata.notes`, and follow the optional `metadata.suggested_next_call` hint to keep fetching additional slices when needed.
+- **`policy_catalog`** - List Automox policies with type and status summaries. Supports `page` (0-indexed) and `limit` pagination — each user page maps 1:1 to the upstream `/policies` page so cursors are stable. Inspect `metadata.pagination.has_more`, read `metadata.notes`, and follow the optional `metadata.suggested_next_call` hint to continue paginating. Per-policy compliance stats are **opt-in** via `include_stats=true` (default off): the stats payload is large and was previously truncating the `policies` array. Use `policy_compliance_stats` for a focused breakdown.
 - **`policy_detail`** - Retrieve configuration and recent history for a policy.
 - **`policy_compliance_stats`** - Retrieve per-policy compliance statistics showing compliant vs. non-compliant device counts and compliance rates.
 - **`apply_policy_changes`** - Preview or submit structured policy create/update operations. Automatically normalizes helper fields (`filter_name`, `filter_names`) and friendly schedule blocks into Automox's expected payloads, ensuring required fields (e.g., `schedule_days`, `schedule_time`) are present before submission.
@@ -71,7 +71,7 @@ Uses the Server Groups API v2 for structured device queries, saved searches, and
 
 Richer policy execution reporting via the `/policy-history` API with UUID-based queries, time-range filtering, and aggregate views.
 
-- **`policy_runs_v2`** - List policy runs with time-range filtering, policy name/type filters, and result status filtering.
+- **`policy_runs_v2`** - List policy runs with time-range filtering, policy name/type filters, and result status filtering. Filters (`policy_name`, `policy_uuid`, `policy_type`, `start_time`, `end_time`, `result_status`) are applied **client-side** because the upstream policy-report-api silently ignores them; `policy_name` matches as a case-insensitive substring, and `result_status` is treated as "include runs where the named counter is non-zero" (success/failed/pending/not_included/remediation_not_applicable/blocked). When a filter is active, `metadata.filter_strategy="client_side"`, `metadata.filters_applied`, and `metadata.pagination` (with `total_count` / `has_more`) describe the local pagination state.
 - **`policy_run_count`** - Get aggregate policy execution counts. Optionally filter by number of days to look back.
 - **`policy_runs_by_policy`** - Get policy runs grouped by policy for cross-policy comparison.
 - **`policy_history_detail`** - Get policy history details by UUID, including run history and status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ constraint-dependencies = [
   "authlib>=1.6.11",      # CVE-2025-68158, GHSA-jj8c-mmj3-mmgv: CSRF in cache-backed state storage
   "cryptography>=46.0.6", # CVE-2026-26007, CVE-2026-34073
   "fastmcp>=3.2.0",       # CVE-2025-69196, CVE-2025-64340, CVE-2026-27124, GHSA-rcfx-77hg-w2wv
+  "idna>=3.15",           # CVE-2026-45409 (DoS via crafted IDN encoding; supersedes CVE-2024-3651 fix)
   "jaraco-context>=6.1.0",# CVE-2026-23949
   "mcp>=1.23.0",          # CVE-2025-66416
   "pygments>=2.20.0",     # CVE-2026-4539

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ constraint-dependencies = [
   "pytest>=9.0.3",            # CVE-2025-71176: /tmp/pytest-of-* privilege escalation
   "python-multipart>=0.0.27", # CVE-2026-24486, CVE-2026-40347, CVE-2026-42561
   "requests>=2.33.0",     # CVE-2026-25645
+  "starlette>=1.0.1",     # PYSEC-2026-161: Host-header path injection in URL reconstruction
   "urllib3>=2.7.0",        # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441, CVE-2026-44431, CVE-2026-44432
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.23"
+version = "1.0.24"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/client.py
+++ b/src/automox_mcp/client.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import time
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -242,6 +243,7 @@ class AutomoxClient:
             correlation_id,
         )
 
+        start = time.monotonic()
         try:
             response = await self._http.request(
                 method,
@@ -251,9 +253,51 @@ class AutomoxClient:
                 headers=merged_headers or None,
             )
         except httpx.RequestError as exc:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            logger.warning(
+                "upstream request failed: %s %s exc=%s:%s latency_ms=%.1f correlation_id=%s",
+                method,
+                path,
+                type(exc).__name__,
+                exc,
+                latency_ms,
+                correlation_id,
+            )
             raise AutomoxAPIError(
                 f"network error calling Automox API at {self._base_url_str}", status_code=0
             ) from exc
+
+        latency_ms = (time.monotonic() - start) * 1000.0
+        retry_after = response.headers.get("Retry-After")
+        log_extra = {
+            "method": method,
+            "path": path,
+            "status": response.status_code,
+            "latency_ms": round(latency_ms, 1),
+            "correlation_id": correlation_id,
+            "retry_after": retry_after,
+        }
+        if response.status_code >= 500 or response.status_code == 429:
+            logger.warning(
+                "upstream %s %s status=%d latency_ms=%.1f retry_after=%s correlation_id=%s",
+                method,
+                path,
+                response.status_code,
+                latency_ms,
+                retry_after,
+                correlation_id,
+                extra=log_extra,
+            )
+        else:
+            logger.info(
+                "upstream %s %s status=%d latency_ms=%.1f correlation_id=%s",
+                method,
+                path,
+                response.status_code,
+                latency_ms,
+                correlation_id,
+                extra=log_extra,
+            )
 
         if response.status_code == 429:
             payload = self._extract_error_payload(response)

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -387,6 +387,14 @@ class PolicySummaryParams(OrgIdContextMixin, ForbidExtraModel):
     include_inactive: bool | None = Field(
         False, description="Include inactive policies in the summary"
     )
+    include_stats: bool | None = Field(
+        False,
+        description=(
+            "Include the per-policy compliance stats array. Off by default — the "
+            "stats payload is large and previously caused response truncation that "
+            "hid policies. Use policy_compliance_stats for a focused breakdown."
+        ),
+    )
 
 
 class PolicyDetailParams(OrgIdContextMixin, ForbidExtraModel):

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -153,12 +153,14 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         limit: int | None = 20,
         page: int | None = 0,
         include_inactive: bool | None = False,
+        include_stats: bool | None = False,
         output_format: str | None = "json",
     ) -> dict[str, Any]:
         params = {
             "limit": limit,
             "page": page,
             "include_inactive": include_inactive,
+            "include_stats": include_stats,
         }
         result = await call_tool_workflow(
             client,

--- a/src/automox_mcp/workflows/policy.py
+++ b/src/automox_mcp/workflows/policy.py
@@ -17,9 +17,6 @@ from ..utils.response import require_org_id
 
 logger = logging.getLogger(__name__)
 
-# Safety cap on auto-pagination to prevent runaway loops.
-_MAX_PAGINATION_PAGES = 50
-
 
 def _take(sequence: Sequence[Any], limit: int) -> Sequence[Any]:
     """Take first N items from a sequence."""
@@ -276,117 +273,109 @@ async def summarize_policies(
     limit: int = 20,
     page: int | None = 0,
     include_inactive: bool = False,
+    include_stats: bool = False,
 ) -> dict[str, Any]:
-    """Provide a curated view of Automox policies."""
+    """Provide a curated view of Automox policies.
+
+    Pagination is pass-through to /policies (the user's `page` and `limit`
+    map 1:1 to the upstream params). A page may contain fewer than `limit`
+    active policies when some entries on that page are inactive and
+    `include_inactive=False`, but the cursor remains correct because each
+    user-page is exactly one upstream page.
+
+    `policy_stats` is opt-in (default off). The /policystats payload can
+    consume the bulk of the response token budget and previously caused
+    truncation of the `policies` array — set `include_stats=True` to
+    re-enable when the per-policy compliance breakdown is needed.
+    """
 
     resolved_org_id = require_org_id(client, org_id)
 
-    # When client-side filtering is active, over-fetch to avoid excessive API calls
-    fetch_limit = min(limit * 3, 500) if not include_inactive else limit
-    params = {"o": resolved_org_id}
-    if fetch_limit is not None:
-        params["limit"] = fetch_limit
+    params: dict[str, Any] = {"o": resolved_org_id}
+    if limit is not None:
+        params["limit"] = limit
     if page is not None:
         params["page"] = page
 
-    policies: list[Mapping[str, Any]] = []
-    current_page = page or 0
-    accumulated = 0
+    policies_response = await client.get("/policies", params=params)
+    page_results: list[Mapping[str, Any]] = []
+    if isinstance(policies_response, Sequence):
+        page_results = [item for item in policies_response if isinstance(item, Mapping)]
+
     type_counts: Counter[str] = Counter()
     status_counts: Counter[str] = Counter()
     filtered: list[Mapping[str, Any]] = []
     preview: list[Mapping[str, Any]] = []
 
-    for _page_num in range(_MAX_PAGINATION_PAGES):
-        policies_response = await client.get("/policies", params=params)
-        page_results: list[Mapping[str, Any]] = []
-        if isinstance(policies_response, Sequence):
-            page_results = [item for item in policies_response if isinstance(item, Mapping)]
-
-        policies.extend(page_results)
-        accumulated += len(page_results)
-
-        for policy_item in page_results:
-            if not isinstance(policy_item, Mapping):
-                continue
-            status_raw = str(policy_item.get("status") or "").lower()
-            active_flag = policy_item.get("active")
-            if active_flag is None:
-                active_flag = policy_item.get("enabled")
-            if active_flag is None:
-                active_flag = policy_item.get("is_active")
-            if active_flag is not None:
-                is_active = active_flag not in (False, 0, "false", "inactive")
-            else:
-                is_active = status_raw not in ("inactive", "disabled")
-            if not include_inactive and not is_active:
-                continue
-
-            policy_type = (
-                policy_item.get("policy_type_name")
-                or policy_item.get("policy_type")
-                or policy_item.get("type")
-                or "unknown"
-            ).lower()
-            if policy_type == "custom":
-                policy_type = "worklet"
-            type_counts[policy_type] += 1
-            status = _normalize_status(
-                policy_item.get("status") or ("active" if is_active else "inactive")
-            )
-            status_counts[status] += 1
-
-            filtered.append(policy_item)
-
-            if limit is None or len(preview) < limit:
-                preview.append(
-                    {
-                        "policy_id": policy_item.get("id"),
-                        "policy_uuid": policy_item.get("guid") or policy_item.get("uuid"),
-                        "name": policy_item.get("name"),
-                        "type": policy_type,
-                        "status": policy_item.get("status"),
-                        "targets": policy_item.get("target"),
-                        "server_groups": policy_item.get("server_groups"),
-                        "schedule_days": policy_item.get("schedule_days"),
-                        "schedule_time": policy_item.get("schedule_time"),
-                        "next_run": policy_item.get("next_run"),
-                    }
-                )
-
-        has_reached_preview_cap = limit is not None and len(preview) >= limit
-        next_page_index = current_page + 1
-        params["page"] = next_page_index
-        current_page = next_page_index
-
-        if has_reached_preview_cap or not page_results:
-            break
-
-    stats_params = {"o": resolved_org_id}
-    stats_data = await client.get("/policystats", params=stats_params)
-    total_available: int | None = None
-    if isinstance(stats_data, Sequence):
-        # Count unique policies represented in the stats payload as a proxy for total policies
-        policy_ids = {
-            item.get("policy_id")
-            for item in stats_data
-            if isinstance(item, Mapping) and item.get("policy_id") is not None
-        }
-        if policy_ids:
-            total_available = len(policy_ids)
+    for policy_item in page_results:
+        status_raw = str(policy_item.get("status") or "").lower()
+        active_flag = policy_item.get("active")
+        if active_flag is None:
+            active_flag = policy_item.get("enabled")
+        if active_flag is None:
+            active_flag = policy_item.get("is_active")
+        if active_flag is not None:
+            is_active = active_flag not in (False, 0, "false", "inactive")
         else:
-            total_available = len([item for item in stats_data if isinstance(item, Mapping)])
+            is_active = status_raw not in ("inactive", "disabled")
+        if not include_inactive and not is_active:
+            continue
 
-    returned_count_raw = len(policies)
-    returned_count = len(preview)
+        policy_type = (
+            policy_item.get("policy_type_name")
+            or policy_item.get("policy_type")
+            or policy_item.get("type")
+            or "unknown"
+        ).lower()
+        if policy_type == "custom":
+            policy_type = "worklet"
+        type_counts[policy_type] += 1
+        normalized = _normalize_status(
+            policy_item.get("status") or ("active" if is_active else "inactive")
+        )
+        status_counts[normalized] += 1
+
+        filtered.append(policy_item)
+        preview.append(
+            {
+                "policy_id": policy_item.get("id"),
+                "policy_uuid": policy_item.get("guid") or policy_item.get("uuid"),
+                "name": policy_item.get("name"),
+                "type": policy_type,
+                "status": policy_item.get("status"),
+                "targets": policy_item.get("target"),
+                "server_groups": policy_item.get("server_groups"),
+                "schedule_days": policy_item.get("schedule_days"),
+                "schedule_time": policy_item.get("schedule_time"),
+                "next_run": policy_item.get("next_run"),
+            }
+        )
+
+    stats_data: Any = None
+    total_available: int | None = None
+    if include_stats:
+        stats_data = await client.get("/policystats", params={"o": resolved_org_id})
+        if isinstance(stats_data, Sequence):
+            policy_ids = {
+                item.get("policy_id")
+                for item in stats_data
+                if isinstance(item, Mapping) and item.get("policy_id") is not None
+            }
+            if policy_ids:
+                total_available = len(policy_ids)
+            else:
+                total_available = len([item for item in stats_data if isinstance(item, Mapping)])
+
+    returned_count_raw = len(page_results)
     normalized_page = page if page is None else max(page, 0)
+
     if total_available is not None and limit is not None and normalized_page is not None:
         has_more = (normalized_page + 1) * limit < total_available
-    elif normalized_page is None:
-        # Auto-pagination already fetched everything; no more data
-        has_more = total_available is not None and returned_count_raw < total_available
     else:
+        # Without a stats-derived total, defer to the page itself: a full page
+        # implies there may be more; a short page is the last page.
         has_more = bool(limit is not None and returned_count_raw >= limit)
+
     next_page: int | None = None
     if has_more and normalized_page is not None:
         next_page = normalized_page + 1
@@ -398,7 +387,7 @@ async def summarize_policies(
         "page": normalized_page,
         "current_page": normalized_page,
         "limit": limit,
-        "returned_count": returned_count,
+        "returned_count": len(preview),
         "returned_count_raw": returned_count_raw,
         "has_more": bool(has_more),
         "next_page": next_page,
@@ -416,17 +405,19 @@ async def summarize_policies(
                 "page": normalized_page + 1,
                 "limit": limit,
                 "include_inactive": include_inactive,
+                "include_stats": include_stats,
             },
         }
 
-    data = {
+    data: dict[str, Any] = {
         "total_policies_considered": len(filtered),
         "policies_returned": len(preview),
         "policy_type_breakdown": dict(type_counts),
         "status_breakdown": dict(status_counts),
         "policies": preview,
-        "policy_stats": stats_data,
     }
+    if include_stats:
+        data["policy_stats"] = stats_data
     if total_available is not None:
         data["total_policies_available"] = total_available
 
@@ -436,6 +427,7 @@ async def summarize_policies(
         "requested_limit": limit,
         "requested_page": normalized_page,
         "include_inactive": include_inactive,
+        "include_stats": include_stats,
         "current_page": normalized_page,
         "limit": limit,
         "pagination": pagination,
@@ -445,14 +437,22 @@ async def summarize_policies(
     if suggested_next_call:
         metadata["suggested_next_call"] = suggested_next_call
     if has_more:
-        note = (
-            f"{returned_count} of {total_available} policies returned; follow "
-            f"metadata.suggested_next_call or increment page to continue pagination."
-            if total_available is not None
-            else "Partial results returned; follow metadata.suggested_next_call or "
-            "increment page to continue pagination."
-        )
+        if total_available is not None:
+            note = (
+                f"{len(preview)} of {total_available} policies returned; follow "
+                f"metadata.suggested_next_call or increment page to continue pagination."
+            )
+        else:
+            note = (
+                "Page is full; more results may be available. Call again with "
+                "`page=<next_page>` to continue."
+            )
         metadata["notes"] = [note]
+    if not include_stats:
+        metadata.setdefault("notes", []).append(
+            "policy_stats omitted (include_stats=false). Call policy_compliance_stats "
+            "for per-policy compliance breakdowns, or re-call with include_stats=true."
+        )
 
     return {
         "data": data,

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -67,6 +67,28 @@ def _summarize_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
     return entry
 
 
+# Max upstream window to fetch when a client-side filter is active. The
+# policy-report-api list endpoint silently ignores filter query params,
+# so we fetch a large window and filter locally. Matches the schema cap
+# on `limit` (PolicyRunsV2Params.limit le=5000).
+_FILTER_POOL_LIMIT = 5000
+
+# Map result_status aliases to the counter key on a run record. Each run
+# aggregates per-device outcomes; we treat the filter as "include runs
+# where this counter is non-zero" since the aggregated record has no
+# single-status field.
+_RESULT_STATUS_KEYS = {
+    "success": "success",
+    "successful": "success",
+    "failed": "failed",
+    "failure": "failed",
+    "pending": "pending",
+    "not_included": "not_included",
+    "remediation_not_applicable": "remediation_not_applicable",
+    "blocked": "blocked",
+}
+
+
 async def list_policy_runs_v2(
     client: AutomoxClient,
     *,
@@ -82,34 +104,35 @@ async def list_policy_runs_v2(
     page: int | None = None,
     limit: int | None = None,
 ) -> dict[str, Any]:
-    """List policy runs with optional filtering and time-range queries."""
+    """List policy runs with optional filtering and time-range queries.
+
+    The upstream policy-report-api list endpoint silently ignores filter
+    query parameters (verified live against `/policy-history/policy-runs`:
+    `policy_name`, `policy_type`, `policy_uuid`, `start_time`, `end_time`,
+    `result_status` all return identical unfiltered results regardless of
+    parameter casing). When any filter is set we fetch a large window
+    upstream and apply filters + pagination client-side.
+    """
     resolved_uuid = await resolve_org_uuid(
         client,
         explicit_uuid=org_uuid,
         org_id=org_id,
     )
 
-    # Policy History v2 requires org UUID as a query parameter.
-    # The policy-report-api uses snake_case query parameter names.
+    has_client_filter = bool(
+        policy_name or policy_uuid or policy_type or start_time or end_time or result_status
+    )
+
     params: dict[str, Any] = {"org": resolved_uuid}
-    if start_time:
-        params["start_time"] = start_time
-    if end_time:
-        params["end_time"] = end_time
-    if policy_name:
-        params["policy_name"] = policy_name
-    if policy_uuid:
-        params["policy_uuid"] = policy_uuid
-    if policy_type:
-        params["policy_type"] = policy_type
-    if result_status:
-        params["result_status"] = result_status
     if sort:
         params["sort"] = sort
-    if page is not None:
-        params["page"] = page
-    if limit is not None:
-        params["limit"] = limit
+    if has_client_filter:
+        params["limit"] = _FILTER_POOL_LIMIT
+    else:
+        if page is not None:
+            params["page"] = page
+        if limit is not None:
+            params["limit"] = limit
 
     response = await client.get(
         "/policy-history/policy-runs",
@@ -117,7 +140,87 @@ async def list_policy_runs_v2(
     )
 
     runs = _extract_list(response)
-    summaries = [_summarize_run(r) for r in runs]
+    fetched_total = len(runs)
+
+    metadata: dict[str, Any] = {"deprecated_endpoint": False}
+
+    if has_client_filter:
+        policy_uuid_str = str(policy_uuid) if policy_uuid else None
+        policy_type_lower = policy_type.lower() if policy_type else None
+        policy_name_lower = policy_name.lower() if policy_name else None
+        status_key = (
+            _RESULT_STATUS_KEYS.get(result_status.lower()) if result_status else None
+        )
+
+        def _match(run: Mapping[str, Any]) -> bool:
+            if policy_uuid_str and str(run.get("policy_uuid") or "") != policy_uuid_str:
+                return False
+            if policy_type_lower and (
+                str(run.get("policy_type") or "").lower() != policy_type_lower
+            ):
+                return False
+            if policy_name_lower and (
+                policy_name_lower not in str(run.get("policy_name") or "").lower()
+            ):
+                return False
+            run_time = str(run.get("run_time") or "")
+            if start_time and run_time < start_time:
+                return False
+            if end_time and run_time > end_time:
+                return False
+            if status_key is not None:
+                counter = run.get(status_key)
+                if not isinstance(counter, (int, float)) or counter <= 0:
+                    return False
+            return True
+
+        filtered_runs = [r for r in runs if isinstance(r, Mapping) and _match(r)]
+        filtered_total = len(filtered_runs)
+
+        effective_limit = limit if limit is not None else 50
+        effective_page = page if page is not None else 0
+        start_idx = effective_page * effective_limit
+        page_slice = filtered_runs[start_idx : start_idx + effective_limit]
+        has_more = (start_idx + effective_limit) < filtered_total
+
+        filters_applied = {
+            k: v
+            for k, v in {
+                "policy_name": policy_name,
+                "policy_uuid": policy_uuid_str,
+                "policy_type": policy_type,
+                "start_time": start_time,
+                "end_time": end_time,
+                "result_status": result_status,
+            }.items()
+            if v is not None
+        }
+
+        metadata["filter_strategy"] = "client_side"
+        metadata["filter_strategy_note"] = (
+            "The Automox policy-report-api list endpoint silently ignores filter "
+            "query parameters. Filters and pagination are applied client-side "
+            "after fetching the maximum upstream window."
+        )
+        metadata["filters_applied"] = filters_applied
+        metadata["upstream_pool_size"] = fetched_total
+        metadata["filtered_count"] = filtered_total
+        metadata["pagination"] = {
+            "page": effective_page,
+            "limit": effective_limit,
+            "total_count": filtered_total,
+            "has_more": has_more,
+        }
+        if fetched_total >= _FILTER_POOL_LIMIT:
+            metadata["upstream_pool_capped"] = True
+            metadata["pool_cap_note"] = (
+                f"Upstream returned {_FILTER_POOL_LIMIT} runs (max). If your tenant "
+                "has more, older runs may be excluded from the filter pool."
+            )
+
+        summaries = [_summarize_run(r) for r in page_slice]
+    else:
+        summaries = [_summarize_run(r) for r in runs]
 
     return {
         "data": {
@@ -125,7 +228,7 @@ async def list_policy_runs_v2(
             "total_runs": len(summaries),
             "runs": summaries,
         },
-        "metadata": {"deprecated_endpoint": False},
+        "metadata": metadata,
     }
 
 

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -148,9 +148,7 @@ async def list_policy_runs_v2(
         policy_uuid_str = str(policy_uuid) if policy_uuid else None
         policy_type_lower = policy_type.lower() if policy_type else None
         policy_name_lower = policy_name.lower() if policy_name else None
-        status_key = (
-            _RESULT_STATUS_KEYS.get(result_status.lower()) if result_status else None
-        )
+        status_key = _RESULT_STATUS_KEYS.get(result_status.lower()) if result_status else None
 
         def _match(run: Mapping[str, Any]) -> bool:
             if policy_uuid_str and str(run.get("policy_uuid") or "") != policy_uuid_str:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -14,6 +14,7 @@ class StubResponse:
         json_data: Any = None,
         text: str | None = None,
         json_error: bool = False,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.status_code = status_code
         self._json_data = json_data
@@ -26,6 +27,7 @@ class StubResponse:
         self.text = text or ""
         if not self.content and self.text:
             self.content = self.text.encode("utf-8")
+        self.headers: dict[str, str] = headers or {}
 
     def json(self) -> Any:
         if self._json_error:

--- a/tests/test_phase3_edge_cases.py
+++ b/tests/test_phase3_edge_cases.py
@@ -113,9 +113,11 @@ def _make_ph_client(**kwargs: Any) -> StubClient:
 
 @pytest.mark.asyncio
 async def test_policy_runs_v2_all_filters() -> None:
-    """Test all filter parameters are passed."""
+    """All filters are recorded as client-side filters; the upstream call only
+    sees `org`, `sort`, and a pool `limit` because the policy-report-api list
+    endpoint silently ignores filter query params (issue #57.2)."""
     client = _make_ph_client(get_responses={"/policy-history/policy-runs": [[]]})
-    await list_policy_runs_v2(
+    result = await list_policy_runs_v2(
         cast(AutomoxClient, client),
         org_id=42,
         start_time="2026-01-01",
@@ -129,10 +131,23 @@ async def test_policy_runs_v2_all_filters() -> None:
         limit=25,
     )
     params = client.calls[0][2]
-    assert params["start_time"] == "2026-01-01"
-    assert params["end_time"] == "2026-03-01"
-    assert params["policy_name"] == "Test"
-    assert params["policy_uuid"] == "pol-001"
+    assert "start_time" not in params
+    assert "end_time" not in params
+    assert "policy_name" not in params
+    assert "policy_uuid" not in params
+    assert "policy_type" not in params
+    assert "result_status" not in params
+    assert params["sort"] == "desc"
+    assert params["limit"] == 5000  # pool size for client-side filtering
+    assert result["metadata"]["filter_strategy"] == "client_side"
+    assert result["metadata"]["filters_applied"] == {
+        "start_time": "2026-01-01",
+        "end_time": "2026-03-01",
+        "policy_name": "Test",
+        "policy_uuid": "pol-001",
+        "policy_type": "patch",
+        "result_status": "failure",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflows_policy.py
+++ b/tests/test_workflows_policy.py
@@ -855,6 +855,74 @@ async def test_summarize_policies_is_active_from_status_raw() -> None:
 
 
 @pytest.mark.asyncio
+async def test_summarize_policies_pagination_is_passthrough() -> None:
+    """Issue #57.1: page/limit must map 1:1 to upstream /policies params.
+
+    The previous implementation over-fetched `limit*3` from /policies, which
+    broke the offset for any user_page>0 once the upstream cap was exceeded.
+    """
+    stub = StubClient(get_responses={"/policies": [[]]})
+    stub.org_id = 42  # type: ignore[attr-defined]
+
+    await summarize_policies(
+        cast(AutomoxClient, stub),
+        org_id=42,
+        limit=10,
+        page=3,
+    )
+
+    # Exactly one call to /policies, with the user's page/limit straight through.
+    policy_calls = [c for c in stub.calls if c[1] == "/policies"]
+    assert len(policy_calls) == 1
+    params = policy_calls[0][2]
+    assert params["limit"] == 10
+    assert params["page"] == 3
+
+
+@pytest.mark.asyncio
+async def test_summarize_policies_skips_stats_by_default() -> None:
+    """Issue #57.3: policy_stats array was filling the token budget and
+    truncating the `policies` array. Stats are now opt-in."""
+    policy = {"id": 1, "name": "P", "policy_type_name": "patch", "status": "active"}
+    stub = StubClient(get_responses={"/policies": [[policy]]})
+    stub.org_id = 42  # type: ignore[attr-defined]
+
+    result = await summarize_policies(
+        cast(AutomoxClient, stub),
+        org_id=42,
+        limit=20,
+    )
+
+    # /policystats must NOT be fetched by default.
+    assert not any(c[1] == "/policystats" for c in stub.calls)
+    assert "policy_stats" not in result["data"]
+    assert result["metadata"]["include_stats"] is False
+
+
+@pytest.mark.asyncio
+async def test_summarize_policies_includes_stats_when_requested() -> None:
+    policy = {"id": 1, "name": "P", "policy_type_name": "patch", "status": "active"}
+    stats = [{"policy_id": 1, "compliant_count": 5, "noncompliant_count": 2}]
+    stub = StubClient(
+        get_responses={
+            "/policies": [[policy]],
+            "/policystats": [stats],
+        }
+    )
+    stub.org_id = 42  # type: ignore[attr-defined]
+
+    result = await summarize_policies(
+        cast(AutomoxClient, stub),
+        org_id=42,
+        limit=20,
+        include_stats=True,
+    )
+
+    assert result["data"]["policy_stats"] == stats
+    assert result["data"]["total_policies_available"] == 1
+
+
+@pytest.mark.asyncio
 async def test_summarize_policies_custom_type_normalized_to_worklet() -> None:
     policy = {
         "id": 4,

--- a/tests/test_workflows_policy_history.py
+++ b/tests/test_workflows_policy_history.py
@@ -89,22 +89,106 @@ async def test_list_runs_returns_summaries() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_runs_passes_filters() -> None:
-    client = _make_client(get_responses={"/policy-history/policy-runs": [[]]})
+async def test_list_runs_filters_client_side() -> None:
+    """The upstream policy-report-api silently ignores filter query params,
+    so the workflow fetches a large window and filters locally. The HTTP
+    call must NOT pass the filter params (they would be noise on the
+    wire), and the upstream `limit` is bumped to the pool size."""
+    client = _make_client(get_responses={"/policy-history/policy-runs": [_POLICY_RUNS]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        policy_type="patch",
+        limit=10,
+        page=0,
+    )
+
+    _, _path, params = client.calls[0]
+    # Filter params must not be forwarded upstream.
+    assert "policy_type" not in params
+    assert "policy_name" not in params
+    assert "result_status" not in params
+    assert "start_time" not in params
+    # Upstream is asked for the full pool when filtering client-side.
+    assert params["limit"] == 5000
+    # Only the patch run survives the filter.
+    runs = result["data"]["runs"]
+    assert len(runs) == 1
+    assert runs[0]["policy_type"] == "patch"
+    assert result["metadata"]["filter_strategy"] == "client_side"
+    assert result["metadata"]["filters_applied"] == {"policy_type": "patch"}
+    assert result["metadata"]["filtered_count"] == 1
+    assert result["metadata"]["pagination"]["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_runs_passes_pagination_when_unfiltered() -> None:
+    """Without filters, upstream pagination is honored — page/limit pass through."""
+    client = _make_client(get_responses={"/policy-history/policy-runs": [_POLICY_RUNS]})
     await list_policy_runs_v2(
         cast(AutomoxClient, client),
         org_id=42,
-        start_time="2026-01-01",
-        policy_type="patch",
-        result_status="failure",
-        limit=10,
+        page=2,
+        limit=25,
     )
 
-    _, path, params = client.calls[0]
-    assert params["start_time"] == "2026-01-01"
-    assert params["policy_type"] == "patch"
-    assert params["result_status"] == "failure"
-    assert params["limit"] == 10
+    _, _path, params = client.calls[0]
+    assert params["page"] == 2
+    assert params["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_list_runs_filters_by_policy_name_substring() -> None:
+    runs = [
+        {"policy_uuid": "p1", "policy_name": "Patch All Devices", "policy_type": "patch"},
+        {"policy_uuid": "p2", "policy_name": "Custom Worklet", "policy_type": "custom"},
+        {"policy_uuid": "p3", "policy_name": "Patch Linux", "policy_type": "patch"},
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        policy_name="patch",
+    )
+    names = sorted(r["policy_name"] for r in result["data"]["runs"])
+    assert names == ["Patch All Devices", "Patch Linux"]
+
+
+@pytest.mark.asyncio
+async def test_list_runs_filters_result_status_by_counter() -> None:
+    """result_status="failed" should include only runs with non-zero `failed`."""
+    runs = [
+        {"policy_uuid": "p1", "policy_name": "A", "failed": 0, "success": 10},
+        {"policy_uuid": "p2", "policy_name": "B", "failed": 3, "success": 7},
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        result_status="failed",
+    )
+    assert len(result["data"]["runs"]) == 1
+    assert result["data"]["runs"][0]["policy_uuid"] == "p2"
+
+
+@pytest.mark.asyncio
+async def test_list_runs_client_pagination_slices_filtered_results() -> None:
+    runs = [
+        {"policy_uuid": f"p{i}", "policy_name": f"name-{i}", "policy_type": "custom"}
+        for i in range(25)
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        policy_type="custom",
+        limit=10,
+        page=1,
+    )
+    returned = [r["policy_uuid"] for r in result["data"]["runs"]]
+    assert returned == [f"p{i}" for i in range(10, 20)]
+    pagination = result["metadata"]["pagination"]
+    assert pagination == {"page": 1, "limit": 10, "total_count": 25, "has_more": True}
 
 
 @pytest.mark.asyncio

--- a/tests/verify_reported_bugs.py
+++ b/tests/verify_reported_bugs.py
@@ -687,7 +687,11 @@ async def main() -> int:
         (14, "patch_tuesday truncation lie (total_available != array)", case_14_truncation_lie),
         (57, "policy_catalog pagination past page 2 (#57.1)", case_57_1_policy_catalog_pagination),
         (57, "policy_runs_v2 filter ignored (#57.2)", case_57_2_policy_runs_v2_filter),
-        (57, "policy_stats hides policies via truncation (#57.3)", case_57_3_policy_stats_hides_policies),
+        (
+            57,
+            "policy_stats hides policies via truncation (#57.3)",
+            case_57_3_policy_stats_hides_policies,
+        ),
     ]
 
     results: list[tuple[int, str, str]] = []

--- a/tests/verify_reported_bugs.py
+++ b/tests/verify_reported_bugs.py
@@ -537,10 +537,7 @@ async def case_57_1_policy_catalog_pagination(session: ClientSession) -> str:
         return "VERIFIED"
     status(
         "NOT_REPRODUCED",
-        (
-            f"page=3 returned={p3_returned} has_more={p3_has_more} "
-            f"total_available={total_available}"
-        ),
+        (f"page=3 returned={p3_returned} has_more={p3_has_more} total_available={total_available}"),
         GREEN,
     )
     return "NOT_REPRODUCED"

--- a/tests/verify_reported_bugs.py
+++ b/tests/verify_reported_bugs.py
@@ -486,6 +486,143 @@ async def case_14_truncation_lie(session: ClientSession) -> str:
     return "NOT_REPRODUCED"
 
 
+async def case_57_1_policy_catalog_pagination(session: ClientSession) -> str:
+    """Reported (#57.1): policy_catalog page>=3 at limit=10 returned 0 with has_more=true.
+
+    Root cause: the workflow over-fetched `limit*3` from /policies while
+    passing the user's `page` directly, so user_page=3 became upstream
+    offset=90 instead of 30.
+
+    Verification strategy: ask for the same total population across pages
+    1..3 and confirm each page returns distinct, non-empty results when
+    the tenant has >30 policies. If page 3 returns 0 policies while
+    has_more is true, the cursor is stalled (VERIFIED). Use
+    include_stats=true once on page 0 to capture total_available.
+    """
+    _, p0, _ = await call_tool(
+        session, "policy_catalog", {"limit": 10, "page": 0, "include_stats": True}
+    )
+    if not isinstance(p0, dict):
+        status("AMBIGUOUS", "page 0 not a dict", YELLOW)
+        return "AMBIGUOUS"
+    p0_data = p0.get("data") or {}
+    total_available = p0_data.get("total_policies_available")
+    if not isinstance(total_available, int) or total_available <= 30:
+        status(
+            "AMBIGUOUS",
+            f"tenant has too few policies to test (total_available={total_available!r})",
+            YELLOW,
+        )
+        return "AMBIGUOUS"
+
+    _, p3, raw3 = await call_tool(session, "policy_catalog", {"limit": 10, "page": 3})
+    if not isinstance(p3, dict):
+        status("AMBIGUOUS", f"page=3 not a dict — {raw3[:200]}", YELLOW)
+        return "AMBIGUOUS"
+    p3_data = p3.get("data") or {}
+    p3_meta = p3.get("metadata") or {}
+    p3_returned = p3_data.get("policies_returned") or 0
+    p3_has_more = (p3_meta.get("pagination") or {}).get("has_more")
+
+    # Bug shape: page=3 at limit=10 returns 0 policies but claims has_more=true.
+    if p3_returned == 0 and p3_has_more:
+        status(
+            "VERIFIED",
+            (
+                f"page=3 limit=10 returned 0 policies but has_more=true "
+                f"(total_available={total_available})"
+            ),
+            RED,
+        )
+        return "VERIFIED"
+    status(
+        "NOT_REPRODUCED",
+        (
+            f"page=3 returned={p3_returned} has_more={p3_has_more} "
+            f"total_available={total_available}"
+        ),
+        GREEN,
+    )
+    return "NOT_REPRODUCED"
+
+
+async def case_57_2_policy_runs_v2_filter(session: ClientSession) -> str:
+    """Reported (#57.2): policy_runs_v2 silently ignores policy_name and policy_type.
+
+    Both filters accepted by the schema but the upstream call returns
+    unfiltered runs (different policy_type than requested, etc.).
+    """
+    # Use a `policy_type=custom` filter — if filter works, every returned run
+    # should have policy_type=custom. If returned runs include other types
+    # (e.g. "patch"), the filter was ignored.
+    _, parsed, raw = await call_tool(
+        session,
+        "policy_runs_v2",
+        {"policy_type": "custom", "limit": 20},
+    )
+    if not isinstance(parsed, dict):
+        status("AMBIGUOUS", f"unexpected shape — {raw[:200]}", YELLOW)
+        return "AMBIGUOUS"
+    data = parsed.get("data") or {}
+    runs = data.get("runs") or []
+    if not isinstance(runs, list) or not runs:
+        status("AMBIGUOUS", f"no runs returned — cannot test filter (runs={runs!r})", YELLOW)
+        return "AMBIGUOUS"
+    types_seen = {r.get("policy_type") for r in runs if isinstance(r, dict)}
+    non_custom = types_seen - {"custom"}
+    if non_custom:
+        status(
+            "VERIFIED",
+            (
+                f"policy_type=custom filter ignored — returned runs include types: "
+                f"{sorted(t for t in non_custom if t)} (n={len(runs)})"
+            ),
+            RED,
+        )
+        return "VERIFIED"
+    status(
+        "NOT_REPRODUCED",
+        f"all {len(runs)} runs have policy_type=custom — filter honored",
+        GREEN,
+    )
+    return "NOT_REPRODUCED"
+
+
+async def case_57_3_policy_stats_hides_policies(session: ClientSession) -> str:
+    """Reported (#57.3): policy_stats array consumes the token budget and
+    truncates the `policies` array, hiding policies that exist in the org.
+    """
+    _, parsed, raw = await call_tool(session, "policy_catalog", {"limit": 10, "page": 0})
+    if not isinstance(parsed, dict):
+        status("AMBIGUOUS", f"unexpected shape — {raw[:200]}", YELLOW)
+        return "AMBIGUOUS"
+    metadata = parsed.get("metadata") or {}
+    truncations = metadata.get("truncations") or {}
+    policies_trunc = truncations.get("policies") if isinstance(truncations, dict) else None
+    stats_trunc = truncations.get("policy_stats") if isinstance(truncations, dict) else None
+    # Bug shape: policies array gets truncated below the requested limit
+    # because policy_stats consumes most of the budget.
+    if isinstance(policies_trunc, dict):
+        p_total = policies_trunc.get("total")
+        p_returned = policies_trunc.get("returned")
+        if isinstance(p_total, int) and isinstance(p_returned, int) and p_returned < p_total:
+            status(
+                "VERIFIED",
+                (
+                    f"policies truncated: total={p_total} returned={p_returned}; "
+                    f"policy_stats truncation={stats_trunc}"
+                ),
+                RED,
+            )
+            return "VERIFIED"
+    status(
+        "NOT_REPRODUCED",
+        f"policies not truncated below request (truncations={truncations})",
+        GREEN,
+    )
+    return "NOT_REPRODUCED"
+
+
 async def case_5_devices_needing_attention(session: ClientSession) -> str:
     """Reported: returns null for policy_status, pending_patches, last_check_in,
     server_group_id."""
@@ -548,6 +685,9 @@ async def main() -> int:
         (8, "audit actor cursor advance on miss", case_8_audit_actor_cursor),
         (9, "policy_health_overview sample mismatch", case_9_policy_health_sample),
         (14, "patch_tuesday truncation lie (total_available != array)", case_14_truncation_lie),
+        (57, "policy_catalog pagination past page 2 (#57.1)", case_57_1_policy_catalog_pagination),
+        (57, "policy_runs_v2 filter ignored (#57.2)", case_57_2_policy_runs_v2_filter),
+        (57, "policy_stats hides policies via truncation (#57.3)", case_57_3_policy_stats_hides_policies),
     ]
 
     results: list[tuple[int, str, str]] = []

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ constraints = [
     { name = "authlib", specifier = ">=1.6.11" },
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -691,11 +692,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ constraints = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "requests", specifier = ">=2.33.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -1735,15 +1736,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.23"
+version = "1.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Closes #57. Three confirmed bugs reproduced against the live tenant via `tests/verify_reported_bugs.py`, fixed, and re-verified. Plus groundwork observability for the intermittent-hangs sub-issue.

- **#57.1 `policy_catalog` pagination stalled past page 2 at `limit=10`.** Over-fetched `min(limit*3, 500)` from `/policies` while passing the user's `page` directly — upstream offset was `page*(limit*3)` instead of `page*limit`. With `limit=10, page=3` against a 79-policy tenant the wrapper asked for offset 90, got zero results, and still reported `has_more=true`. Dropped the over-fetch and multi-page walk; user `page`/`limit` now map 1:1 to upstream params.
- **#57.2 `policy_runs_v2` silently ignored every filter parameter.** Verified directly against `/policy-history/policy-runs`: the policy-report-api list endpoint ignores `policy_name`, `policy_uuid`, `policy_type`, `start_time`, `end_time`, `result_status` regardless of param casing (snake_case, camelCase, short forms). Filters now apply client-side after fetching a 5000-run pool. `policy_name` matches case-insensitive substring; `result_status` is reinterpreted against the aggregated counter model (include runs where the named counter — `success`/`failed`/`pending`/`not_included`/`remediation_not_applicable`/`blocked`, plus `failure`/`successful` aliases — is non-zero). When any filter is active, `metadata.filter_strategy="client_side"`, `metadata.filters_applied`, `metadata.upstream_pool_size`, `metadata.filtered_count`, and `metadata.pagination` describe the local pagination state. Pagination is pass-through when no filter is set.
- **#57.3 `policy_stats` truncated the `policies` array by filling the token budget.** The 79-entry `policy_stats` array consumed ~80% of the 4000-token budget, leaving the `policies` array truncated to whatever fit — one real policy was invisible across ~20 catalog queries because truncation always cut before its alphabetical slot. Stats are now opt-in via `include_stats=true` (default `false`). Use `policy_compliance_stats` for the dedicated breakdown.
- **#57.4 (groundwork) upstream HTTP observability.** `AutomoxClient._request` now emits one structured log line per upstream call with `method`, `path`, `status`, `latency_ms`, `correlation_id`, and `retry_after` on 429/5xx. Network failures log exception type and elapsed time. No retry policy is introduced; this is observability for diagnosing the intermittent multi-minute hangs reported in #57.

Bumps version to `1.0.24`, updates `CHANGELOG.md` and `docs/tool-reference.md` accordingly.

## Test plan

- [x] `tests/verify_reported_bugs.py` against the live tenant (`~/automox/.env`): all three #57 cases flipped from `VERIFIED` → `NOT_REPRODUCED`.
- [x] `uv run pytest` — 1070 passed.
- [x] Manual probe of the new `upstream GET /path status=… latency_ms=…` log line on a live request.
- [ ] (Reviewer) Spot-check on a multi-tenant install: `policy_runs_v2` with a `policy_name` substring filter against a tenant where multiple policies share a name prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)