### PR TITLE
Parallel pagination for device-list workflows (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.34] - 2026-05-28
+
+### Performance
+
+- **Parallel pagination for device-list workflows (#69)** — `summarize_device_health`, `list_device_inventory`, and `search_devices` previously paginated `/servers` serially, costing one upstream RTT per page; on multi-page tenants the loop dominated wall time. New shared helper `automox_mcp.utils.pagination.parallel_paginate` fetches page 0 serially (fast path for single-page tenants), then fans out subsequent pages via `asyncio.gather` in batches of `concurrency` (default 4 for exhaustive aggregation, 2 for filter-and-limit workflows). Results are walked in strict page order; short pages and `on_page` early-stop signals discard any prefetched pages after the terminator (offset pagination makes them empty or racily inconsistent).
+  - **Empirical speedup on a 5-page query against the live tenant: 4 parallel pages = 1.21s vs 4.49s serial (3.7×).** The full `summarize_device_health` workflow at `limit=50` (5 pages) ran in ~2.0s vs ~5s serial-projected.
+  - 12 new helper tests cover single-page, exact-multiple-of-page-size, off-by-one termination, short-page-discards-batch-tail, on_page early stop, strict page-order invariant under out-of-order completion, concurrency bound, gather-with-failure, and boundary conditions (`max_pages=0`, `max_pages=1`, empty page 0).
+  - No behavior change for callers: response shape and the canonical pagination metadata block are unchanged.
+
 ## [1.0.33] - 2026-05-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.33"
+version = "1.0.34"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/src/automox_mcp/utils/pagination.py
+++ b/src/automox_mcp/utils/pagination.py
@@ -1,0 +1,133 @@
+"""Concurrent pagination helper for upstream endpoints with bounded parallelism.
+
+Used by ``summarize_device_health``, ``list_device_inventory``, and
+``search_devices`` to fetch their pages of ``/servers`` in parallel rather
+than serially. On big tenants (multi-thousand-device fleets) the serial
+loop dominated wall time at 50-500 ms per page × up to 20 pages — this
+helper roughly halves that by overlapping requests.
+
+Two pagination styles are supported through one entry point:
+
+1. **Exhaustive** — fetch every page until a short page (fewer items than
+   ``page_size``) signals the end. Default behavior: the helper returns
+   the flattened item list. Used when every record matters
+   (fleet-wide aggregation).
+2. **Driven by a per-page callback** — pass ``on_page``. The callback is
+   invoked once per page in strict page order, even when the underlying
+   fetches were in parallel. Return ``True`` from the callback to
+   terminate pagination. Used for workflows that filter client-side and
+   have a target count: the callback can mutate workflow-local state
+   (accumulator, counters) and decide when enough has been seen.
+
+In both modes, pages 1..N are fetched concurrently in batches of
+``concurrency``. The first short page in a batch terminates pagination;
+any prefetched pages after the short page are discarded.
+
+Page 0 is always fetched serially: a single-page tenant should not pay
+the cost of warming a gather, and the helper needs to see page 0's
+length to know whether to spin up parallelism at all.
+
+Issue #69 — design + rationale documented inline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# Default in-flight cap. The Automox upstream has no documented per-org
+# concurrency limit and our local rate limiter applies at the tool-call
+# boundary (one slot per invocation), not per upstream request — so this
+# bound is purely a backpressure guard against unbounded RAM/socket use.
+# 4 covers the common case (5-20 page fleets) without blasting upstream.
+_DEFAULT_CONCURRENCY = 4
+
+
+async def parallel_paginate(
+    fetch_page: Callable[[int], Awaitable[Sequence[T]]],
+    *,
+    page_size: int,
+    max_pages: int,
+    concurrency: int = _DEFAULT_CONCURRENCY,
+    on_page: Callable[[int, Sequence[T]], bool] | None = None,
+) -> list[T]:
+    """Fetch pages from ``fetch_page`` with bounded concurrency.
+
+    Page 0 is fetched serially. If it returns ``< page_size`` items, the
+    function returns immediately. Otherwise pages ``1..concurrency`` are
+    fetched concurrently via :func:`asyncio.gather`. Results are walked in
+    page order; the first short page terminates pagination and any
+    prefetched pages after it are discarded.
+
+    Args:
+        fetch_page: Async callable taking a 0-indexed page number and
+            returning that page's items.
+        page_size: Expected items per full page. A page with fewer items
+            signals end-of-data.
+        max_pages: Hard safety cap on total pages fetched. Set generously;
+            the helper short-circuits as soon as a short page or
+            ``on_page`` triggers.
+        concurrency: Maximum number of pages in flight beyond page 0.
+            Default ``4``. Set lower (``1-2``) for workflows where each
+            page is large or where over-fetch has bandwidth cost.
+        on_page: Optional callback invoked once per page in strict page
+            order. Called as ``on_page(page_num, items)`` and may
+            mutate workflow-local state. Return ``True`` to terminate
+            pagination. Useful for limit-driven workflows where the
+            caller filters client-side and has a target count.
+
+    Returns:
+        All accumulated items across pages, in page order. When
+        ``on_page`` mutates workflow-local state, the caller often
+        ignores the returned list and reads its own accumulator instead.
+
+    Raises:
+        Whatever ``fetch_page`` raises. :func:`asyncio.gather` re-raises
+        the first exception in a batch; later exceptions are discarded
+        with their corresponding pages.
+    """
+    if max_pages <= 0:
+        return []
+
+    accumulated: list[T] = []
+
+    # Page 0 first — cheap fast path for single-page tenants and a clean
+    # signal of whether parallelism is worth setting up.
+    page_zero = list(await fetch_page(0))
+    accumulated.extend(page_zero)
+    if on_page is not None and on_page(0, page_zero):
+        return accumulated
+    if len(page_zero) < page_size:
+        return accumulated
+    if max_pages == 1:
+        return accumulated
+
+    next_page = 1
+    while next_page < max_pages:
+        batch_end = min(next_page + concurrency, max_pages)
+        batch_indices = list(range(next_page, batch_end))
+        # gather preserves submission order in the results list, so we
+        # can walk results in page-index order and apply the "discard
+        # everything after a short page" rule deterministically.
+        batch_results = await asyncio.gather(*(fetch_page(p) for p in batch_indices))
+
+        for page_num, items in zip(batch_indices, batch_results, strict=True):
+            items_list = list(items)
+            accumulated.extend(items_list)
+            if on_page is not None and on_page(page_num, items_list):
+                return accumulated
+            if len(items_list) < page_size:
+                # Short page — any prefetched pages after this one are
+                # discarded (intentionally; offset pagination makes them
+                # either empty or racily inconsistent).
+                return accumulated
+
+        next_page = batch_end
+
+    return accumulated
+
+
+__all__ = ["parallel_paginate"]

--- a/src/automox_mcp/workflows/devices.py
+++ b/src/automox_mcp/workflows/devices.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal, cast
 
 from ..client import AutomoxAPIError, AutomoxClient
+from ..utils.pagination import parallel_paginate
 from ..utils.response import normalize_status as _normalize_status
 from ..utils.response import require_org_id
 from .device_inventory import get_device_inventory
@@ -521,25 +522,26 @@ async def list_device_inventory(
     policy_status_filter = _normalize_status(policy_status) if policy_status else None
     curated_devices: list[dict[str, Any]] = []
 
-    for page_num in range(max_pages):
-        params["page"] = page_num
-        payload = await client.get("/servers", params=params)
-        # Handle both list and paginated dict response formats
+    async def _fetch_inventory_page(page_num: int) -> Sequence[Mapping[str, Any]]:
+        page_params = dict(params)
+        page_params["page"] = page_num
+        payload = await client.get("/servers", params=page_params)
         if isinstance(payload, list):
-            devices: Sequence[Mapping[str, Any]] = payload
-        elif isinstance(payload, Mapping):
+            return payload
+        if isinstance(payload, Mapping):
             _data = payload.get("data") or payload.get("results")
-            devices = _data if isinstance(_data, list) else []
-        else:
-            devices = []
+            return _data if isinstance(_data, list) else []
+        return []
 
-        if not devices:
-            break
+    def _process_inventory_page(_page_num: int, items: Sequence[Mapping[str, Any]]) -> bool:
+        """Apply filters to each device in ``items``; stop when limit reached.
 
-        for item in devices:
+        Called by parallel_paginate in strict page order; safe to mutate
+        ``curated_devices`` from here.
+        """
+        for item in items:
             summary_fields = _summarize_device_common_fields(item)
             is_managed = summary_fields["is_managed"]
-
             if managed is not None and is_managed != managed:
                 continue
             if not include_unmanaged and not is_managed:
@@ -547,7 +549,6 @@ async def list_device_inventory(
             device_policy_status = summary_fields["policy_status"]
             if policy_status_filter and device_policy_status != policy_status_filter:
                 continue
-
             curated_devices.append(
                 {
                     "device_id": item.get("id") or item.get("device_id"),
@@ -565,13 +566,20 @@ async def list_device_inventory(
                 }
             )
             if len(curated_devices) >= limit:
-                break
+                return True
+        return False
 
-        if len(curated_devices) >= limit:
-            break
-        # If the API returned fewer than requested, there are no more pages
-        if len(devices) < fetch_limit:
-            break
+    # #69: parallel-paginate with on_page filtering and limit-driven stop.
+    # Concurrency 2 (not 4) because filtered queries already over-fetch
+    # at fetch_limit = limit*3, so the marginal value of more parallel
+    # pages is outweighed by potential over-fetch on selective filters.
+    await parallel_paginate(
+        _fetch_inventory_page,
+        page_size=fetch_limit,
+        max_pages=max_pages,
+        concurrency=2,
+        on_page=_process_inventory_page,
+    )
 
     preview = curated_devices[:limit]
 
@@ -942,32 +950,26 @@ async def search_devices(
 
     filtered: list[Any] = []
 
-    for page_num in range(max_pages):
-        params["page"] = page_num
-
+    async def _fetch_search_page(page_num: int) -> Sequence[Any]:
+        page_params = dict(params)
+        page_params["page"] = page_num
         # Build params as list of tuples so httpx repeats the severity key correctly
-        param_tuples = list(params.items())
+        param_tuples = list(page_params.items())
         for sev in severity_values:
             param_tuples.append(("filters[severity][]", sev))
-
         raw_devices = await client.get(
-            "/servers", params=dict(params) if not severity_values else param_tuples
+            "/servers", params=page_params if not severity_values else param_tuples
         )
-        # Handle both list and paginated dict response formats
         if isinstance(raw_devices, Sequence) and not isinstance(raw_devices, (str, bytes)):
-            devices = raw_devices
-        elif isinstance(raw_devices, Mapping):
+            return raw_devices
+        if isinstance(raw_devices, Mapping):
             _data = raw_devices.get("data") or raw_devices.get("results")
             if isinstance(_data, Sequence) and not isinstance(_data, (str, bytes)):
-                devices = _data
-            else:
-                devices = []
-        else:
-            devices = []
+                return _data
+        return []
 
-        if not devices:
-            break
-
+    def _process_search_page(_page_num: int, devices: Sequence[Any]) -> bool:
+        """Apply client-side filters per-device; stop when limit reached."""
         for device in devices:
             if hostname_term:
                 name = str(device.get("name") or device.get("hostname") or "").lower()
@@ -994,12 +996,21 @@ async def search_devices(
 
             filtered.append(device)
             if len(filtered) >= limit:
-                break
+                return True
+        return False
 
-        if len(filtered) >= limit:
-            break
-        if len(devices) < fetch_limit:
-            break
+    # #69: parallel-paginate with on_page filtering. Concurrency 2 for
+    # the same reason as list_device_inventory — filtered queries
+    # over-fetch on selective filters; tight concurrency caps the waste.
+    await parallel_paginate(
+        _fetch_search_page,
+        page_size=fetch_limit,
+        max_pages=max_pages,
+        concurrency=2,
+        on_page=_process_search_page,
+    )
+    # _process_search_page mutates `filtered`; the helper's return value
+    # is ignored. Building the preview is the only post-pagination work.
 
     preview = []
     for item in filtered[:limit]:
@@ -1065,26 +1076,29 @@ async def summarize_device_health(
     if group_id is not None:
         params["groupId"] = group_id
 
-    # Paginate to collect all devices (up to a safety cap)
+    # Paginate to collect all devices (up to a safety cap).
+    # #69: parallel-paginate via the shared helper. health is the cleanest
+    # case — no client-side filter, no early-break on limit, every page is
+    # needed. Concurrency 4 cuts wall-time roughly in half on big fleets.
     _MAX_HEALTH_PAGES = 20
-    all_devices: list[Any] = []
-    for _page_num in range(_MAX_HEALTH_PAGES):
-        params["page"] = _page_num
-        page_response = await client.get("/servers", params=params)
-        # Handle both list and paginated dict response formats
+
+    async def _fetch_health_page(page_num: int) -> Sequence[Any]:
+        page_params = dict(params)
+        page_params["page"] = page_num
+        page_response = await client.get("/servers", params=page_params)
         if isinstance(page_response, Sequence) and not isinstance(page_response, (str, bytes)):
-            page_items = page_response
-        elif isinstance(page_response, Mapping):
+            return page_response
+        if isinstance(page_response, Mapping):
             _data = page_response.get("data") or page_response.get("results")
             if isinstance(_data, Sequence) and not isinstance(_data, (str, bytes)):
-                page_items = _data
-            else:
-                page_items = []
-        else:
-            page_items = []
-        all_devices.extend(page_items)
-        if len(page_items) < effective_limit:
-            break
+                return _data
+        return []
+
+    all_devices = await parallel_paginate(
+        _fetch_health_page,
+        page_size=effective_limit,
+        max_pages=_MAX_HEALTH_PAGES,
+    )
     devices: Sequence[Any] = all_devices
 
     totals: Counter[str] = Counter()

--- a/tests/test_utils_pagination.py
+++ b/tests/test_utils_pagination.py
@@ -1,0 +1,283 @@
+"""Tests for the parallel_paginate helper (issue #69).
+
+Covers the acceptance criteria from the issue:
+  - single-page response (no parallel batches spun up)
+  - exact-multiple-of-page-size last page (off-by-one boundary)
+  - short-page termination mid-batch (discard later pages in same batch)
+  - on_page early stop (limit-driven termination)
+  - gather-with-failure (one page in a batch raises)
+
+The helper is exercised against an in-memory fake `fetch_page` so the
+tests are deterministic and run in microseconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from automox_mcp.utils.pagination import parallel_paginate
+
+
+def _make_fetcher(
+    pages: list[list[int]],
+    *,
+    track_calls: list[int] | None = None,
+):
+    """Build a fake fetch_page that returns ``pages[N]`` for page N.
+
+    Pages beyond the supplied list return ``[]`` (simulates the upstream
+    serving past the last real page). If ``track_calls`` is supplied,
+    each call records its page index.
+    """
+
+    async def _fetch(page_num: int) -> list[int]:
+        if track_calls is not None:
+            track_calls.append(page_num)
+        if page_num < len(pages):
+            return pages[page_num]
+        return []
+
+    return _fetch
+
+
+# ---------------------------------------------------------------------------
+# Single-page
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_single_page_no_parallel_batches() -> None:
+    """If page 0 is short, the helper returns without firing parallel fetches."""
+    calls: list[int] = []
+    fetch = _make_fetcher([[1, 2, 3]], track_calls=calls)
+
+    result = await parallel_paginate(fetch, page_size=10, max_pages=20)
+
+    assert result == [1, 2, 3]
+    assert calls == [0]  # only page 0 fetched
+
+
+@pytest.mark.asyncio
+async def test_single_full_page_with_no_followers() -> None:
+    """Page 0 is full but page 1 onwards is empty — short-page rule terminates."""
+    calls: list[int] = []
+    fetch = _make_fetcher([[1, 2, 3]], track_calls=calls)
+
+    result = await parallel_paginate(fetch, page_size=3, max_pages=20)
+
+    # page 0 was full so we go parallel; pages 1..4 fetched and seen empty.
+    assert result == [1, 2, 3]
+    # Concurrency 4 by default → pages 1, 2, 3, 4 all fetched in one batch.
+    # First short page (1) terminates; remaining results discarded but
+    # the fetch_page calls themselves are real network round-trips that
+    # the helper can't unfire. Verify that's what happens.
+    assert calls == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Multi-page exhaustive
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_exact_multiple_last_page() -> None:
+    """Three full pages of exactly page_size — last page's followers are empty
+    pages that the helper must terminate on without dropping any data."""
+    pages = [
+        list(range(0, 10)),
+        list(range(10, 20)),
+        list(range(20, 30)),
+    ]
+    fetch = _make_fetcher(pages)
+
+    result = await parallel_paginate(fetch, page_size=10, max_pages=20)
+
+    # All 30 items returned, in page order.
+    assert result == list(range(30))
+
+
+@pytest.mark.asyncio
+async def test_short_last_page_terminates_pagination() -> None:
+    """Pages 0..2 full, page 3 short — pages 4+ should not appear."""
+    pages = [
+        list(range(0, 10)),  # full
+        list(range(10, 20)),  # full
+        list(range(20, 30)),  # full
+        list(range(30, 33)),  # short — 3 items
+    ]
+    fetch = _make_fetcher(pages)
+
+    result = await parallel_paginate(fetch, page_size=10, max_pages=20)
+
+    assert result == list(range(33))
+
+
+@pytest.mark.asyncio
+async def test_short_page_in_batch_discards_later_prefetched_pages() -> None:
+    """If page 1 is short, pages 2 and 3 (also in the same gather batch)
+    must be discarded — the helper can't trust pages after a short page
+    because offset pagination makes them empty or racily inconsistent."""
+    pages = [
+        list(range(0, 10)),  # full
+        list(range(10, 15)),  # short — 5 items
+        list(range(15, 25)),  # would be full but must be discarded
+        list(range(25, 35)),  # would be full but must be discarded
+    ]
+    fetch = _make_fetcher(pages)
+
+    result = await parallel_paginate(fetch, page_size=10, max_pages=20, concurrency=4)
+
+    # Items from pages 0 + 1 only — pages 2 and 3 must NOT appear.
+    assert result == list(range(15))
+
+
+# ---------------------------------------------------------------------------
+# on_page early stop
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_on_page_stops_mid_pagination() -> None:
+    """The on_page callback returning True terminates pagination after the
+    page it was called on."""
+    pages = [
+        list(range(0, 10)),
+        list(range(10, 20)),
+        list(range(20, 30)),
+        list(range(30, 40)),
+    ]
+    fetch = _make_fetcher(pages)
+
+    pages_seen_by_callback: list[int] = []
+
+    def on_page(page_num: int, items: Any) -> bool:
+        pages_seen_by_callback.append(page_num)
+        return page_num == 1  # stop after seeing page 1
+
+    result = await parallel_paginate(
+        fetch, page_size=10, max_pages=20, concurrency=4, on_page=on_page
+    )
+
+    # The callback ran on page 0 then page 1, then returned True.
+    assert pages_seen_by_callback == [0, 1]
+    # Items from pages 0 and 1 are in the accumulator; page 2 fetched
+    # in parallel but its items must not appear since on_page stopped
+    # at page 1.
+    assert result == list(range(20))
+
+
+@pytest.mark.asyncio
+async def test_on_page_fires_in_strict_page_order_under_concurrency() -> None:
+    """Even when pages 1..4 complete out of order, on_page sees them in
+    page-index order — important for limit-driven callers."""
+    pages = [list(range(p * 10, p * 10 + 10)) for p in range(5)]
+
+    # Reverse the completion order: page 4 returns instantly, page 0
+    # returns last. But the helper still walks results in page order.
+    delays = {0: 0.04, 1: 0.03, 2: 0.02, 3: 0.01, 4: 0.0}
+
+    async def fetch(page_num: int) -> list[int]:
+        await asyncio.sleep(delays[page_num])
+        return pages[page_num]
+
+    seen_order: list[int] = []
+
+    def on_page(page_num: int, _items: Any) -> bool:
+        seen_order.append(page_num)
+        return False
+
+    await parallel_paginate(fetch, page_size=10, max_pages=5, concurrency=4, on_page=on_page)
+
+    assert seen_order == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_concurrency_bound_respected() -> None:
+    """At most ``concurrency`` pages should be in flight beyond page 0 at any time."""
+    in_flight = 0
+    max_observed = 0
+    lock = asyncio.Lock()
+
+    pages = [list(range(p * 10, p * 10 + 10)) for p in range(10)]
+
+    async def fetch(page_num: int) -> list[int]:
+        nonlocal in_flight, max_observed
+        async with lock:
+            in_flight += 1
+            max_observed = max(max_observed, in_flight)
+        try:
+            await asyncio.sleep(0.005)
+            return pages[page_num] if page_num < len(pages) else []
+        finally:
+            async with lock:
+                in_flight -= 1
+
+    await parallel_paginate(fetch, page_size=10, max_pages=10, concurrency=3)
+
+    # Page 0 is serial (in_flight == 1), then batches of 3 → never exceed 3.
+    assert max_observed <= 3
+
+
+# ---------------------------------------------------------------------------
+# Gather with one failing page
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_gather_with_failure_propagates_first_exception() -> None:
+    """If any page in a batch raises, the exception propagates (default
+    asyncio.gather behavior). The remaining pages in the batch are
+    effectively discarded — they may or may not complete, but their
+    results never reach the accumulator."""
+    pages = [
+        list(range(0, 10)),  # page 0
+        list(range(10, 20)),  # page 1 — fine
+        list(range(20, 30)),  # page 2 — will raise
+        list(range(30, 40)),  # page 3 — would be fine
+    ]
+
+    async def fetch(page_num: int) -> list[int]:
+        if page_num == 2:
+            raise RuntimeError("page 2 boom")
+        return pages[page_num] if page_num < len(pages) else []
+
+    with pytest.raises(RuntimeError, match="page 2 boom"):
+        await parallel_paginate(fetch, page_size=10, max_pages=10, concurrency=4)
+
+
+# ---------------------------------------------------------------------------
+# Boundary conditions
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_max_pages_zero_returns_empty() -> None:
+    """max_pages=0 short-circuits without even fetching page 0."""
+    calls: list[int] = []
+    fetch = _make_fetcher([[1, 2, 3]], track_calls=calls)
+
+    result = await parallel_paginate(fetch, page_size=10, max_pages=0)
+
+    assert result == []
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_max_pages_one_returns_only_page_zero() -> None:
+    """max_pages=1 fetches page 0 and stops, even if it was full."""
+    calls: list[int] = []
+    fetch = _make_fetcher([[1, 2, 3, 4, 5]], track_calls=calls)
+
+    result = await parallel_paginate(fetch, page_size=5, max_pages=1)
+
+    assert result == [1, 2, 3, 4, 5]
+    assert calls == [0]
+
+
+@pytest.mark.asyncio
+async def test_empty_first_page_returns_immediately() -> None:
+    """If page 0 returns no items, the helper returns without firing any
+    parallel batches."""
+    calls: list[int] = []
+    fetch = _make_fetcher([[]], track_calls=calls)
+
+    result = await parallel_paginate(fetch, page_size=10, max_pages=20)
+
+    assert result == []
+    assert calls == [0]

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.33"
+version = "1.0.34"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #69.

## What

\`summarize_device_health\`, \`list_device_inventory\`, and \`search_devices\` previously fetched \`/servers\` pages serially. On multi-page tenants the loop dominated wall time at ~400ms per upstream RTT × up to 20 pages.

Shipped a shared \`parallel_paginate\` helper in \`utils/pagination.py\`:

- **Page 0 serial.** Single-page tenants short-circuit before any parallelism is set up — they pay zero overhead.
- **Pages 1..N batched via \`asyncio.gather\`** with default concurrency 4.
- **Strict page-order walk:** even if page 4 completes before page 1 inside the same gather batch, the \`on_page\` callback sees them in 1, 2, 3, 4 order. Critical for limit-driven workflows.
- **Short-page discard:** a page with fewer items than \`page_size\` terminates pagination AND discards any prefetched pages after it in the same batch. Offset-based pagination makes those trailing pages empty or racily inconsistent.
- **Optional \`on_page\` callback** for limit-driven workflows: returns \`True\` to stop. Used by inventory + search to terminate as soon as client-side filters satisfy the limit. Concurrency 2 there (not 4) so over-fetch on selective filters stays bounded.

## Why it works

The local rate limiter applies at the **tool-call** boundary (one slot per invocation), not per upstream HTTP call. So firing 4 parallel \`/servers\` requests within a single tool call doesn't burn rate-limit budget. The httpx default connection pool (10 max connections, 5 keepalive) accommodates the bounded concurrency cleanly.

## Empirical results (live tenant)

| Scenario | Serial | Parallel | Speedup |
|---|---|---|---|
| 4 \`/servers\` pages (limit=50), raw httpx fetches | 4.49 s | 1.21 s | **3.7×** |
| \`summarize_device_health\` (5 pages, limit=50) | ~5 s projected | 2.01 s | **~2.5×** |

The 226-device test tenant maxes out at 5 pages on limit=50. Larger fleets (multi-thousand devices) hit the helper's max-page path proportionally harder — that's where the win compounds.

## Tests

12 new tests in \`tests/test_utils_pagination.py\`:

- Single-page response (no parallel batches spun up)
- Exact-multiple-of-page-size last page (off-by-one boundary)
- Short last page terminates pagination
- **Short page mid-batch discards prefetched pages after it** (offset-pagination invariant)
- \`on_page\` early stop
- \`on_page\` fires in strict page order under out-of-order gather completion
- Concurrency bound respected (instrumented in-flight counter)
- \`gather\` with one failing page — exception propagates
- \`max_pages=0\`, \`max_pages=1\`, empty page 0

Plus the existing 16 device-workflow tests still pass — confirming the integration didn't change response shape.

## No behavior change for callers

Response shape and the canonical \`metadata.pagination\` block are unchanged. Only wall-clock latency improves.

## Version

1.0.33 → 1.0.34.

## Test plan

- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy .\` — clean
- [x] \`uv run pytest tests/\` — 1152 passed (was 1140, +12 new helper tests)
- [x] Live-tenant benchmark confirmed 3.7× speedup on raw parallel fetches
- [x] Live-tenant benchmark of \`summarize_device_health\` confirmed end-to-end ~2.5× win
- [x] Tool counts re-grep'd: 79 total, 21 write — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)