### PR TITLE
release: wait for PyPI to serve new version before MCP Registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,29 @@ jobs:
       # the registry GAs. Currently uses `latest` to match the upstream
       # quickstart. Tracked alongside other supply-chain items.
       # ---------------------------------------------------------------
+
+      # The MCP Registry validates the package by querying PyPI's JSON
+      # API. Between uploading to PyPI and PyPI's CDN serving the new
+      # version, the registry call routinely sees a 404 — observed on
+      # v1.0.29 and v1.0.30, both requiring a manual `gh workflow run
+      # release.yml --ref vX.Y.Z` backfill. Poll PyPI until it serves
+      # the version we just published, then continue.
+      - name: Wait for PyPI to serve new version
+        if: steps.pypi_check.outputs.exists != 'true'
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Waiting for PyPI CDN to serve automox-mcp==${VERSION}..."
+          for i in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/automox-mcp/${VERSION}/json" > /dev/null 2>&1; then
+              echo "PyPI now serving ${VERSION} (after $((i * 10))s)."
+              exit 0
+            fi
+            echo "  attempt ${i}/30: not yet, sleeping 10s..."
+            sleep 10
+          done
+          echo "::error::PyPI did not serve ${VERSION} within 5 minutes — registry publish will likely fail. Re-run via 'gh workflow run release.yml --ref ${GITHUB_REF_NAME}' once PyPI catches up."
+          exit 1
+
       - name: Install mcp-publisher
         if: steps.pypi_check.outputs.exists != 'true'
         run: |


### PR DESCRIPTION
## Problem

The release workflow uploads to PyPI, then immediately calls \`mcp-publisher publish\` against the MCP Registry. The registry validates the package by querying PyPI's JSON API — and PyPI's CDN takes 30s–2min after a successful upload before the new version is queryable.

Result: the MCP Registry step fails with:

\`\`\`
Error: publish failed: server returned status 400: ... "registry validation failed for package 0 (automox-mcp): PyPI package 'automox-mcp' not found (status: 404)"
\`\`\`

Observed on **v1.0.29** and **v1.0.30** — back-to-back releases, both requiring \`gh workflow run release.yml --ref vX.Y.Z\` to backfill once PyPI caught up. Two unnecessary manual round-trips.

## Fix

Insert a polling step between \`Publish to PyPI\` and \`Install mcp-publisher\` that queries the PyPI JSON API for the just-published version. Up to 30 attempts × 10s = 5-minute budget; exits as soon as the version is served. If the budget exhausts, fails with a pointer to the backfill command.

\`\`\`yaml
- name: Wait for PyPI to serve new version
  if: steps.pypi_check.outputs.exists != 'true'
  run: |
    VERSION=\"\${GITHUB_REF_NAME#v}\"
    for i in \$(seq 1 30); do
      if curl -sf \"https://pypi.org/pypi/automox-mcp/\${VERSION}/json\" > /dev/null 2>&1; then
        echo \"PyPI now serving \${VERSION} (after \$((i * 10))s).\"
        exit 0
      fi
      sleep 10
    done
    echo \"::error::PyPI did not serve \${VERSION} within 5 minutes\"
    exit 1
\`\`\`

Polls the **same endpoint** the existing \`Check if version already exists on PyPI\` step already uses (line 53), so no new dependency surface.

## Why polling vs. fixed sleep

A fixed \`sleep 60\` is wasteful when PyPI is fast and might be insufficient when PyPI is slow. Polling waits exactly as long as needed: typically <30s on the happy path, up to 5 minutes when the CDN is lagging.

## Why a wait vs. retrying the registry step

Targeted: we know what we're waiting for. A retry on \`mcp-publisher publish\` would also handle this transient, but it would obscure other failure modes (registry being down, auth issues) under a generic retry loop. The PyPI poll fails fast on a non-transient and the registry call is then trusted to surface real registry errors directly.

## No version bump / CHANGELOG entry

CI-only change. No package release; effective on the next \`v*\` tag push.

## Test plan

- [x] YAML syntax validated locally
- [x] \`uv run ruff format --check .\` / \`ruff check .\` / \`mypy .\` / \`pytest tests/\` — all clean (no source changes)
- [ ] Verified on the next release — v1.0.31 (whenever it ships) should publish to PyPI + MCP Registry in a single run, no backfill needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)