### PR TITLE
Loosen scheduled-windows date regex + document upstream quirks (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.33] - 2026-05-28
+
+### Changed
+
+- **Scheduled-windows `date` schema accepts the standard ISO 8601 surface (#78)** — `GetGroupScheduledWindowsParams.date` and `GetDeviceScheduledWindowsParams.date` previously rejected any ISO 8601 string with milliseconds or a timezone offset (e.g., `2026-05-28T00:00:00.000Z`, `2026-05-28T00:00:00+00:00`), which are the default outputs of `datetime.isoformat()` in Python and `Date.toISOString()` in JavaScript. Loosened the regex to `^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:\d{2})?)?$` so the schema matches what callers actually emit. Added a `description` to both fields documenting a known upstream Automox API bug (issue #78): the `/policy-windows/.../scheduled-windows` endpoints currently reject every `date` format including the one documented in their own error message — omit the parameter unless tenant-specific scoping is required. New parametrized schema tests cover the accepted formats and reject obvious garbage.
+- **`audit_events_ocsf` tool description documents the dual-permission requirement** — per the Automox API change log entry of 2025-10-27, the upstream OCSF audit endpoint now requires the calling API key to have BOTH `organization:manage` and `users:read` scopes; keys missing either scope return 403. The tool description now surfaces that requirement so callers can provision the right key without hitting a runtime 403.
+
 ## [1.0.32] - 2026-05-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.32"
+version = "1.0.33"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/tools/audit_v2_tools.py
+++ b/src/automox_mcp/tools/audit_v2_tools.py
@@ -27,7 +27,10 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "Query OCSF-formatted audit events from the Automox Audit Service v2. "
             "Supports filtering by date, event category (authentication, account_change, "
             "entity_management, user_access, web_resource_activity), and event type name. "
-            "Uses cursor-based pagination for large result sets."
+            "Uses cursor-based pagination for large result sets. "
+            "Permissions: as of 2025-10-27 the upstream endpoint requires the API key "
+            "to have BOTH `organization:manage` and `users:read` scopes; keys missing "
+            "either scope return 403."
         ),
         annotations={
             "readOnlyHint": True,

--- a/src/automox_mcp/tools/policy_windows_tools.py
+++ b/src/automox_mcp/tools/policy_windows_tools.py
@@ -50,16 +50,59 @@ class CheckWindowActiveParams(ForbidExtraModel):
     window_uuid: UUID
 
 
+# ISO 8601 date or date-time. Accepts:
+#   YYYY-MM-DD                       (date only)
+#   YYYY-MM-DDTHH:MM[:SS]            (local time)
+#   YYYY-MM-DDTHH:MM[:SS].sss        (with sub-second precision)
+#   YYYY-MM-DDTHH:MM[:SS][.sss]Z         (UTC)
+#   YYYY-MM-DDTHH:MM[:SS][.sss]+HH:MM    (with offset)
+#
+# Previous regex was tighter (`^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?Z?)?$`)
+# and silently rejected ISO 8601 strings with milliseconds or offsets — both
+# common outputs from `datetime.isoformat()` and JS `Date.toISOString()`.
+# Loosened to accept the standard ISO 8601 surface so the schema reflects
+# what callers actually emit. Upstream date-format quirks documented per
+# field below — see issue #78.
+_ISO_DATE_OR_DATETIME = (
+    r"^\d{4}-\d{2}-\d{2}"
+    r"(T\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:\d{2})?)?$"
+)
+
+
+# Known upstream quirk (issue #78): the /policy-windows/.../scheduled-windows
+# endpoints declare `date` optional but treat it as required, and reject any
+# format containing URL-encoded colons (i.e., the format every standard HTTP
+# client emits). The Automox API error message says "Expected format:
+# YYYY-MM-DDTHH:mm:ss" but in practice rejects that too. Until upstream is
+# fixed, omitting `date` is the most reliable path; callers who must pass
+# one should expect a 400 from the upstream.
+_SCHEDULED_WINDOWS_DATE_DESCRIPTION = (
+    "Optional ISO 8601 date or date-time. Note: the upstream Automox API "
+    "currently has a known bug where this parameter is rejected for most "
+    "formats including the one documented in its own error message; omit "
+    "this parameter unless you have a tenant-specific reason to set it. "
+    "Tracked as issue #78."
+)
+
+
 class GetGroupScheduledWindowsParams(ForbidExtraModel):
     org_uuid: UUID
     group_uuid: UUID
-    date: str | None = Field(None, pattern=r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?Z?)?$")
+    date: str | None = Field(
+        None,
+        pattern=_ISO_DATE_OR_DATETIME,
+        description=_SCHEDULED_WINDOWS_DATE_DESCRIPTION,
+    )
 
 
 class GetDeviceScheduledWindowsParams(ForbidExtraModel):
     org_uuid: UUID
     device_uuid: UUID
-    date: str | None = Field(None, pattern=r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?Z?)?$")
+    date: str | None = Field(
+        None,
+        pattern=_ISO_DATE_OR_DATETIME,
+        description=_SCHEDULED_WINDOWS_DATE_DESCRIPTION,
+    )
 
 
 class CreatePolicyWindowParams(ForbidExtraModel):

--- a/tests/test_workflows_policy_windows.py
+++ b/tests/test_workflows_policy_windows.py
@@ -495,3 +495,45 @@ async def test_all_functions_include_metadata() -> None:
     for r in results:
         assert "metadata" in r, f"Missing metadata in {r}"
         assert r["metadata"]["deprecated_endpoint"] is False
+
+
+# ---------------------------------------------------------------------------
+# Schema regex — #78: accept the full standard ISO 8601 surface so the
+# schema reflects what `datetime.isoformat()` and JS `Date.toISOString()`
+# actually emit. Previously the regex blocked milliseconds and offsets.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-05-28",  # date only
+        "2026-05-28T00:00",  # date + HH:MM
+        "2026-05-28T00:00:00",  # + seconds
+        "2026-05-28T00:00:00.000",  # + milliseconds
+        "2026-05-28T00:00:00.000000",  # + microseconds
+        "2026-05-28T00:00:00Z",  # UTC
+        "2026-05-28T00:00:00.000Z",  # millis + UTC
+        "2026-05-28T00:00:00+00:00",  # offset
+        "2026-05-28T00:00:00.000+00:00",  # millis + offset
+        "2026-05-28T00:00:00-04:00",  # negative offset
+    ],
+)
+def test_scheduled_windows_date_accepts_iso8601(value: str) -> None:
+    """#78: the loosened regex must accept the formats standard ISO 8601 emitters produce."""
+    from automox_mcp.tools.policy_windows_tools import GetGroupScheduledWindowsParams
+
+    params = GetGroupScheduledWindowsParams(org_uuid=_ORG_UUID, group_uuid=_GROUP_UUID, date=value)
+    assert params.date == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["banana", "2026/05/28", "not-a-date", ""],
+)
+def test_scheduled_windows_date_rejects_obvious_garbage(value: str) -> None:
+    """Loosening the regex should not let free-text through."""
+    from pydantic import ValidationError
+
+    from automox_mcp.tools.policy_windows_tools import GetGroupScheduledWindowsParams
+
+    with pytest.raises(ValidationError):
+        GetGroupScheduledWindowsParams(org_uuid=_ORG_UUID, group_uuid=_GROUP_UUID, date=value)

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.32"
+version = "1.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #78.

