### PR TITLE
Sweep harness cleanup: false-positive validators + per-tool param mismatches

### DIFF
--- a/tests/exploratory_sweep.py
+++ b/tests/exploratory_sweep.py
@@ -191,32 +191,48 @@ def v_no_exception_leak(parsed: Any, raw: str) -> list[str]:
 
 
 def v_no_internal_path_leak(parsed: Any, raw: str) -> list[str]:
-    """Filesystem paths from the server host should not appear in responses."""
-    out = []
-    for needle in ("/Users/", "/home/runner", "/private/var/"):
-        if needle in raw:
-            out.append(f"internal path leak: {needle!r}")
-    return out
+    """Filesystem paths from the *server host* should not appear in responses.
+
+    Earlier versions also flagged ``/Users/`` and ``/private/var/``, but those
+    are legitimate macOS device-inventory paths (LaunchAgent plists, syslog
+    sockets, etc.) returned by ``get_device_inventory`` and friends — the
+    paths are FROM the managed endpoint, not the MCP server. Only flag
+    ``/home/runner`` (the GitHub Actions runner path) which would never
+    legitimately appear in API responses.
+    """
+    if "/home/runner" in raw:
+        return ["internal path leak: '/home/runner'"]
+    return []
 
 
 def v_pagination_coherent(parsed: Any, raw: str) -> list[str]:
-    """If pagination metadata claims has_more, a cursor/offset must be provided."""
+    """If pagination metadata claims has_more, the response must provide a hint
+    for how to fetch the next page. Accepts cursor-, offset-, or page-based
+    schemes (next_cursor / next_offset / next_page) or a top-level
+    metadata.suggested_next_call block (the canonical contract since #76)."""
     if not isinstance(parsed, dict):
         return []
     meta = parsed.get("metadata") or {}
     if not isinstance(meta, dict):
         return ["metadata is not a dict"]
-    pag = meta.get("pagination") or meta
+    pag = meta.get("pagination") if isinstance(meta.get("pagination"), dict) else meta
     has_more = pag.get("has_more") if isinstance(pag, dict) else None
-    if has_more:
-        nxt = (
-            (pag.get("next_cursor") if isinstance(pag, dict) else None)
-            or (pag.get("next_offset") if isinstance(pag, dict) else None)
-            or meta.get("next_cursor")
-        )
-        if not nxt:
-            return ["has_more=True but no next_cursor / next_offset"]
-    return []
+    if not has_more:
+        return []
+    # Any one of these is sufficient evidence the caller can drill into the
+    # next page. policy_catalog / policy_runs_v2 use next_page +
+    # suggested_next_call; cursor-based tools use next_cursor; offset-based
+    # tools use next_offset. A top-level suggested_next_call is the canonical
+    # form per the compound-tool contract.
+    if isinstance(pag, dict):
+        for hint in ("next_cursor", "next_offset", "next_page"):
+            if pag.get(hint) is not None:
+                return []
+    if meta.get("next_cursor") is not None:
+        return []
+    if isinstance(meta.get("suggested_next_call"), dict):
+        return []
+    return ["has_more=True but no next_cursor / next_offset / next_page / suggested_next_call"]
 
 
 def v_truncation_honest(parsed: Any, raw: str) -> list[str]:
@@ -303,6 +319,14 @@ async def probe(
     extra_anomaly_checks: list[str] | None = None,
 ) -> Any:
     is_error, parsed, raw = await call_tool(session, tool, args)
+    # The MCP server enforces 30 calls per 60s locally; a ~50-probe sweep
+    # blows past that in under a minute. Detect the rate-limit error and
+    # sleep until the sliding window opens, then retry once. Real failures
+    # (other isError outcomes) propagate as FAIL on first attempt.
+    if is_error and "rate limit exceeded" in raw.lower():
+        print(f"    [{DIM}WAIT   {RESET}] rate-limited; sleeping 60s before retrying {tool}...")
+        await asyncio.sleep(60)
+        is_error, parsed, raw = await call_tool(session, tool, args)
     if is_error and not expect_error:
         record(step, tool, "FAIL", f"isError — {raw[:120]}")
         return parsed
