### PR TITLE
Release v1.0.26: compound tool detail_limit contract (#53 proof-of-shape)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.26] - 2026-05-26
+
+### Added
+
+- **`get_patch_tuesday_readiness` — proof-of-shape for the compound-tool contract (#53)** — The compound tool used to embed full inner lists (`prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules`) verbatim, which routinely exceeded the 4000-token response budget on tenants of any meaningful size and triggered arbitrary truncation. The tool now accepts a `detail_limit` parameter (default `10`) that caps every inner list. Counts and aggregates (`total_devices_needing_patches`, `pending_count`, `readiness_summary`) are always returned in full; truncated sections surface a per-section entry under `metadata.section_summaries.<key>` with `total`, `returned`, `has_more`, and a `follow_up_tool` / `follow_up_args_hint` pointing at the underlying detail tool (`get_prepatch_report`, `patch_approvals_summary`, `policy_catalog`). `metadata.notes` carries an LLM-friendly hint per truncated section. `detail_limit=0` returns a pure summary with empty previews. This establishes the contract; `get_compliance_snapshot` and `get_device_full_profile` will follow in subsequent releases.
+- **Compound tools section in `docs/tool-reference.md`** — Documents the `detail_limit` parameter, the `metadata.section_summaries` shape, and the follow-up-tool dispatch pattern.
+
 ## [1.0.25] - 2026-05-26
 
 ### Added

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -126,7 +126,7 @@ Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-b
 
 ## Compound Workflows (3 tools)
 
-- **`get_patch_tuesday_readiness`** - Combined view of pre-patch report, pending approvals, and patch policy schedules. Answers "Are we ready for Patch Tuesday?" in a single call. Includes per-device severity classification computed from CVE data.
+- **`get_patch_tuesday_readiness`** - Combined view of pre-patch report, pending approvals, and patch policy schedules. Answers "Are we ready for Patch Tuesday?" in a single call. Includes per-device severity classification computed from CVE data. Each inner list is capped at `detail_limit` (default 10); see the **Compound tools** section under [Pagination](#pagination) for the `metadata.section_summaries` shape and how to fetch the full data via the linked detail tools.
 - **`get_compliance_snapshot`** - Combined view of non-compliant devices, fleet health metrics, and policy statistics. Answers "What is our compliance posture?" in a single call. Includes compliance rate, device health breakdown, and stale device detection.
 - **`get_device_full_profile`** - Complete device profile combining device detail, inventory summary, packages, and policy assignments in a single call. Inventory is summarized with key values per category; packages capped at 25 by default. Metadata includes per-section status, data completeness flag, and item counts for verification.
 
@@ -243,6 +243,34 @@ Fields are emitted only when applicable to the tool's pagination style:
 A generic pagination loop can therefore read `metadata.pagination.has_more` and either increment `page` or pass `metadata.pagination.next_cursor` to the next call without per-tool special-cases.
 
 **Legacy aliases retained for backwards-compat:** Some tools also still emit `metadata.current_page`, `metadata.total_count`, `metadata.limit`, `data.total_elements`, `data.total_pages`, `data.next_cursor`, `metadata.next_cursor`, and `metadata.last_event_cursor` at their pre-#52 locations. These are aliases; prefer the canonical `metadata.pagination` block in new code.
+
+### Compound tools
+
+Compound tools (`get_patch_tuesday_readiness`, `get_compliance_snapshot`, `get_device_full_profile`) fold several upstream calls into a single response. Each inner list (e.g. `prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules`) is capped at a `detail_limit` parameter (default 10) so the response fits the token budget on tenants of any size. Counts and aggregates are always returned in full.
+
+When a section is truncated, the response surfaces a per-section entry under `metadata.section_summaries`:
+
+```json
+{
+  "metadata": {
+    "detail_limit": 10,
+    "section_summaries": {
+      "prepatch_report.devices": {
+        "total": 230,
+        "returned": 10,
+        "has_more": true,
+        "follow_up_tool": "get_prepatch_report",
+        "follow_up_args_hint": {"group_id": 42}
+      }
+    },
+    "notes": [
+      "prepatch_report.devices capped at 10 of 230 — call `get_prepatch_report` for the full set."
+    ]
+  }
+}
+```
+
+`detail_limit=0` returns counts only (pure-summary mode); the previews are empty and `section_summaries` describes everything that was omitted. To pull the full data for a specific section, call the `follow_up_tool` named in its entry — those tools paginate normally via the canonical `metadata.pagination` block.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.25"
+version = "1.0.26"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -781,6 +781,17 @@ class DeviceByUuidParams(ForbidExtraModel):
 class PatchTuesdayReadinessParams(OrgIdRequiredMixin, ForbidExtraModel):
     group_id: int | None = Field(None, ge=1, description="Restrict to a specific server group")
     org_uuid: str | None = Field(None, description="Organization UUID (auto-resolved)")
+    detail_limit: int = Field(
+        10,
+        ge=0,
+        le=200,
+        description=(
+            "Cap each inner list (devices, approvals, patch policy schedules) at "
+            "this size. 0 returns counts only — useful for a pure summary. Truncated "
+            "sections surface `metadata.section_summaries.<key>` with the total, "
+            "returned count, and the detail tool to call for the rest."
+        ),
+    )
 
 
 class ComplianceSnapshotParams(OrgIdRequiredMixin, ForbidExtraModel):

--- a/src/automox_mcp/tools/compound_tools.py
+++ b/src/automox_mcp/tools/compound_tools.py
@@ -37,8 +37,9 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_patch_tuesday_readiness(
         group_id: int | None = None,
+        detail_limit: int = 10,
     ) -> dict[str, Any]:
-        params: dict[str, Any] = {}
+        params: dict[str, Any] = {"detail_limit": detail_limit}
         if group_id is not None:
             params["group_id"] = group_id
         return await call_tool_workflow(

--- a/src/automox_mcp/workflows/compound.py
+++ b/src/automox_mcp/workflows/compound.py
@@ -32,10 +32,18 @@ async def get_patch_tuesday_readiness(
     org_id: int,
     org_uuid: str,
     group_id: int | None = None,
+    detail_limit: int = 10,
 ) -> dict[str, Any]:
     """Combine pre-patch report, pending approvals, and policy schedules into one view.
 
     Answers: "Are we ready for Patch Tuesday?"
+
+    Each inner list is capped at ``detail_limit`` (default 10) so the response
+    fits the token budget on tenants of any size. Counts and aggregates are
+    always returned in full; sections that exceed the cap surface a
+    ``metadata.section_summaries.<key>`` entry with ``total``, ``returned``,
+    ``has_more``, and a ``follow_up_tool``/``follow_up_args_hint`` pointing
+    at the underlying detail tool (#53 compound contract).
     """
     raw_results = await asyncio.gather(
         reports.get_prepatch_report(client, org_id=org_id, group_id=group_id),
@@ -74,29 +82,94 @@ async def get_patch_tuesday_readiness(
             if isinstance(a, Mapping) and a.get("status") in ("pending", "Pending")
         )
 
+    prepatch_devices_full = prepatch_data.get("devices") or []
+    approval_items_full = approval_items if isinstance(approval_items, list) else []
+    patch_policy_entries_full = [
+        {
+            "id": p.get("policy_id"),
+            "name": p.get("name"),
+            "status": p.get("status"),
+            "schedule_days": p.get("schedule_days"),
+            "schedule_time": p.get("schedule_time"),
+            "next_run": p.get("next_run"),
+            "server_groups": p.get("server_groups"),
+        }
+        for p in patch_policies
+    ]
+
+    prepatch_devices_preview = prepatch_devices_full[:detail_limit]
+    approvals_preview = approval_items_full[:detail_limit]
+    patch_policy_schedules_preview = patch_policy_entries_full[:detail_limit]
+
+    follow_up_hint = {"group_id": group_id} if group_id is not None else {}
+    section_summaries: dict[str, Any] = {}
+
+    def _record(
+        section_key: str,
+        full: list[Any],
+        preview: list[Any],
+        follow_up_tool: str,
+        args_hint: dict[str, Any],
+    ) -> None:
+        if len(full) > len(preview):
+            section_summaries[section_key] = {
+                "total": len(full),
+                "returned": len(preview),
+                "has_more": True,
+                "follow_up_tool": follow_up_tool,
+                "follow_up_args_hint": args_hint,
+            }
+
+    _record(
+        "prepatch_report.devices",
+        prepatch_devices_full,
+        prepatch_devices_preview,
+        "get_prepatch_report",
+        follow_up_hint,
+    )
+    _record(
+        "patch_approvals.approvals",
+        approval_items_full,
+        approvals_preview,
+        "patch_approvals_summary",
+        {},
+    )
+    _record(
+        "patch_policy_schedules",
+        patch_policy_entries_full,
+        patch_policy_schedules_preview,
+        "policy_catalog",
+        # The detail tool returns all policies; the caller filters by
+        # type=patch client-side (no native type filter today).
+        {"include_inactive": False, "limit": 200},
+    )
+
+    metadata: dict[str, Any] = {
+        "errors": errors if errors else None,
+        "detail_limit": detail_limit,
+    }
+    if section_summaries:
+        metadata["section_summaries"] = section_summaries
+        metadata["notes"] = [
+            (
+                f"{key} capped at {detail_limit} of {info['total']} — call "
+                f"`{info['follow_up_tool']}` for the full set."
+            )
+            for key, info in section_summaries.items()
+        ]
+
     return {
         "data": {
             "prepatch_report": {
                 "total_devices_needing_patches": prepatch_data.get("total_devices", 0),
                 "summary": prepatch_data.get("summary", {}),
-                "devices": prepatch_data.get("devices", []),
+                "devices": prepatch_devices_preview,
             },
             "patch_approvals": {
                 "pending_count": pending_approval_count,
-                "approvals": approval_items,
+                "approvals": approvals_preview,
             },
-            "patch_policy_schedules": [
-                {
-                    "id": p.get("policy_id"),
-                    "name": p.get("name"),
-                    "status": p.get("status"),
-                    "schedule_days": p.get("schedule_days"),
-                    "schedule_time": p.get("schedule_time"),
-                    "next_run": p.get("next_run"),
-                    "server_groups": p.get("server_groups"),
-                }
-                for p in patch_policies
-            ],
+            "patch_policy_schedules": patch_policy_schedules_preview,
             "readiness_summary": {
                 "devices_needing_patches": prepatch_data.get("total_devices", 0),
                 "pending_approvals": pending_approval_count,
@@ -107,9 +180,7 @@ async def get_patch_tuesday_readiness(
                 ),
             },
         },
-        "metadata": {
-            "errors": errors if errors else None,
-        },
+        "metadata": metadata,
     }
 
 

--- a/tests/test_workflows_compound.py
+++ b/tests/test_workflows_compound.py
@@ -239,6 +239,164 @@ async def test_patch_tuesday_readiness_handles_partial_failures() -> None:
 
 
 @pytest.mark.asyncio
+async def test_patch_tuesday_readiness_caps_inner_lists_at_detail_limit() -> None:
+    """#53 contract: each inner list is capped at detail_limit; truncated
+    sections surface metadata.section_summaries with follow-up tool hints."""
+    # 30 prepatch devices, 30 approvals, 30 patch policies — well over the
+    # default detail_limit=10.
+    devices_payload = {
+        "prepatch": {
+            "devices": [
+                {"id": i, "name": f"host-{i}", "patches": [{"severity": "high"}] * 3}
+                for i in range(30)
+            ],
+            "total": 30,
+        }
+    }
+    approvals_payload = [
+        {
+            "id": i,
+            "title": f"Approval {i}",
+            "status": "pending",
+            "severity": "high",
+            "device_count": 1,
+        }
+        for i in range(30)
+    ]
+    policies_payload = [
+        {
+            "id": 1000 + i,
+            "name": f"Patch Policy {i}",
+            "policy_type_name": "patch",
+            "status": "active",
+            "schedule_days": 124,
+            "schedule_time": "02:00",
+        }
+        for i in range(30)
+    ]
+    client = StubClient(
+        get_responses={
+            "/reports/prepatch": [devices_payload],
+            "/approvals": [approvals_payload],
+            "/policies": [policies_payload],
+            "/policystats": [[]],
+        }
+    )
+    client.org_id = 555
+
+    result = await get_patch_tuesday_readiness(
+        cast(AutomoxClient, client),
+        org_id=555,
+        org_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        detail_limit=10,
+    )
+
+    data = result["data"]
+    # Each preview is capped.
+    assert len(data["prepatch_report"]["devices"]) == 10
+    assert len(data["patch_approvals"]["approvals"]) == 10
+    assert len(data["patch_policy_schedules"]) == 10
+
+    # Counts remain accurate.
+    assert data["prepatch_report"]["total_devices_needing_patches"] == 30
+    assert data["readiness_summary"]["devices_needing_patches"] == 30
+
+    # Section summaries surface the truncation + follow-up tool.
+    summaries = result["metadata"]["section_summaries"]
+    assert summaries["prepatch_report.devices"] == {
+        "total": 30,
+        "returned": 10,
+        "has_more": True,
+        "follow_up_tool": "get_prepatch_report",
+        "follow_up_args_hint": {},
+    }
+    assert summaries["patch_approvals.approvals"]["follow_up_tool"] == "patch_approvals_summary"
+    assert summaries["patch_policy_schedules"]["follow_up_tool"] == "policy_catalog"
+
+    # Notes are LLM-friendly hints; one per truncated section.
+    notes = result["metadata"]["notes"]
+    assert len(notes) == 3
+    assert all("call `" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_patch_tuesday_readiness_detail_limit_zero_returns_summary_only() -> None:
+    """detail_limit=0 — pure summary mode. Inner lists are empty but counts and
+    section_summaries describe what was omitted."""
+    devices_payload = {
+        "prepatch": {
+            "devices": [{"id": i, "name": f"host-{i}"} for i in range(5)],
+            "total": 5,
+        }
+    }
+    approvals_payload = [{"id": i, "title": f"A{i}", "status": "pending"} for i in range(5)]
+    policies_payload = [
+        {"id": 1000 + i, "name": f"P{i}", "policy_type_name": "patch", "status": "active"}
+        for i in range(3)
+    ]
+    client = StubClient(
+        get_responses={
+            "/reports/prepatch": [devices_payload],
+            "/approvals": [approvals_payload],
+            "/policies": [policies_payload],
+            "/policystats": [[]],
+        }
+    )
+    client.org_id = 555
+
+    result = await get_patch_tuesday_readiness(
+        cast(AutomoxClient, client),
+        org_id=555,
+        org_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        detail_limit=0,
+    )
+
+    assert result["data"]["prepatch_report"]["devices"] == []
+    assert result["data"]["patch_approvals"]["approvals"] == []
+    assert result["data"]["patch_policy_schedules"] == []
+    # Counts intact.
+    assert result["data"]["prepatch_report"]["total_devices_needing_patches"] == 5
+    assert result["data"]["patch_approvals"]["pending_count"] == 5
+    # All three sections summarized.
+    assert set(result["metadata"]["section_summaries"]) == {
+        "prepatch_report.devices",
+        "patch_approvals.approvals",
+        "patch_policy_schedules",
+    }
+
+
+@pytest.mark.asyncio
+async def test_patch_tuesday_readiness_no_summary_when_under_limit() -> None:
+    """If a section is already under detail_limit, no truncation metadata for it."""
+    devices_payload = {"prepatch": {"devices": [], "total": 0}}
+    approvals_payload: list[Any] = []
+    policies_payload = [
+        {"id": 1, "name": "P1", "policy_type_name": "patch", "status": "active"},
+        {"id": 2, "name": "P2", "policy_type_name": "patch", "status": "active"},
+    ]
+    client = StubClient(
+        get_responses={
+            "/reports/prepatch": [devices_payload],
+            "/approvals": [approvals_payload],
+            "/policies": [policies_payload],
+            "/policystats": [[]],
+        }
+    )
+    client.org_id = 555
+
+    result = await get_patch_tuesday_readiness(
+        cast(AutomoxClient, client),
+        org_id=555,
+        org_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        detail_limit=10,
+    )
+
+    # No truncation metadata when everything fits.
+    assert result["metadata"].get("section_summaries") is None
+    assert "notes" not in result["metadata"]
+
+
+@pytest.mark.asyncio
 async def test_patch_tuesday_readiness_no_errors_when_all_succeed() -> None:
     client = _build_readiness_client()
     result = await get_patch_tuesday_readiness(

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.25"
+version = "1.0.26"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Proof-of-shape for #53. `get_patch_tuesday_readiness` adopts the new compound-tool contract; `get_compliance_snapshot` and `get_device_full_profile` will follow in subsequent releases once the shape is validated in the field.

**The problem:** Compound tools folded full inner lists (`prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules`) verbatim into a single response. On any tenant with more than a handful of devices needing patches, the response exceeded the 4000-token budget and `_apply_token_budget` arbitrarily truncated whichever array fit last — usually dropping the most useful detail.

**The shape:**

- New `detail_limit` parameter (default `10`, range `[0, 200]`) caps every inner list.
- **Counts and aggregates are always returned in full** (`total_devices_needing_patches`, `pending_count`, `readiness_summary` — the things an LLM needs to actually answer the question).
- Truncated sections surface a per-section entry under `metadata.section_summaries.<key>`:

```json
{
  "metadata": {
    "detail_limit": 10,
    "section_summaries": {
      "prepatch_report.devices": {
        "total": 230,
        "returned": 10,
        "has_more": true,
        "follow_up_tool": "get_prepatch_report",
        "follow_up_args_hint": {"group_id": 42}
      }
    },
    "notes": [
      "prepatch_report.devices capped at 10 of 230 — call `get_prepatch_report` for the full set."
    ]
  }
}
```

- `detail_limit=0` returns a pure summary with empty previews — useful for "give me the executive summary" prompts.

**Why hybrid (not budget-raise or pure summary):**

- Budget-raise doesn't help users on small models.
- Pure summary loses the small-tenant case where the full data fits anyway.
- Hybrid keeps the compound tool's "one call to answer the question" value, while making the truncation predictable, navigable (via `follow_up_tool`), and tenant-size-agnostic.

## What's in here

- `PatchTuesdayReadinessParams.detail_limit` (schema)
- `get_patch_tuesday_readiness` tool + workflow wiring
- 3 new tests covering: truncation + section_summaries + follow-up-tool emission; `detail_limit=0` pure-summary mode; no-truncation case when sections are already small
- `docs/tool-reference.md` — new **Compound tools** subsection under **Pagination** documenting the contract, plus an inline note on the `get_patch_tuesday_readiness` entry
- CHANGELOG entry for v1.0.26

## Test plan

- [x] `uv run pytest` — 1088 passed (+3 new compound tests; +19 compound tests total)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [ ] (Reviewer) On the test tenant, call `get_patch_tuesday_readiness` and confirm the response stays under the token budget while `metadata.section_summaries.prepatch_report.devices` describes the omitted devices
- [ ] (Reviewer) Call with `detail_limit=0` and confirm pure-summary mode

## Follow-ups (separate PRs)

- `get_compliance_snapshot` — same contract, sections `noncompliant_report.devices`, `device_health.stale_devices`, `policy_summary` (already partially summarized)
- `get_device_full_profile` — sections `packages.packages` (already caps via `max_packages`, just align the metadata shape), inventory sub-categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)