### PR TITLE
Release v1.0.27: sweep compound-tool contract (#53 sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.27] - 2026-05-26
+
+### Added
+
+- **`get_compliance_snapshot` adopts the compound-tool contract (#53)** — The tool now accepts `detail_limit` (default `10`) and caps `data.noncompliant_report.devices` and `data.device_health.stale_devices` per the contract from v1.0.26. Truncated sections surface `metadata.section_summaries.<key>` with `follow_up_tool` (`get_noncompliant_report`, `device_health_metrics`) and `follow_up_args_hint` (including `group_id` when set). The `stale_devices` summary reads `metadata.stale_device_count` from `summarize_device_health` so the reported total reflects the true fleet count, not just what fit in the per-section cap.
+- **`get_device_full_profile` adopts the compound-tool contract (#53)** — The tool now accepts `detail_limit`. When omitted it falls back to the legacy `max_packages` parameter (default `25`), preserving existing callers. The `packages.packages` list is capped at the effective limit; `metadata.section_summaries.packages.packages` surfaces `total`, `returned`, `has_more`, and `follow_up_tool="list_device_packages"` with `follow_up_args_hint={"device_id": ...}`. The legacy `data.packages.truncated` / `data.packages.note` fields are retained for backwards-compat. Inventory remains server-side summarized (counts + key-values per category) because its upstream payload is dict-structured, not a flat list.
+- **`build_section_summary` / `build_section_summary_notes` helpers in `automox_mcp.utils.response`** — The per-section truncation block (`total` / `returned` / `has_more` / `follow_up_tool` / `follow_up_args_hint`) is now built by a shared helper instead of duplicated across the three compound workflows. `build_section_summary_notes` builds the LLM-facing `metadata.notes` strings.
+
 ## [1.0.26] - 2026-05-26
 
 ### Added

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -127,8 +127,8 @@ Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-b
 ## Compound Workflows (3 tools)
 
 - **`get_patch_tuesday_readiness`** - Combined view of pre-patch report, pending approvals, and patch policy schedules. Answers "Are we ready for Patch Tuesday?" in a single call. Includes per-device severity classification computed from CVE data. Each inner list is capped at `detail_limit` (default 10); see the **Compound tools** section under [Pagination](#pagination) for the `metadata.section_summaries` shape and how to fetch the full data via the linked detail tools.
-- **`get_compliance_snapshot`** - Combined view of non-compliant devices, fleet health metrics, and policy statistics. Answers "What is our compliance posture?" in a single call. Includes compliance rate, device health breakdown, and stale device detection.
-- **`get_device_full_profile`** - Complete device profile combining device detail, inventory summary, packages, and policy assignments in a single call. Inventory is summarized with key values per category; packages capped at 25 by default. Metadata includes per-section status, data completeness flag, and item counts for verification.
+- **`get_compliance_snapshot`** - Combined view of non-compliant devices, fleet health metrics, and policy statistics. Answers "What is our compliance posture?" in a single call. Includes compliance rate, device health breakdown, and stale device detection. Inner lists capped at `detail_limit` (default 10) per the compound-tool contract.
+- **`get_device_full_profile`** - Complete device profile combining device detail, inventory summary, packages, and policy assignments in a single call. Inventory is summarized server-side with key values per category (its raw payload is dict-shaped, not a flat list). The `packages.packages` list is capped at `detail_limit` (default falls back to legacy `max_packages=25`); `metadata.section_summaries.packages.packages` surfaces the truncation and points at `list_device_packages` for full data.
 
 ## Events (1 tool)
 
@@ -246,7 +246,13 @@ A generic pagination loop can therefore read `metadata.pagination.has_more` and 
 
 ### Compound tools
 
-Compound tools (`get_patch_tuesday_readiness`, `get_compliance_snapshot`, `get_device_full_profile`) fold several upstream calls into a single response. Each inner list (e.g. `prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules`) is capped at a `detail_limit` parameter (default 10) so the response fits the token budget on tenants of any size. Counts and aggregates are always returned in full.
+Compound tools (`get_patch_tuesday_readiness`, `get_compliance_snapshot`, `get_device_full_profile`) fold several upstream calls into a single response. Each inner list is capped at a `detail_limit` parameter (default 10) so the response fits the token budget on tenants of any size. Counts and aggregates are always returned in full.
+
+| Compound tool | Capped sections | Follow-up detail tools |
+|---|---|---|
+| `get_patch_tuesday_readiness` | `prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules` | `get_prepatch_report`, `patch_approvals_summary`, `policy_catalog` |
+| `get_compliance_snapshot` | `noncompliant_report.devices`, `device_health.stale_devices` | `get_noncompliant_report`, `device_health_metrics` |
+| `get_device_full_profile` | `packages.packages` (inventory is server-side summarized) | `list_device_packages` |
 
 When a section is truncated, the response surfaces a per-section entry under `metadata.section_summaries`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.26"
+version = "1.0.27"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -796,8 +796,39 @@ class PatchTuesdayReadinessParams(OrgIdRequiredMixin, ForbidExtraModel):
 
 class ComplianceSnapshotParams(OrgIdRequiredMixin, ForbidExtraModel):
     group_id: int | None = Field(None, ge=1, description="Restrict to a specific server group")
+    detail_limit: int = Field(
+        10,
+        ge=0,
+        le=200,
+        description=(
+            "Cap each inner list (noncompliant devices, stale devices) at this "
+            "size. 0 returns counts only. Truncated sections surface "
+            "`metadata.section_summaries.<key>` with the follow-up tool to call "
+            "for the rest. See compound-tool contract in the Pagination docs."
+        ),
+    )
 
 
 class DeviceFullProfileParams(OrgIdRequiredMixin, ForbidExtraModel):
     device_id: int = Field(description="Device identifier", ge=1)
-    max_packages: int = Field(25, ge=0, le=500, description="Max packages to include")
+    max_packages: int = Field(
+        25,
+        ge=0,
+        le=500,
+        description=(
+            "Legacy alias for `detail_limit`, retained for backwards-compat. "
+            "Used when `detail_limit` is omitted."
+        ),
+    )
+    detail_limit: int | None = Field(
+        None,
+        ge=0,
+        le=500,
+        description=(
+            "Cap on the `packages.packages` inner list. When omitted falls "
+            "back to `max_packages`. 0 returns counts only. Truncated sections "
+            "surface `metadata.section_summaries.<key>` with the follow-up "
+            "tool to call for the rest. See the compound-tool contract in the "
+            "Pagination docs."
+        ),
+    )

--- a/src/automox_mcp/tools/compound_tools.py
+++ b/src/automox_mcp/tools/compound_tools.py
@@ -66,8 +66,9 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_compliance_snapshot(
         group_id: int | None = None,
+        detail_limit: int = 10,
     ) -> dict[str, Any]:
-        params: dict[str, Any] = {}
+        params: dict[str, Any] = {"detail_limit": detail_limit}
         if group_id is not None:
             params["group_id"] = group_id
         return await call_tool_workflow(
@@ -96,8 +97,14 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_device_full_profile(
         device_id: int,
         max_packages: int = 25,
+        detail_limit: int | None = None,
     ) -> dict[str, Any]:
-        params: dict[str, Any] = {"device_id": device_id, "max_packages": max_packages}
+        params: dict[str, Any] = {
+            "device_id": device_id,
+            "max_packages": max_packages,
+        }
+        if detail_limit is not None:
+            params["detail_limit"] = detail_limit
         return await call_tool_workflow(
             client,
             workflows.compound.get_device_full_profile,

--- a/src/automox_mcp/utils/__init__.py
+++ b/src/automox_mcp/utils/__init__.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from .organization import resolve_org_uuid
-from .response import build_pagination_metadata, extract_list, normalize_status, require_org_id
+from .response import (
+    build_pagination_metadata,
+    build_section_summary,
+    build_section_summary_notes,
+    extract_list,
+    normalize_status,
+    require_org_id,
+)
 from .tooling import (
     RateLimiter,
     RateLimitError,
@@ -20,6 +27,8 @@ __all__ = [
     "RateLimiter",
     "as_tool_response",
     "build_pagination_metadata",
+    "build_section_summary",
+    "build_section_summary_notes",
     "call_tool_workflow",
     "enforce_rate_limit",
     "extract_list",

--- a/src/automox_mcp/utils/response.py
+++ b/src/automox_mcp/utils/response.py
@@ -135,6 +135,48 @@ def build_pagination_metadata(
     return block
 
 
+def build_section_summary(
+    *,
+    total: int,
+    returned: int,
+    follow_up_tool: str,
+    follow_up_args_hint: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build a single ``metadata.section_summaries.<key>`` entry.
+
+    Returns ``None`` when ``total <= returned`` so the caller can skip
+    emitting a no-op summary. When emitted the entry has ``total``,
+    ``returned``, ``has_more`` (always ``True`` in this branch),
+    ``follow_up_tool`` (the detail tool to call for the full set), and
+    ``follow_up_args_hint`` (initial args to seed that call). This is
+    the compound-tool contract from issue #53.
+    """
+    if total <= returned:
+        return None
+    return {
+        "total": total,
+        "returned": returned,
+        "has_more": True,
+        "follow_up_tool": follow_up_tool,
+        "follow_up_args_hint": dict(follow_up_args_hint or {}),
+    }
+
+
+def build_section_summary_notes(
+    section_summaries: Mapping[str, Mapping[str, Any]],
+    *,
+    detail_limit: int,
+) -> list[str]:
+    """Build the LLM-facing ``metadata.notes`` entries for truncated sections."""
+    return [
+        (
+            f"{key} capped at {detail_limit} of {info['total']} — call "
+            f"`{info['follow_up_tool']}` for the full set."
+        )
+        for key, info in section_summaries.items()
+    ]
+
+
 def require_org_id(
     client: Any,
     org_id: int | None = None,

--- a/src/automox_mcp/workflows/compound.py
+++ b/src/automox_mcp/workflows/compound.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from ..client import AutomoxClient
+from ..utils.response import build_section_summary, build_section_summary_notes
 from . import devices, packages, policy, reports
 
 
@@ -103,46 +104,39 @@ async def get_patch_tuesday_readiness(
 
     follow_up_hint = {"group_id": group_id} if group_id is not None else {}
     section_summaries: dict[str, Any] = {}
-
-    def _record(
-        section_key: str,
-        full: list[Any],
-        preview: list[Any],
-        follow_up_tool: str,
-        args_hint: dict[str, Any],
-    ) -> None:
-        if len(full) > len(preview):
-            section_summaries[section_key] = {
-                "total": len(full),
-                "returned": len(preview),
-                "has_more": True,
-                "follow_up_tool": follow_up_tool,
-                "follow_up_args_hint": args_hint,
-            }
-
-    _record(
-        "prepatch_report.devices",
-        prepatch_devices_full,
-        prepatch_devices_preview,
-        "get_prepatch_report",
-        follow_up_hint,
-    )
-    _record(
-        "patch_approvals.approvals",
-        approval_items_full,
-        approvals_preview,
-        "patch_approvals_summary",
-        {},
-    )
-    _record(
-        "patch_policy_schedules",
-        patch_policy_entries_full,
-        patch_policy_schedules_preview,
-        "policy_catalog",
-        # The detail tool returns all policies; the caller filters by
-        # type=patch client-side (no native type filter today).
-        {"include_inactive": False, "limit": 200},
-    )
+    for key, full, preview, tool, args in (
+        (
+            "prepatch_report.devices",
+            prepatch_devices_full,
+            prepatch_devices_preview,
+            "get_prepatch_report",
+            follow_up_hint,
+        ),
+        (
+            "patch_approvals.approvals",
+            approval_items_full,
+            approvals_preview,
+            "patch_approvals_summary",
+            {},
+        ),
+        (
+            "patch_policy_schedules",
+            patch_policy_entries_full,
+            patch_policy_schedules_preview,
+            "policy_catalog",
+            # The detail tool returns all policies; the caller filters by
+            # type=patch client-side (no native type filter today).
+            {"include_inactive": False, "limit": 200},
+        ),
+    ):
+        summary = build_section_summary(
+            total=len(full),
+            returned=len(preview),
+            follow_up_tool=tool,
+            follow_up_args_hint=args,
+        )
+        if summary is not None:
+            section_summaries[key] = summary
 
     metadata: dict[str, Any] = {
         "errors": errors if errors else None,
@@ -150,13 +144,9 @@ async def get_patch_tuesday_readiness(
     }
     if section_summaries:
         metadata["section_summaries"] = section_summaries
-        metadata["notes"] = [
-            (
-                f"{key} capped at {detail_limit} of {info['total']} — call "
-                f"`{info['follow_up_tool']}` for the full set."
-            )
-            for key, info in section_summaries.items()
-        ]
+        metadata["notes"] = build_section_summary_notes(
+            section_summaries, detail_limit=detail_limit
+        )
 
     return {
         "data": {
@@ -189,10 +179,15 @@ async def get_compliance_snapshot(
     *,
     org_id: int,
     group_id: int | None = None,
+    detail_limit: int = 10,
 ) -> dict[str, Any]:
     """Combine non-compliant report, health metrics, and policy stats into one view.
 
     Answers: "What's our overall compliance posture?"
+
+    Each inner list is capped at ``detail_limit`` (default 10); see
+    :func:`get_patch_tuesday_readiness` for the compound-tool contract
+    (#53). Counts and aggregates are always returned in full.
     """
     raw_results = await asyncio.gather(
         reports.get_noncompliant_report(client, org_id=org_id, group_id=group_id),
@@ -202,7 +197,7 @@ async def get_compliance_snapshot(
             group_id=group_id,
             include_unmanaged=False,
             limit=500,
-            max_stale_devices=10,
+            max_stale_devices=max(detail_limit, 10),
         ),
         policy.summarize_policies(
             client,
@@ -246,6 +241,61 @@ async def get_compliance_snapshot(
     compliant_count = max(0, total_devices - noncompliant_count)
     compliance_rate = round(compliant_count / total_devices * 100, 1) if total_devices > 0 else 0
 
+    noncompliant_devices_full = noncompliant_data.get("devices") or []
+    noncompliant_devices_preview = noncompliant_devices_full[:detail_limit]
+
+    # summarize_device_health already capped stale_devices at max_stale_devices,
+    # but its metadata.stale_device_count reports the true fleet-wide count
+    # so we can still emit an honest section_summary.
+    stale_devices_preview = (health_data.get("stale_devices") or [])[:detail_limit]
+    health_meta = health.get("metadata") if isinstance(health, Mapping) else None
+    stale_total = (
+        health_meta.get("stale_device_count") if isinstance(health_meta, Mapping) else None
+    )
+    if not isinstance(stale_total, int):
+        stale_total = len(stale_devices_preview)
+
+    follow_up_hint = {"group_id": group_id} if group_id is not None else {}
+    section_summaries: dict[str, Any] = {}
+    for key, full, preview, tool, args in (
+        (
+            "noncompliant_report.devices",
+            noncompliant_devices_full,
+            noncompliant_devices_preview,
+            "get_noncompliant_report",
+            follow_up_hint,
+        ),
+    ):
+        summary = build_section_summary(
+            total=len(full),
+            returned=len(preview),
+            follow_up_tool=tool,
+            follow_up_args_hint=args,
+        )
+        if summary is not None:
+            section_summaries[key] = summary
+
+    # stale_devices uses the upstream-reported total instead of the local
+    # length, since summarize_device_health caps its own output.
+    stale_summary = build_section_summary(
+        total=stale_total,
+        returned=len(stale_devices_preview),
+        follow_up_tool="device_health_metrics",
+        follow_up_args_hint=follow_up_hint,
+    )
+    if stale_summary is not None:
+        section_summaries["device_health.stale_devices"] = stale_summary
+
+    metadata: dict[str, Any] = {
+        "errors": errors if errors else None,
+        "detail_limit": detail_limit,
+    }
+    if section_summaries:
+        metadata["section_summaries"] = section_summaries
+        metadata["notes"] = build_section_summary_notes(
+            section_summaries, detail_limit=detail_limit
+        )
+
     return {
         "data": {
             "compliance_overview": {
@@ -256,18 +306,16 @@ async def get_compliance_snapshot(
             },
             "noncompliant_report": {
                 "summary": noncompliant_data.get("summary", {}),
-                "devices": noncompliant_data.get("devices", []),
+                "devices": noncompliant_devices_preview,
             },
             "device_health": {
                 "status_breakdown": health_data.get("device_status_breakdown", {}),
                 "check_in_recency": health_data.get("check_in_recency_breakdown", {}),
-                "stale_devices": health_data.get("stale_devices", []),
+                "stale_devices": stale_devices_preview,
             },
             "policy_summary": policy_summary,
         },
-        "metadata": {
-            "errors": errors if errors else None,
-        },
+        "metadata": metadata,
     }
 
 
@@ -277,17 +325,23 @@ async def get_device_full_profile(
     org_id: int,
     device_id: int,
     max_packages: int = 25,
+    detail_limit: int | None = None,
 ) -> dict[str, Any]:
     """Combine device detail, packages, inventory, and policy status into one view.
 
     Answers: "Give me the full profile for [device]."
 
-    Inventory is summarized (counts + key values per category) to keep
-    the response readable.  Packages are capped at *max_packages* with a
-    note indicating how many were omitted.  Use get_device_inventory or
-    list_device_packages for full data.
+    Inventory is summarized server-side (counts + key values per category)
+    because the raw payload is dict-structured rather than a flat list.
+    The ``packages.packages`` array is capped at ``detail_limit`` and the
+    canonical ``metadata.section_summaries`` block points at
+    ``list_device_packages`` for the full list. ``max_packages`` is a
+    legacy alias retained for backwards-compat — when ``detail_limit`` is
+    omitted, ``max_packages`` is used.
     """
     labels = ("device_detail", "device_inventory", "device_packages")
+
+    effective_limit = detail_limit if detail_limit is not None else max_packages
 
     raw_results = await asyncio.gather(
         devices.describe_device(
@@ -307,7 +361,7 @@ async def get_device_full_profile(
             client,
             org_id=org_id,
             device_id=device_id,
-            limit=max_packages,
+            limit=effective_limit,
         ),
         return_exceptions=True,
     )
@@ -354,12 +408,42 @@ async def get_device_full_profile(
     # Cap packages
     all_packages = packages_data.get("packages", [])
     total_packages = packages_data.get("total_packages", 0)
-    packages_preview = all_packages[:max_packages]
+    packages_preview = all_packages[:effective_limit]
     packages_truncated = total_packages > len(packages_preview)
 
     # Policy assignments
     policy_assignments = device_data.get("policy_assignments", {})
     total_policies = policy_assignments.get("total", 0)
+
+    section_summaries: dict[str, Any] = {}
+    package_section_summary = build_section_summary(
+        total=total_packages,
+        returned=len(packages_preview),
+        follow_up_tool="list_device_packages",
+        follow_up_args_hint={"device_id": device_id},
+    )
+    if package_section_summary is not None:
+        section_summaries["packages.packages"] = package_section_summary
+
+    metadata: dict[str, Any] = {
+        "errors": errors if errors else None,
+        "section_status": section_status,
+        "data_complete": not errors,
+        "detail_limit": effective_limit,
+        "counts": {
+            "inventory_categories": len(inventory_summary),
+            "inventory_items": total_inventory_items,
+            "packages_total": total_packages,
+            "packages_returned": len(packages_preview),
+            "policy_assignments": total_policies,
+            "pending_commands": len(device_data.get("pending_commands", [])),
+        },
+    }
+    if section_summaries:
+        metadata["section_summaries"] = section_summaries
+        metadata["notes"] = build_section_summary_notes(
+            section_summaries, detail_limit=effective_limit
+        )
 
     return {
         "data": {
@@ -374,6 +458,8 @@ async def get_device_full_profile(
                 "note": "Summarized view — use get_device_inventory for full data",
             },
             "packages": {
+                # Legacy shape retained for backwards-compat (#53). Canonical
+                # truncation state now lives in metadata.section_summaries.
                 "total": total_packages,
                 "returned": len(packages_preview),
                 "truncated": packages_truncated,
@@ -386,17 +472,5 @@ async def get_device_full_profile(
                 else None,
             },
         },
-        "metadata": {
-            "errors": errors if errors else None,
-            "section_status": section_status,
-            "data_complete": not errors,
-            "counts": {
-                "inventory_categories": len(inventory_summary),
-                "inventory_items": total_inventory_items,
-                "packages_total": total_packages,
-                "packages_returned": len(packages_preview),
-                "policy_assignments": total_policies,
-                "pending_commands": len(device_data.get("pending_commands", [])),
-            },
-        },
+        "metadata": metadata,
     }

--- a/tests/test_workflows_compound.py
+++ b/tests/test_workflows_compound.py
@@ -863,3 +863,149 @@ async def test_full_profile_metadata_counts(monkeypatch: pytest.MonkeyPatch) -> 
     assert counts["packages_returned"] == 3
     assert counts["policy_assignments"] == 2
     assert counts["pending_commands"] == 1
+
+
+# ---------------------------------------------------------------------------
+# #53 sweep: detail_limit contract on get_compliance_snapshot and
+# get_device_full_profile.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compliance_snapshot_caps_inner_lists_at_detail_limit() -> None:
+    """#53: noncompliant_report.devices and device_health.stale_devices are
+    capped at detail_limit; metadata.section_summaries points at the detail
+    tools for full data."""
+    noncompliant_payload = {
+        "nonCompliant": {
+            "total": 30,
+            "devices": [{"id": i, "name": f"host-{i}", "groupId": 10} for i in range(30)],
+        }
+    }
+    # 30 servers all marked stale (no recent check-in)
+    servers_payload = [
+        {
+            "id": 1000 + i,
+            "managed": True,
+            "status": {"policy_status": "success"},
+            "last_check_in": "2024-01-01T00:00:00Z",
+        }
+        for i in range(30)
+    ]
+    client = StubClient(
+        get_responses={
+            "/reports/needs-attention": [noncompliant_payload],
+            "/servers": [servers_payload],
+            "/policies": [_POLICIES_RESPONSE],
+            "/policystats": [_POLICYSTATS_RESPONSE],
+        }
+    )
+    client.org_id = 555
+
+    result = await get_compliance_snapshot(
+        cast(AutomoxClient, client),
+        org_id=555,
+        detail_limit=10,
+    )
+
+    data = result["data"]
+    assert len(data["noncompliant_report"]["devices"]) == 10
+    assert len(data["device_health"]["stale_devices"]) <= 10
+    # Counts unaffected.
+    assert data["compliance_overview"]["noncompliant_devices"] == 30
+
+    summaries = result["metadata"]["section_summaries"]
+    assert summaries["noncompliant_report.devices"]["total"] == 30
+    assert summaries["noncompliant_report.devices"]["returned"] == 10
+    assert summaries["noncompliant_report.devices"]["follow_up_tool"] == "get_noncompliant_report"
+    assert summaries["device_health.stale_devices"]["follow_up_tool"] == "device_health_metrics"
+    # LLM-friendly notes.
+    notes = result["metadata"]["notes"]
+    assert any("get_noncompliant_report" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_compliance_snapshot_no_summary_when_under_limit() -> None:
+    """Already-small sections shouldn't surface section_summaries."""
+    client = _build_compliance_client()
+    result = await get_compliance_snapshot(
+        cast(AutomoxClient, client),
+        org_id=555,
+        detail_limit=10,
+    )
+    assert result["metadata"].get("section_summaries") is None
+
+
+@pytest.mark.asyncio
+async def test_full_profile_emits_section_summary_for_truncated_packages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#53: packages.packages truncation surfaces via metadata.section_summaries
+    in addition to the legacy packages.truncated / packages.note fields."""
+    many_packages = {
+        "data": {
+            "device_id": 101,
+            "total_packages": 50,
+            "packages": [{"id": i, "name": f"pkg-{i}", "version": "1.0"} for i in range(50)],
+        },
+        "metadata": {},
+    }
+    _patch_sub_workflows(
+        monkeypatch,
+        list_device_packages=AsyncMock(return_value=many_packages),
+    )
+    client = StubClient()
+
+    result = await get_device_full_profile(
+        cast(AutomoxClient, client),
+        org_id=555,
+        device_id=101,
+        detail_limit=5,
+    )
+
+    # Canonical section summary present.
+    summaries = result["metadata"]["section_summaries"]
+    assert summaries["packages.packages"] == {
+        "total": 50,
+        "returned": 5,
+        "has_more": True,
+        "follow_up_tool": "list_device_packages",
+        "follow_up_args_hint": {"device_id": 101},
+    }
+    # Legacy fields still emitted for backwards-compat.
+    pkg_section = result["data"]["packages"]
+    assert pkg_section["truncated"] is True
+    assert "use list_device_packages" in pkg_section["note"]
+    # detail_limit recorded in metadata.
+    assert result["metadata"]["detail_limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_full_profile_detail_limit_falls_back_to_max_packages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy callers passing only max_packages still get the old behavior."""
+    many_packages = {
+        "data": {
+            "device_id": 101,
+            "total_packages": 50,
+            "packages": [{"id": i, "name": f"pkg-{i}", "version": "1.0"} for i in range(50)],
+        },
+        "metadata": {},
+    }
+    _patch_sub_workflows(
+        monkeypatch,
+        list_device_packages=AsyncMock(return_value=many_packages),
+    )
+    client = StubClient()
+
+    # Only max_packages set, no detail_limit
+    result = await get_device_full_profile(
+        cast(AutomoxClient, client),
+        org_id=555,
+        device_id=101,
+        max_packages=7,
+    )
+
+    assert result["data"]["packages"]["returned"] == 7
+    assert result["metadata"]["detail_limit"] == 7

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.26"
+version = "1.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Closes the #53 follow-up. **Replaces PR #63**, which was auto-closed when its stacked base branch was deleted on merge of #62.

Sweeps the v1.0.26 compound-tool contract across the remaining two aggregation tools and extracts the per-section truncation block into a shared helper.

`get_compliance_snapshot`:
- New `detail_limit` parameter (default `10`).
- Caps `data.noncompliant_report.devices` and `data.device_health.stale_devices`.
- `metadata.section_summaries` entries point at `get_noncompliant_report` / `device_health_metrics`, with `group_id` carried through in `follow_up_args_hint` when set.
- `stale_devices` total reads `metadata.stale_device_count` from `summarize_device_health` so the reported total reflects the true fleet count, not just what fit under the per-section cap.

`get_device_full_profile`:
- New `detail_limit` parameter; falls back to legacy `max_packages` (default `25`) when omitted, preserving existing callers.
- Caps `data.packages.packages` and emits `metadata.section_summaries.packages.packages` with `follow_up_tool="list_device_packages"` and `follow_up_args_hint={"device_id": ...}`.
- Legacy `data.packages.truncated` / `data.packages.note` retained for backwards-compat.
- Inventory remains server-side summarized — its raw payload is dict-structured (categories → sub-categories → items), not a flat list, so the standard list-cap pattern doesn't apply.

Shared helpers in `automox_mcp.utils.response`:
- `build_section_summary` — builds a per-section truncation entry. Returns `None` when `total <= returned` so callers can skip emitting a no-op summary.
- `build_section_summary_notes` — builds the LLM-facing `metadata.notes` strings.
- `get_patch_tuesday_readiness` (from #62) refactored to use both helpers so the contract code lives in one place.

## Test plan

- [x] `uv run pytest` — 1092 passed (+4 new compound tests on top of #62)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [ ] (Reviewer) On the test tenant: call `get_compliance_snapshot` and confirm the response stays under budget on a tenant with many noncompliant devices, and that `metadata.section_summaries` points at the correct follow-up tools
- [ ] (Reviewer) Call `get_device_full_profile` with `detail_limit=5` and `detail_limit=0`; confirm the canonical `metadata.section_summaries.packages.packages` is emitted while the legacy `data.packages.truncated` field still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)