@@ -382,14 +406,27 @@ async def persona_security_analyst(session: ClientSession) -> None:
     await probe(session, "noncompliant report", "noncompliant_report", {})
 
     scenario("audit events recent activity")
-    await probe(session, "audit_events_ocsf", "audit_events_ocsf", {"limit": 10})
-
-    scenario("advanced device search by severity")
+    # audit_events_ocsf requires a date string (YYYY-MM-DD). Use today.
+    today = time.strftime("%Y-%m-%d")
     await probe(
         session,
-        "search critical",
+        "audit_events_ocsf",
+        "audit_events_ocsf",
+        {"date": today, "limit": 10},
+    )
+
+    # advanced_device_search takes a structured Elasticsearch-style `query`
+    # dict whose exact DSL isn't documented here; calling without that
+    # specific shape returns "organizationUuids required" from upstream.
+    # The Fleet Manager persona already exercises `search_devices` for the
+    # device-search surface, so we skip this probe rather than guess at
+    # the right payload and emit noise. To probe this tool, pass a
+    # tenant-specific query via env var (out of scope for the canned sweep).
+    record(
+        "minimal query",
         "advanced_device_search",
-        {"severity": ["critical", "high"]},
+        "SKIP",
+        "upstream query DSL not modeled; covered by search_devices in Fleet Manager",
     )
 
 
@@ -397,7 +434,7 @@ async def persona_fleet_manager(session: ClientSession) -> None:
     persona("Fleet Manager")
 
     scenario("list devices small page → multi-page if available")
-    parsed = await probe(session, "list page 1", "list_devices", {"limit": 50})
+    await probe(session, "list page 1", "list_devices", {"limit": 50})
 
     scenario("device health aggregate")
     await probe(session, "device_health_metrics", "device_health_metrics", {})
@@ -437,14 +474,26 @@ async def persona_policy_operator(session: ClientSession) -> None:
     await probe(session, "policy_compliance_stats", "policy_compliance_stats", {})
 
     scenario("policy_detail + runs + count for a known policy")
-    await probe(
-        session,
-        "policy detail",
-        "policy_detail",
-        {"policy_id": 1, "include_recent_runs": 3},
-        # policy_id=1 may not exist on this tenant — accept anomaly/fail gracefully
-        validators=(v_no_exception_leak, v_no_internal_path_leak),
-    )
+    # Resolve a real policy_id from the catalog rather than guessing at id=1
+    # (which doesn't exist on most tenants and produces unhelpful FAILs).
+    catalog_parsed = await probe(session, "lookup policy id", "policy_catalog", {"limit": 1})
+    catalog_data = (catalog_parsed or {}).get("data") if isinstance(catalog_parsed, dict) else None
+    policy_id: int | None = None
+    if isinstance(catalog_data, dict):
+        policies = catalog_data.get("policies") or []
+        if isinstance(policies, list) and policies and isinstance(policies[0], dict):
+            pid = policies[0].get("id") or policies[0].get("policy_id")
+            if isinstance(pid, int):
+                policy_id = pid
+    if policy_id is not None:
+        await probe(
+            session,
+            "policy detail",
+            "policy_detail",
+            {"policy_id": policy_id, "include_recent_runs": 3},
+        )
+    else:
+        record("policy detail", "policy_detail", "SKIP", "no policy id resolvable from catalog")
     # Use the configured policy UUID for the v2 path
     await probe(
         session,
@@ -452,7 +501,8 @@ async def persona_policy_operator(session: ClientSession) -> None:
         "policy_runs_v2",
         {"policy_uuid": POLICY_UUID, "limit": 5},
     )
-    await probe(session, "run_count", "policy_run_count", {"policy_uuid": POLICY_UUID})
+    # policy_run_count is org-scoped aggregate; only accepts `days`.
+    await probe(session, "run_count", "policy_run_count", {"days": 7})
 
 
 async def persona_vuln_manager(session: ClientSession) -> None:
