### PR TITLE
release: retry MCP Registry publish to handle PyPI CDN PoP divergence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,12 @@ jobs:
       # quickstart. Tracked alongside other supply-chain items.
       # ---------------------------------------------------------------
 
-      # The MCP Registry validates the package by querying PyPI's JSON
-      # API. Between uploading to PyPI and PyPI's CDN serving the new
-      # version, the registry call routinely sees a 404 — observed on
-      # v1.0.29 and v1.0.30, both requiring a manual `gh workflow run
-      # release.yml --ref vX.Y.Z` backfill. Poll PyPI until it serves
-      # the version we just published, then continue.
+      # The MCP Registry validates the package by querying the SAME URL
+      # this step polls (https://pypi.org/pypi/<name>/<version>/json). On
+      # the happy path PyPI serves it within seconds; on the unhappy path
+      # this confirms PyPI itself completed the upload. The registry's
+      # *server-side* lookup is handled by the retry loop on the publish
+      # step below.
       - name: Wait for PyPI to serve new version
         if: steps.pypi_check.outputs.exists != 'true'
         run: |
@@ -125,7 +125,7 @@ jobs:
             echo "  attempt ${i}/30: not yet, sleeping 10s..."
             sleep 10
           done
-          echo "::error::PyPI did not serve ${VERSION} within 5 minutes — registry publish will likely fail. Re-run via 'gh workflow run release.yml --ref ${GITHUB_REF_NAME}' once PyPI catches up."
+          echo "::error::PyPI did not serve ${VERSION} within 5 minutes."
           exit 1
 
       - name: Install mcp-publisher
@@ -149,9 +149,30 @@ jobs:
           MCP_REGISTRY_PRIVATE_KEY: ${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
         run: ./mcp-publisher login dns --domain automox.com --private-key "$MCP_REGISTRY_PRIVATE_KEY"
 
-      - name: Publish to MCP Registry
+      # The MCP Registry validates by fetching the same PyPI JSON URL the
+      # wait step above just confirmed (see
+      # https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/registries/pypi.go).
+      # But the registry's server-side lookup hits a different PyPI CDN
+      # edge than the GitHub Actions runner — observed on v1.0.29, v1.0.30,
+      # and v1.0.31 (which had the wait step in place, runner saw 200,
+      # registry saw 404 within 0.3 s). PoP propagation between PyPI edges
+      # typically catches up within 3-5 minutes. Retry with 30 s backoff
+      # so the publish lands as soon as the registry's PoP is in sync.
+      - name: Publish to MCP Registry (with retry)
         if: steps.pypi_check.outputs.exists != 'true'
-        run: ./mcp-publisher publish
+        run: |
+          for i in $(seq 1 6); do
+            if ./mcp-publisher publish; then
+              echo "MCP Registry publish succeeded on attempt ${i}."
+              exit 0
+            fi
+            if [ "$i" -lt 6 ]; then
+              echo "  attempt ${i}/6 failed, sleeping 30s before retry..."
+              sleep 30
+            fi
+          done
+          echo "::error::MCP Registry publish failed after 6 attempts (~2.5 min total). Re-run via 'gh workflow run release.yml --ref ${GITHUB_REF_NAME}'."
+          exit 1
 
       # ---------------------------------------------------------------
       # MCPB Desktop Extension build & upload


### PR DESCRIPTION
## Why the previous fix didn't work

PR #73 (v1.0.30) added a \"Wait for PyPI to serve new version\" step that polled \`https://pypi.org/pypi/<name>/<version>/json\` from the GitHub runner. I assumed the MCP Registry was waiting on PyPI metadata propagation, so polling the same endpoint would gate the registry publish on the same condition.

**v1.0.31 disproved that.** The wait step saw HTTP 200 and the registry's validation saw HTTP 404 only **0.3 seconds later**. Same URL, opposite results.

## What's actually happening

I pulled the MCP Registry source (\`internal/validators/registries/pypi.go\` on \`modelcontextprotocol/registry@main\`) and the registry queries this exact URL:

\`\`\`go
fetchURL := fmt.Sprintf(\"%s/pypi/%s/%s/json\", pkg.RegistryBaseURL, ...)
\`\`\`

Identical to what I was polling. The divergence is a **CDN PoP boundary**: GitHub Actions runners and the MCP Registry server hit different PyPI CDN edges. The runner's PoP had the new version; the registry's PoP hadn't. Both pointing at PyPI, neither lying — they're just resolving the JSON URL via different cache nodes.

Polling from the runner side can never predict when the registry's PoP catches up.

## Fix

Wrap \`./mcp-publisher publish\` in a retry loop: **6 attempts × 30 s backoff = ~2.5 min budget**. The publish lands as soon as the registry's PoP is in sync (historical observation: 3-5 min after upload, so the budget catches the typical case). If the budget exhausts, exits with an explicit pointer to the backfill command.

I kept the \"Wait for PyPI to serve new version\" step from PR #73. It's still useful as a cheap (~10 s on happy path) confirmation that PyPI itself completed the upload — catches a different failure mode (publish was structurally accepted but never appeared). Removed the misleading 'will fix the registry publish' framing from its comment.

## Test plan

- [x] YAML syntax validated locally.
- [x] \`uv run ruff format --check .\` / \`ruff check .\` / \`mypy .\` / \`pytest tests/\` — all clean (no source changes).
- [ ] **Real validation: the next release.** A clean run with the retry kicking in once (or never) confirms the fix. If the retry budget exhausts, the diagnosis was incomplete and we revisit.

## Version

CI-only; no version bump or CHANGELOG entry (consistent with PR #73 and the repo convention for workflow-only changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)