### PR TITLE
Teach compound-tool contract in prompts (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.31] - 2026-05-27
+
+### Changed
+
+- **Prompts teach the compound-tool contract (#67)** — `prepare_patch_tuesday` and `review_security_posture` now document the `detail_limit` parameter, the `metadata.section_summaries.<key>` shape, and the follow-up-tool dispatch pattern (which detail tool to call for each truncated section, and to use the `follow_up_args_hint` rather than guessing args). The compound-tool contract shipped across v1.0.26 / v1.0.27 / v1.0.30, but the prompts that drive these tools didn't teach how to use it — LLMs were learning the contract by reading the response only after potentially losing fidelity. Now the contract is taught up-front so the LLM can ask for `detail_limit=0` when it only wants the headline counts, or call the follow-up tool proactively when the user wants full detail. Two new regression tests assert each prompt mentions `detail_limit`, `section_summaries`, and `follow_up_tool`.
+
 ## [1.0.30] - 2026-05-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.30"
+version = "1.0.31"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/prompts/patch_tuesday.py
+++ b/src/automox_mcp/prompts/patch_tuesday.py
@@ -15,9 +15,12 @@ def register(server: FastMCP) -> None:
 
 1. **Get Patch Tuesday readiness**: Use `get_patch_tuesday_readiness` to get a combined view of pre-patch status, pending approvals, and policy schedules.
 
-2. **Review pending approvals**: Use `patch_approvals_summary` to see all pending patch approval requests. Prioritize by severity (critical > high > medium > low).
+   - The tool accepts an optional `detail_limit` (default `10`) that caps every inner list (`prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules`). Counts and aggregates (`total_devices_needing_patches`, `pending_count`, `readiness_summary`) are always returned in full, so set `detail_limit=0` if you only need the headline numbers.
+   - If a section was truncated, the response surfaces `metadata.section_summaries.<key>` with `total`, `returned`, `has_more`, and a `follow_up_tool` + `follow_up_args_hint` pointing at the detail tool to call for the rest (`prepatch_report` for devices, `patch_approvals_summary` for approvals, `policy_catalog` for schedules). Use those hints rather than guessing at args.
 
-3. **Check pre-patch report**: Use `prepatch_report` to identify devices with pending patches and their severity breakdown.
+2. **Review pending approvals**: Use `patch_approvals_summary` to see all pending patch approval requests. Prioritize by severity (critical > high > medium > low). Use this if step 1 reported truncated `patch_approvals.approvals` via `metadata.section_summaries`.
+
+3. **Check pre-patch report**: Use `prepatch_report` to identify devices with pending patches and their severity breakdown. Use this if step 1 reported truncated `prepatch_report.devices`.
 
 4. **Review patch policies**: Use `policy_catalog` to list all patch policies. For each active patch policy, use `policy_detail` to check:
    - Schedule (is it aligned with the Patch Tuesday window?)

--- a/src/automox_mcp/prompts/security_posture.py
+++ b/src/automox_mcp/prompts/security_posture.py
@@ -15,9 +15,12 @@ def register(server: FastMCP) -> None:
 
 1. **Get compliance snapshot**: Use `get_compliance_snapshot` for a combined view of non-compliant devices, health metrics, and policy compliance statistics.
 
-2. **Check fleet health**: Use `device_health_metrics` for aggregate statistics on device connectivity, patch status, and OS distribution.
+   - The tool accepts an optional `detail_limit` (default `10`) that caps inner lists (`noncompliant_report.devices`, `device_health.stale_devices`). Compliance counts and aggregates are always returned in full, so set `detail_limit=0` if you only need the headline numbers.
+   - If a section was truncated, the response surfaces `metadata.section_summaries.<key>` with `total`, `returned`, `has_more`, and a `follow_up_tool` + `follow_up_args_hint` pointing at the detail tool to call for the rest (`noncompliant_report` for non-compliant devices, `device_health_metrics` for stale devices). Use those hints rather than guessing at args.
 
-3. **Identify non-compliant devices**: Use `noncompliant_report` to get a detailed list of devices failing policy checks. Sort by severity.
+2. **Check fleet health**: Use `device_health_metrics` for aggregate statistics on device connectivity, patch status, and OS distribution. Use this if step 1 reported truncated `device_health.stale_devices`.
+
+3. **Identify non-compliant devices**: Use `noncompliant_report` to get a detailed list of devices failing policy checks. Sort by severity. Use this if step 1 reported truncated `noncompliant_report.devices`.
 
 4. **Review critical patches**: Use `search_org_packages` with severity filtering to find critical and high-severity patches across the organization.
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -53,6 +53,17 @@ def test_patch_tuesday_prompt_renders(server: FastMCP) -> None:
     assert "patch_approvals_summary" in result
 
 
+def test_patch_tuesday_prompt_teaches_compound_contract(server: FastMCP) -> None:
+    """#67: the prompt that uses get_patch_tuesday_readiness must teach the
+    detail_limit / section_summaries / follow_up_tool dispatch contract so
+    the LLM knows what to do when a section is truncated."""
+    prompt = _get_prompts(server)["prepare_patch_tuesday"]
+    result = prompt.fn()
+    assert "detail_limit" in result
+    assert "section_summaries" in result
+    assert "follow_up_tool" in result
+
+
 def test_audit_policy_prompt_renders(server: FastMCP) -> None:
     prompt = _get_prompts(server)["audit_policy_execution"]
     result = prompt.fn(policy_id="999")
@@ -79,3 +90,14 @@ def test_security_posture_prompt_renders(server: FastMCP) -> None:
     result = prompt.fn()
     assert "compliance" in result.lower()
     assert "device_health_metrics" in result
+
+
+def test_security_posture_prompt_teaches_compound_contract(server: FastMCP) -> None:
+    """#67: the prompt that uses get_compliance_snapshot must teach the
+    detail_limit / section_summaries / follow_up_tool dispatch contract so
+    the LLM knows what to do when a section is truncated."""
+    prompt = _get_prompts(server)["review_security_posture"]
+    result = prompt.fn()
+    assert "detail_limit" in result
+    assert "section_summaries" in result
+    assert "follow_up_tool" in result

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.30"
+version = "1.0.31"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #67.

## Why

The compound-tool contract (`detail_limit` parameter, `metadata.section_summaries.<key>` with `follow_up_tool` + `follow_up_args_hint`) shipped across **v1.0.26** (proof-of-shape on `get_patch_tuesday_readiness`), **v1.0.27** (sweep across `get_compliance_snapshot` and `get_device_full_profile`), and **v1.0.30** (fix that made the dispatch hint point at real tool names).

But the prompts driving those compounds — `prepare_patch_tuesday` and `review_security_posture` — never taught the LLM about any of it. The contract existed in the response shape, but the LLM had to discover it by reading the response. Worse, an LLM that didn't carefully inspect `metadata.section_summaries` might never realize a section was truncated.

## What changed

`src/automox_mcp/prompts/patch_tuesday.py` and `src/automox_mcp/prompts/security_posture.py` now document, inline in step 1 (the step that calls the compound tool):

- The `detail_limit` parameter (default 10), and that counts/aggregates are always returned in full so `detail_limit=0` returns a pure-summary view.
- The `metadata.section_summaries.<key>` shape (`total` / `returned` / `has_more` / `follow_up_tool` / `follow_up_args_hint`) emitted when a section truncates.
- The exact detail tool to call for each truncated section:
  - **Patch Tuesday:** `prepatch_report` / `patch_approvals_summary` / `policy_catalog`.
  - **Security posture:** `noncompliant_report` / `device_health_metrics`.
- The instruction to use the `follow_up_args_hint` rather than guessing args (avoids the kind of param mismatch the exploratory sweep surfaced).

The downstream steps that drill into the detail tools were also annotated to point back at the `section_summaries` they correspond to, so the LLM sees the chain end-to-end.

## Tests

Added two regression tests in `tests/test_prompts.py`:

- `test_patch_tuesday_prompt_teaches_compound_contract`
- `test_security_posture_prompt_teaches_compound_contract`

Each asserts the prompt mentions `detail_limit`, `section_summaries`, and `follow_up_tool`. Locks in the teaching so a future prompt edit doesn't quietly drop it.

## Test plan

- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — clean
- [x] `uv run pytest tests/` — 1125 passed (was 1123, +2 new prompt-contract tests)
- [x] Manual: re-read both prompts top-to-bottom to confirm the contract teaching reads naturally inline rather than tacked-on.

## Version

1.0.30 → 1.0.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)