@@ -526,7 +576,7 @@ async def persona_device_drill(session: ClientSession) -> None:
     )
 
     scenario("device_detail with all includes")
-    await probe(
+    detail_parsed = await probe(
         session,
         "detail",
         "device_detail",
@@ -538,6 +588,13 @@ async def persona_device_drill(session: ClientSession) -> None:
             "include_raw_details": False,
         },
     )
+    # Pull the device UUID from the detail response for the UUID-keyed
+    # follow-up tools (get_device_scheduled_windows expects a UUID, not an
+    # integer device_id).
+    detail_data = (detail_parsed or {}).get("data") if isinstance(detail_parsed, dict) else None
+    device_uuid: str | None = None
+    if isinstance(detail_data, dict):
+        device_uuid = detail_data.get("server_uuid") or detail_data.get("uuid")
 
     scenario("inventory + categories")
     await probe(
@@ -554,13 +611,23 @@ async def persona_device_drill(session: ClientSession) -> None:
     )
 
     scenario("assignments + scheduled windows")
-    await probe(session, "assignments", "get_device_assignments", {"device_id": DEVICE_ID})
-    await probe(
-        session,
-        "scheduled windows",
-        "get_device_scheduled_windows",
-        {"device_id": DEVICE_ID},
-    )
+    # get_device_assignments is org-wide (no device_id arg).
+    await probe(session, "assignments", "get_device_assignments", {})
+    # get_device_scheduled_windows is UUID-keyed. Skip if we couldn't resolve.
+    if device_uuid:
+        await probe(
+            session,
+            "scheduled windows",
+            "get_device_scheduled_windows",
+            {"org_uuid": ORG_UUID, "device_uuid": device_uuid},
+        )
+    else:
+        record(
+            "scheduled windows",
+            "get_device_scheduled_windows",
+            "SKIP",
+            "no device UUID resolvable from device_detail",
+        )
 
     scenario("packages — paginated list")
     await probe(
@@ -575,11 +642,12 @@ async def persona_maintenance_windows(session: ClientSession) -> None:
     persona("Maintenance Windows")
 
     scenario("policy windows search + drill")
+    # search_policy_windows uses `size` not `limit` (Spring-style pagination).
     parsed = await probe(
         session,
         "search windows",
         "search_policy_windows",
-        {"org_uuid": ORG_UUID, "limit": 5},
+        {"org_uuid": ORG_UUID, "size": 5},
     )
     data = (parsed or {}).get("data") or {}
     items = data.get("policy_windows") if isinstance(data, dict) else []
@@ -600,21 +668,37 @@ async def persona_maintenance_windows(session: ClientSession) -> None:
             )
 
     scenario("group scheduled windows")
-    # First need a group id; reuse from server groups
+    # get_group_scheduled_windows is UUID-keyed. Pull the UUID from the
+    # server-groups listing rather than the integer id.
     groups_parsed = await probe(session, "list groups", "list_server_groups", {})
     data = (groups_parsed or {}).get("data") or {}
     groups = (
         data.get("groups") or data.get("server_groups") or (data if isinstance(data, list) else [])
     )
+    group_uuid: str | None = None
     if isinstance(groups, list) and groups and isinstance(groups[0], dict):
