### PR TITLE
policy_runs_v2 pagination hint + doc audit catch-up (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.32] - 2026-05-27
+
+### Changed
+
+- **`policy_runs_v2` now provides `next_page` + `suggested_next_call` (#76)** — Previously the filtered-pagination branch emitted `metadata.pagination.has_more=true` without telling the caller how to fetch the rest, forcing an LLM to infer "call with `page=current_page+1`" from raw counters. That diverged from `policy_catalog`'s richer contract. Now matches `policy_catalog`: when `has_more=True`, the response includes `pagination.next_page` and a top-level `metadata.suggested_next_call` with the exact tool name and args (carrying through the original filter parameters). On the last page neither hint is emitted, so the LLM knows there's nothing more to fetch. Surfaced by `tests/exploratory_sweep.py`.
+
+### Fixed
+
+- **Documentation corrections — tool names + counts** —
+  - `docs/tool-reference.md` documented the wrong follow-up tool names in the compound-tool contract (`get_prepatch_report`, `get_noncompliant_report`), the same bug that landed in production code with v1.0.27 / v1.0.26 and was fixed in v1.0.30 but never propagated to the doc. Updated to the registered names (`prepatch_report`, `noncompliant_report`).
+  - Tool-count drift across `README.md`, `SECURITY.md`, and `docs/deployment-security.md`: "22 write tools" → 21; "all 80 tools" → 79; "57 of 79 tools remain" → 58; "58 of 80" → 58 of 79. Reflects the actual surface: 79 total, 58 read-only, 21 write.
+
 ## [1.0.31] - 2026-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 | `AUTOMOX_API_KEY` | Yes | — | Automox API key |
 | `AUTOMOX_ACCOUNT_UUID` | Yes | — | Account UUID from Secrets & Keys |
 | `AUTOMOX_ORG_ID` | Recommended | — | Numeric organization ID (required by most tools) |
-| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (57 of 79 tools remain) |
+| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (58 of 79 tools remain) |
 | `AUTOMOX_MCP_MODULES` | No | all | Comma-separated list of modules to load (see below) |
 | `AUTOMOX_MCP_TOKEN_BUDGET` | No | `4000` | Max estimated tokens per response before truncation |
 | `AUTOMOX_MCP_SANITIZE_RESPONSES` | No | `true` | Sanitize API data to mitigate prompt injection |
@@ -130,7 +130,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 AUTOMOX_MCP_READ_ONLY=true
 ```
 
-Disables all write operations. Only read-only tools are registered (58 of 80). Useful for auditing and monitoring.
+Disables all write operations. Only read-only tools are registered (58 of 79). Useful for auditing and monitoring.
 
 ### Modular Loading
 
@@ -182,7 +182,7 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 
 **Highlights:**
 
-- **Read-only mode** (`AUTOMOX_MCP_READ_ONLY`) disables all 22 write tools
+- **Read-only mode** (`AUTOMOX_MCP_READ_ONLY`) disables all 21 write tools
 - **Module filtering** (`AUTOMOX_MCP_MODULES`) for least-privilege tool loading
 - **Correlation IDs** on every tool call, forwarded to Automox API as `X-Correlation-ID`
 - **Rate limiting** (30 calls/60s) with token budget estimation and auto-truncation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,7 @@ For sensitive deployments, we recommend using an MCP gateway with inline guardra
 
 ### Privilege Escalation
 
-- `AUTOMOX_MCP_READ_ONLY` mode disables all 22 write tools
+- `AUTOMOX_MCP_READ_ONLY` mode disables all 21 write tools
 - `AUTOMOX_MCP_MODULES` limits which tool domains load (principle of least functionality)
 - Pagination capped at 50 pages to prevent resource exhaustion (V-011)
 - Report limits bounded to 500 results (V-004)
@@ -187,7 +187,7 @@ For sensitive deployments, we recommend using an MCP gateway with inline guardra
 | V-178 | Null-safe policy count in group summaries | `workflows/groups.py` |
 | V-179 | Rate limiter eviction covers `_failures` dict | `transport_security.py` |
 | V-180 | Code block sanitizer strips all fenced blocks regardless of language label | `utils/sanitize.py` |
-| V-181 | MCP Tool Annotations on all 80 tools (readOnlyHint, destructiveHint, idempotentHint, openWorldHint) | `tools/*.py` |
+| V-181 | MCP Tool Annotations on all 79 tools (readOnlyHint, destructiveHint, idempotentHint, openWorldHint) | `tools/*.py` |
 
 ## Scope and Limitations
 

--- a/docs/deployment-security.md
+++ b/docs/deployment-security.md
@@ -265,7 +265,7 @@ These are always enabled on HTTP/SSE transports with no opt-out (defense-in-dept
 
 Client-side controls that complement the server's safety features:
 
-- Enable **confirmation dialogs** in your MCP client for all write tools (the server's 22 write tools are identifiable by their MCP Tool Annotations: `readOnlyHint: false`, `destructiveHint: true`)
+- Enable **confirmation dialogs** in your MCP client for all write tools (the server's 21 write tools are identifiable by their MCP Tool Annotations: `readOnlyHint: false`, `destructiveHint: true`)
 - Use `AUTOMOX_MCP_READ_ONLY=true` for monitoring and read-only use cases
 - Use `AUTOMOX_MCP_MODULES` to load only required tool domains (principle of least functionality)
 - Test new or untrusted server versions in a staging environment with `AUTOMOX_MCP_READ_ONLY=true` before production use

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -250,8 +250,8 @@ Compound tools (`get_patch_tuesday_readiness`, `get_compliance_snapshot`, `get_d
 
 | Compound tool | Capped sections | Follow-up detail tools |
 |---|---|---|
-| `get_patch_tuesday_readiness` | `prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules` | `get_prepatch_report`, `patch_approvals_summary`, `policy_catalog` |
-| `get_compliance_snapshot` | `noncompliant_report.devices`, `device_health.stale_devices` | `get_noncompliant_report`, `device_health_metrics` |
+| `get_patch_tuesday_readiness` | `prepatch_report.devices`, `patch_approvals.approvals`, `patch_policy_schedules` | `prepatch_report`, `patch_approvals_summary`, `policy_catalog` |
+| `get_compliance_snapshot` | `noncompliant_report.devices`, `device_health.stale_devices` | `noncompliant_report`, `device_health_metrics` |
 | `get_device_full_profile` | `packages.packages` (inventory is server-side summarized) | `list_device_packages` |
 
 When a section is truncated, the response surfaces a per-section entry under `metadata.section_summaries`:
@@ -265,12 +265,12 @@ When a section is truncated, the response surfaces a per-section entry under `me
         "total": 230,
         "returned": 10,
         "has_more": true,
-        "follow_up_tool": "get_prepatch_report",
+        "follow_up_tool": "prepatch_report",
         "follow_up_args_hint": {"group_id": 42}
       }
     },
     "notes": [
-      "prepatch_report.devices capped at 10 of 230 — call `get_prepatch_report` for the full set."
+      "prepatch_report.devices capped at 10 of 230 — call `prepatch_report` for the full set."
     ]
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.31"
+version = "1.0.32"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -204,14 +204,43 @@ async def list_policy_runs_v2(
         metadata["filters_applied"] = filters_applied
         metadata["upstream_pool_size"] = fetched_total
         metadata["filtered_count"] = filtered_total
+        next_page = effective_page + 1 if has_more else None
         metadata["pagination"] = build_pagination_metadata(
             page=effective_page,
             page_size=effective_limit,
             total_elements=filtered_total,
             has_more=has_more,
-            # Legacy aliases retained for backwards-compat (#52).
-            extra={"limit": effective_limit, "total_count": filtered_total},
+            # Legacy aliases retained for backwards-compat (#52). `next_page`
+            # matches the hint policy_catalog already provides so the LLM
+            # doesn't have to derive it from current_page + 1 (#76).
+            extra={
+                "limit": effective_limit,
+                "total_count": filtered_total,
+                "next_page": next_page,
+            },
         )
+        # Top-level suggested_next_call mirrors policy_catalog's contract
+        # (#76): when more pages are available, hand the LLM the exact next
+        # invocation rather than making it infer args from raw counters.
+        if has_more:
+            metadata["suggested_next_call"] = {
+                "tool": "policy_runs_v2",
+                "args": {
+                    k: v
+                    for k, v in {
+                        "policy_uuid": policy_uuid_str or policy_uuid,
+                        "policy_name": policy_name,
+                        "policy_type": policy_type,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "result_status": result_status,
+                        "sort": sort,
+                        "page": next_page,
+                        "limit": effective_limit,
+                    }.items()
+                    if v is not None
+                },
+            }
         if fetched_total >= _FILTER_POOL_LIMIT:
             metadata["upstream_pool_capped"] = True
             metadata["pool_cap_note"] = (

--- a/tests/test_workflows_policy_history.py
+++ b/tests/test_workflows_policy_history.py
@@ -196,6 +196,35 @@ async def test_list_runs_client_pagination_slices_filtered_results() -> None:
     assert pagination["has_more"] is True
     assert pagination["limit"] == 10
     assert pagination["total_count"] == 25
+    # #76: emit next_page so the LLM doesn't have to derive it from page+1.
+    assert pagination["next_page"] == 2
+    suggested = result["metadata"]["suggested_next_call"]
+    assert suggested["tool"] == "policy_runs_v2"
+    assert suggested["args"]["page"] == 2
+    assert suggested["args"]["limit"] == 10
+    assert suggested["args"]["policy_type"] == "custom"
+
+
+@pytest.mark.asyncio
+async def test_list_runs_last_page_omits_next_page_hints() -> None:
+    """#76: when has_more=False, neither next_page nor suggested_next_call
+    should appear — the LLM must know there's nothing more to fetch."""
+    runs = [
+        {"policy_uuid": f"p{i}", "policy_name": f"name-{i}", "policy_type": "custom"}
+        for i in range(15)
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        policy_type="custom",
+        limit=10,
+        page=1,  # 15 items, limit=10, page=1 → items 10-14, no more pages
+    )
+    pagination = result["metadata"]["pagination"]
+    assert pagination["has_more"] is False
+    assert "next_page" not in pagination
+    assert "suggested_next_call" not in result["metadata"]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.31"
+version = "1.0.32"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #76.

## Code fix

\`policy_runs_v2\` emitted \`metadata.pagination.has_more=true\` without telling the caller how to fetch the rest, forcing an LLM to infer \"call with \`page=current_page+1\`\" from raw counters. That diverged from \`policy_catalog\` which provides both \`pagination.next_page\` AND a top-level \`metadata.suggested_next_call\` block.

Now \`policy_runs_v2\` matches that contract:

\`\`\`json
{
  \"metadata\": {
    \"pagination\": {
      \"page\": 1,
      \"page_size\": 10,
      \"has_more\": true,
      \"total_elements\": 25,
      \"total_pages\": 3,
      \"next_page\": 2
    },
    \"suggested_next_call\": {
      \"tool\": \"policy_runs_v2\",
      \"args\": {
        \"policy_type\": \"custom\",
        \"page\": 2,
        \"limit\": 10
      }
    }
  }
}
\`\`\`

On the last page neither hint is emitted, so the LLM knows there's nothing more to fetch. The \`suggested_next_call.args\` carries through the original filter parameters (\`policy_uuid\`, \`policy_name\`, \`policy_type\`, time range, status, sort), so the LLM doesn't lose context.

Surfaced by \`tests/exploratory_sweep.py\` (Policy Operator persona) during the v1.0.30 review.

## Doc audit catch-up

This is the part that should have shipped alongside earlier PRs. My PR-submission memory says to audit docs on every PR; I haven't been.

### \`docs/tool-reference.md\` — the v1.0.30 bug names lived on in the doc

The compound-tool contract section documented \`get_prepatch_report\` and \`get_noncompliant_report\` as the follow-up tools. **Same bug** the v1.0.30 PR (#72) fixed in \`workflows/compound.py\`. The contract doc that teaches the names to readers and downstream LLMs was never updated. Now reads \`prepatch_report\` and \`noncompliant_report\` in:
- The compound-tool follow-up table (line 253-254).
- The example \`metadata.section_summaries\` JSON (line 268).
- The example \`metadata.notes\` text (line 273).

### Tool-count drift across README / SECURITY / deployment-security

Actual tool surface: **79 total, 58 read-only, 21 write** (verified by \`grep '@server.tool' src/automox_mcp/tools/*.py\` and the registered-surface count in the v1.0.30 regression test).

The docs had drifted to:
| File | Was | Now |
|---|---|---|
| \`README.md:106\` | \"57 of 79 tools remain\" | \"58 of 79\" |
| \`README.md:133\` | \"58 of 80\" | \"58 of 79\" |
| \`README.md:185\` | \"22 write tools\" | \"21 write tools\" |
| \`SECURITY.md:63\` | \"22 write tools\" | \"21 write tools\" |
| \`SECURITY.md:190\` | \"all 80 tools\" | \"all 79 tools\" |
| \`docs/deployment-security.md:268\` | \"22 write tools\" | \"21 write tools\" |

CHANGELOG was already current through v1.0.31 (entries added inline with each release).

## Test plan

- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy .\` — clean
- [x] \`uv run pytest tests/\` — 1126 passed (was 1125, +1 new pagination regression test)
- [x] New test \`test_list_runs_last_page_omits_next_page_hints\` asserts the negative case too — neither hint emitted on the last page.
- [x] Doc edits eyeballed; only the specific drift items changed.

## Version

1.0.31 → 1.0.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)