Two API-doc-driven changes bundled per the v1.0.32 audit.

## #78 — Scheduled-windows \`date\` schema

Empirically probed \`get_group_scheduled_windows\` / \`get_device_scheduled_windows\` against the live tenant. Two findings, one on each side of the wire:

### Our schema's regex was too restrictive

Previous pattern \`^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?Z?)?$\` silently rejected:

- \`2026-05-28T00:00:00.000Z\` (the default output of JavaScript \`Date.toISOString()\`)
- \`2026-05-28T00:00:00+00:00\` (the default output of Python \`datetime.isoformat()\` with timezone)
- \`2026-05-28T00:00:00.000000\` (Python \`datetime\` default microseconds)

Loosened to \`^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,9})?)?(Z|[+-]\\d{2}:\\d{2})?)?$\` so the schema reflects what callers actually emit. New parametrized tests cover all of the above plus negative offsets, with companion tests confirming obvious garbage (\`banana\`, \`2026/05/28\`, \`\`) still rejects.

### Upstream Automox API has a real bug

Once a value passes our schema, the upstream returns 400 for **every** format I tried, including the one its own error message documents:

| Format | Upstream response |
|---|---|
| \`YYYY-MM-DD\` | \`400 \"Invalid date-time format. Expected: YYYY-MM-DDTHH:mm:ss\"\` |
| \`YYYY-MM-DDTHH:MM:SSZ\` | \`400 \"Validation failed\"\` |
| \`YYYY-MM-DDTHH:MM:SS\` (URL-encoded colons, the default) | \`400 \"Invalid date-time format\"\` — even though that's the documented format |
| \`YYYY-MM-DDTHH:MM:SS\` (literal colons) | \`400 \"Validation failed\"\` |
| \`YYYY-MM-DDTHH:MM:SS.sssZ\` | \`400 \"Invalid date-time format\"\` |

Looks like the upstream parses the URL-encoded form against its regex without first decoding, but even when colons are passed literally the validation still fails. This is on Automox to fix — not something we can solve client-side.

Documented this on both fields' Pydantic \`description\` so callers know to omit \`date\` unless they have tenant-specific reason to set it. The quirk is tracked as #78 itself (which can be the public-facing issue if Automox wants to follow up).

## \`audit_events_ocsf\` — dual-permission requirement

Per the [Automox API change log entry of 2025-10-27](https://docs.automox.com/product/Developer/What_s_New.htm), the upstream OCSF audit endpoint now requires the calling API key to have **both** \`organization:manage\` and \`users:read\` scopes; keys missing either scope return 403. Surfaced in the tool description so callers can provision the right key without hitting a runtime 403.

## Filed alongside (out of scope for this PR)

- **#80** — Saved-Search CRUD + bulk-assignment tools (Device Explorer 2025-12-11, 23 new endpoints; we currently expose 4)
- **#81** — Splashtop Remote Control tools (10 new endpoints, 2026-01-14; we expose 0)

## Test plan

- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy .\` — clean
- [x] \`uv run pytest tests/\` — 1140 passed (+14 new parametrized schema tests)
- [x] Live-tenant probe verified the upstream-bug findings
- [x] Re-grep on tool counts — 79 total, 21 write, 58 read (README/SECURITY/deployment-security already correct from v1.0.32 audit)

## Version

1.0.32 → 1.0.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)