-        gid = groups[0].get("id")
-        if gid:
-            await probe(
-                session,
-                "group windows",
-                "get_group_scheduled_windows",
-                {"group_id": gid},
-            )
+        first = groups[0]
+        group_uuid = first.get("uuid") or first.get("server_group_uuid") or first.get("group_uuid")
+    if group_uuid:
+        # The upstream requires `date` even though the Pydantic schema marks
+        # it optional, and the exact accepted format is tenant- /
+        # endpoint-specific (YYYY-MM-DD rejected as "Invalid date-time
+        # format", ISO 8601 UTC rejected as "Validation failed"). Skip
+        # rather than guess at undocumented upstream date semantics; this
+        # is a tool-quirk to document, not a harness defect.
+        record(
+            "group windows",
+            "get_group_scheduled_windows",
+            "SKIP",
+            "upstream `date` format undocumented (rejects YYYY-MM-DD and ISO 8601 UTC)",
+        )
+    else:
+        record(
+            "group windows",
+            "get_group_scheduled_windows",
+            "SKIP",
+            "no group UUID resolvable from list_server_groups",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -628,19 +712,51 @@ async def safe_writes(session: ClientSession) -> None:
 
     sentinel = f"sweep-probe-{uuid.uuid4().hex[:8]}"
 
-    scenario(f"server group create+delete: name={sentinel}")
-    parsed = await probe(
-        session,
-        "create group",
-        "create_server_group",
-        {"name": sentinel, "color": "#888888"},
+    # create_server_group requires parent_server_group_id; grab the org's
+    # default (first listed) group to nest the probe-created group under.
+    groups_parsed = await probe(session, "lookup parent group", "list_server_groups", {})
+    groups_data = (groups_parsed or {}).get("data") or {}
+    candidates = (
+        groups_data.get("groups")
+        or groups_data.get("server_groups")
+        or (groups_data if isinstance(groups_data, list) else [])
     )
-    data = (parsed or {}).get("data") or {}
-    gid = data.get("id") if isinstance(data, dict) else None
-    if gid:
-        await probe(session, "delete group", "delete_server_group", {"group_id": gid})
+    parent_id: int | None = None
+    if isinstance(candidates, list):
+        for g in candidates:
+            if isinstance(g, dict):
+                pid = g.get("id") or g.get("server_group_id")
+                if isinstance(pid, int):
+                    parent_id = pid
+                    break
+
+    scenario(f"server group create+delete: name={sentinel}")
+    if parent_id is None:
+        record(
+            "create group",
+            "create_server_group",
+            "SKIP",
+            "no parent_server_group_id resolvable from list_server_groups",
+        )
     else:
-        record("delete group", "delete_server_group", "SKIP", "create did not return an id")
+        parsed = await probe(
+            session,
+            "create group",
+            "create_server_group",
+            {
+                "name": sentinel,
+                # 1440 minutes = 24h (typical default). ui_color (not `color`).
+                "refresh_interval": 1440,
+                "parent_server_group_id": parent_id,
+                "ui_color": "#888888",
+            },
+        )
+        data = (parsed or {}).get("data") or {}
+        gid = data.get("id") if isinstance(data, dict) else None
+        if gid:
+            await probe(session, "delete group", "delete_server_group", {"group_id": gid})
+        else:
+            record("delete group", "delete_server_group", "SKIP", "create did not return an id")
 
     scenario(f"webhook create+delete using sink={SWEEP_WEBHOOK_SINK}")
     parsed = await probe(
@@ -674,19 +790,34 @@ async def safe_writes(session: ClientSession) -> None:
         record("delete webhook", "delete_webhook", "SKIP", "create did not return an id")
 
     scenario("idempotency double-call")
+    if parent_id is None:
+        record(
+            "idempotency",
+            "create_server_group",
+            "SKIP",
+            "no parent_server_group_id resolvable",
+        )
+        return
     req_id = f"sweep-{uuid.uuid4().hex}"
     sentinel2 = f"sweep-idem-{uuid.uuid4().hex[:8]}"
+    idem_args = {
+        "name": sentinel2,
+        "refresh_interval": 1440,
+        "parent_server_group_id": parent_id,
+        "ui_color": "#888888",
+        "request_id": req_id,
+    }
     parsed_a = await probe(
         session,
         "create group #1",
         "create_server_group",
-        {"name": sentinel2, "color": "#888888", "request_id": req_id},
+        idem_args,
     )
     parsed_b = await probe(
         session,
         "create group #2 same id",
         "create_server_group",
-        {"name": sentinel2, "color": "#888888", "request_id": req_id},
+        idem_args,
     )
     # Both should resolve cleanly. Either the second is a `duplicate=True`
     # marker (in-flight collision unlikely since we awaited the first) or it


### PR DESCRIPTION
## Why

\`tests/exploratory_sweep.py\` (shipped in v1.0.30) produced two real findings — the compound-tool dispatch bug (fixed in v1.0.30) and the \`policy_runs_v2\` pagination gap (fixed in v1.0.32 / #76). But it also produced a lot of noise from validator false positives and persona-scenario param mismatches that obscured the real signal. This cleanup makes future re-runs trustworthy.

## Before / after

Same probe surface against the same tenant:

| Metric | Before | After |
|---|---|---|
| PASS | 25 | **43** |
| ANOMALY | 4 | **0** |
| FAIL | 12 | **0** |
| SKIP | 2 | 5 (all intentional + documented) |
| Elapsed | 38 s | 93 s (60 s of which is one rate-limit retry sleep) |

## Changes

### Validator fixes (the false positives)

- \`v_pagination_coherent\` previously only recognized \`next_cursor\` / \`next_offset\` as valid \"has_more\" hints. That falsely flagged \`policy_catalog\` and \`policy_runs_v2\` (page-based with \`next_page\` + \`suggested_next_call\`). Now accepts cursor-, offset-, OR page-based hints, plus a top-level \`metadata.suggested_next_call\` block as canonical evidence.
- \`v_no_internal_path_leak\` previously flagged \`/Users/\` and \`/private/var/\`. Those are legitimate macOS device-inventory paths returned by \`get_device_inventory\` (LaunchAgent plists, syslog sockets — paths FROM the managed endpoint, not the MCP server). Now flags only \`/home/runner\` (the GitHub Actions runner path that would never legitimately appear in tenant data).

### Per-tool param fixes (the 12 FAILs)

| Tool | Was | Now |
|---|---|---|
| \`audit_events_ocsf\` | missing required \`date\` | pass today |
| \`advanced_device_search\` | guessed at \`severity\` kwarg | SKIP (DSL not modeled; \`search_devices\` covers the surface) |
| \`policy_run_count\` | invented \`policy_uuid\` arg | \`days\` (the only param) |
| \`get_device_assignments\` | invented \`device_id\` arg | called bare (org-wide tool) |
| \`get_device_scheduled_windows\` | sent \`device_id\` | resolve \`device_uuid\` from \`device_detail\` |
| \`search_policy_windows\` | \`limit\` | \`size\` (Spring-style) |
| \`get_group_scheduled_windows\` | sent \`group_id\` | resolve \`group_uuid\` from \`list_server_groups\` + SKIP'd for the date-format quirk (filed as #78) |
| \`create_server_group\` | only \`name\` + \`color\` | required \`refresh_interval=1440\`, \`parent_server_group_id\` (resolved), and \`ui_color\` (renamed from \`color\`) |
| \`policy_detail\` | guessed at \`policy_id=1\` | resolve from \`policy_catalog\` |

### Rate-limit retry

The first cleanup run exposed a different problem — the fixed harness actually makes successful upstream calls now (where the buggy old one fail-fasted on validation errors without consuming rate budget), and a ~50-probe sweep blows past the local 30/60s rate limit around probe 30. \`probe()\` now detects the rate-limit error string, sleeps 60s for the sliding window to open, and retries once. Visible as a \`[WAIT]\` line during the run.

## Issues filed during cleanup

- **#78** — \`get_group_scheduled_windows\` \`date\` is documented optional but upstream requires it, and the accepted format is undocumented (rejects both \`YYYY-MM-DD\` and ISO 8601 UTC).

## No version bump

Test-harness only; not part of the published library surface.

## Test plan

- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy .\` — clean (tests/ excluded per project config)
- [x] \`uv run pytest tests/\` — 1126 passed (no production code changes)
- [x] Live-tenant re-run: 43 PASS / 5 SKIP / 0 FAIL / 0 ANOMALY in 92.7s

🤖 Generated with [Claude Code](https://claude.com/claude-code)