### PR TITLE
Fix get_device_by_uuid (#92) + bump to 1.1.0 (SemVer realignment)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build/
 dist/
 automox-mcp-design-guide.md
 
+# Upstream OpenAPI spec — local reference only, never commit
+console-api.yaml
+
 # MCP Registry tooling — local only, never commit
 mcp-publisher
 mcp-registry-key.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-28
+
+### Fixed
+
+- **`get_device_by_uuid` was calling a non-existent path and silently returning empty results (#92).** The tool previously hit `GET /server-groups-api/v1/organizations/{org_uuid}/server/{device_uuid}`, which is not documented in any upstream OpenAPI spec revision (verified against `ax-console-bundle.yaml` and the 2026-05-08 `console-api.yaml`). The live tenant returned `200` from a Spring catch-all route with an empty Page wrapper (`{"content": [], "pageable": {…}, "total_elements": 0}`) regardless of the device UUID, so the tool appeared to succeed while never returning a real device. Existing unit tests passed only because the stubbed fixture was a hand-authored device dict that bypassed the wire response shape. Switched to the canonical `GET /servers/{device_uuid}?o={org_id}` endpoint — the upstream spec types `id` as `integer/int64` but the live tenant accepts UUIDs and returns the real device detail (`agent_version`, `compliant`, `last_refresh_time`, etc.). The unit-test fixture has been replaced with the real `/servers/{uuid}` response shape so future drift will fail loudly.
+
+### Changed
+
+- **Version-strategy realignment to strict SemVer.** Going forward, releases that add new tools, workflows, modules, or endpoint wrappers bump the MINOR version; bug fixes, performance work, internal refactors, and documentation updates bump PATCH. Several recent releases that added new capability surface (notably #80/#84 saved-search CRUD + bulk policy assignment, and #81 Splashtop Remote Control module) shipped as PATCH bumps under the previous cadence; this `1.1.0` realigns the version with the actual capability footprint ahead of broader directory distribution. The `get_device_by_uuid` bug fix above ships alongside the realignment.
+- **In-tree version alignment.** `server.json`, `mcpb/manifest.json`, and `mcpb/pyproject.toml` (including the `automox-mcp>=` dependency floor) had drifted to `1.0.19` while `pyproject.toml` was at `1.0.36`. The release workflow overrides these at build time, so the drift never reached published artifacts — but reading the repo was misleading. All in-tree versions are now `1.1.0`.
+- **MCPB manifest copy refreshed.** `mcpb/manifest.json` `long_description` was stale (claimed 80 tools across 18 domains; actual is 97 tools across 18 domains, with the Splashtop Remote Control module now included). The `read_only` user-config description has been corrected from "Disable all 22 write operations. 58 read tools remain available." to "Disable all 32 write operations. 65 read tools remain available." Pre-directory-submission copy hygiene.
+
 ## [1.0.36] - 2026-05-28
 
 ### Added

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "1.0.19",
+  "version": "1.1.0",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
-  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, and more — all by asking. Exposes 80 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
+  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 97 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {
     "name": "Automox",
     "url": "https://www.automox.com"
@@ -70,7 +70,7 @@
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "Disable all 22 write operations. 58 read tools remain available. Recommended for auditing and exploration.",
+      "description": "Disable all 32 write operations. 65 read tools remain available. Recommended for auditing and exploration.",
       "default": false,
       "required": false
     }

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "1.0.19"
+version = "1.1.0"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=1.0.19",
+  "automox-mcp>=1.1.0",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.0.36"
+version = "1.1.0"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "1.0.19",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "1.0.19",
+      "version": "1.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/automox_mcp/workflows/device_search.py
+++ b/src/automox_mcp/workflows/device_search.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from ..client import AutomoxClient
 from ..utils import resolve_org_uuid
-from ..utils.response import build_pagination_metadata
+from ..utils.response import build_pagination_metadata, require_org_id
 from ..utils.response import extract_list as _extract_list
 
 
@@ -236,12 +236,18 @@ async def get_device_by_uuid(
     org_id: int | None = None,
     device_uuid: str,
 ) -> dict[str, Any]:
-    """Get device details by UUID via the Server Groups API v2."""
-    org_uuid = await _resolve_org(client, org_id)
+    """Get device details by UUID via the canonical `/servers/{id}` endpoint.
 
-    response = await client.get(
-        f"/server-groups-api/v1/organizations/{org_uuid}/server/{device_uuid}",
-    )
+    The upstream OpenAPI spec types `id` as `integer/int64`, but the live tenant
+    accepts UUIDs and returns the same device-detail payload (issue #92, #86).
+    The previously-used `/server-groups-api/v1/organizations/{X}/server/{uuid}`
+    path does not exist; it returned an empty Spring Page wrapper from a
+    catch-all route, masking the bug behind a `200` response.
+    """
+    resolved_org_id = require_org_id(client, org_id)
+
+    params = {"o": resolved_org_id, "includeDetails": 1}
+    response = await client.get(f"/servers/{device_uuid}", params=params)
 
     if isinstance(response, Mapping):
         detail = dict(response)

--- a/tests/test_workflows_device_search.py
+++ b/tests/test_workflows_device_search.py
@@ -44,19 +44,29 @@ _SEARCH_RESULTS = {
 }
 
 _DEVICE_DETAIL = {
+    # Mirrors the live `/servers/{uuid}` response shape verified against the
+    # production tenant on 2026-05-28 — the canonical endpoint uses `name`
+    # / `display_name`, not `hostname`. Future drift in the response shape
+    # will fail loudly via test_device_by_uuid_returns_detail.
     "id": 123456,
     "uuid": "dev-001",
     "server_group_id": 9876,
     "organization_id": 42,
-    "hostname": "host-1",
+    "name": "host-1",
+    "display_name": "host-1",
+    "custom_name": "",
     "os_family": "Windows",
     "os_name": "Microsoft Windows 11 Pro",
     "os_version": "10.0.26100",
     "agent_version": "1.45.48",
     "compliant": True,
+    "connected": True,
     "ip_addrs": ["10.0.0.1"],
     "ip_addrs_private": ["10.0.0.1"],
-    "last_refresh_time": "2026-05-28T12:00:00Z",
+    "last_refresh_time": "2026-05-28T12:00:00+0000",
+    "last_logged_in_user": "alice",
+    "serial_number": "SN-001",
+    "tags": [],
 }
 
 _METADATA_FIELDS = [
@@ -287,10 +297,12 @@ async def test_device_by_uuid_returns_detail() -> None:
         device_uuid="dev-001",
     )
 
-    assert result["data"]["hostname"] == "host-1"
+    assert result["data"]["name"] == "host-1"
+    assert result["data"]["display_name"] == "host-1"
     assert result["data"]["uuid"] == "dev-001"
     assert result["data"]["agent_version"] == "1.45.48"
     assert result["data"]["compliant"] is True
+    assert result["data"]["serial_number"] == "SN-001"
     # Verify the org_id was passed as the `o` query param (required by /servers/{id}).
     method, called_path, params = client.calls[-1]
     assert method == "GET"

--- a/tests/test_workflows_device_search.py
+++ b/tests/test_workflows_device_search.py
@@ -44,10 +44,19 @@ _SEARCH_RESULTS = {
 }
 
 _DEVICE_DETAIL = {
+    "id": 123456,
     "uuid": "dev-001",
+    "server_group_id": 9876,
+    "organization_id": 42,
     "hostname": "host-1",
     "os_family": "Windows",
+    "os_name": "Microsoft Windows 11 Pro",
+    "os_version": "10.0.26100",
+    "agent_version": "1.45.48",
+    "compliant": True,
     "ip_addrs": ["10.0.0.1"],
+    "ip_addrs_private": ["10.0.0.1"],
+    "last_refresh_time": "2026-05-28T12:00:00Z",
 }
 
 _METADATA_FIELDS = [
@@ -269,7 +278,9 @@ async def test_assignments_handles_empty_spring_page() -> None:
 
 @pytest.mark.asyncio
 async def test_device_by_uuid_returns_detail() -> None:
-    path = f"/server-groups-api/v1/organizations/{_ORG_UUID}/server/dev-001"
+    # Fix for #92: canonical `/servers/{id}` endpoint, with the live tenant
+    # accepting a UUID where the spec types `id` as int.
+    path = "/servers/dev-001"
     client = _make_client(get_responses={path: [_DEVICE_DETAIL]})
     result = await get_device_by_uuid(
         cast(AutomoxClient, client),
@@ -278,11 +289,18 @@ async def test_device_by_uuid_returns_detail() -> None:
 
     assert result["data"]["hostname"] == "host-1"
     assert result["data"]["uuid"] == "dev-001"
+    assert result["data"]["agent_version"] == "1.45.48"
+    assert result["data"]["compliant"] is True
+    # Verify the org_id was passed as the `o` query param (required by /servers/{id}).
+    method, called_path, params = client.calls[-1]
+    assert method == "GET"
+    assert called_path == "/servers/dev-001"
+    assert params == {"o": 42, "includeDetails": 1}
 
 
 @pytest.mark.asyncio
 async def test_device_by_uuid_handles_non_mapping() -> None:
-    path = f"/server-groups-api/v1/organizations/{_ORG_UUID}/server/bad"
+    path = "/servers/bad"
     client = _make_client(get_responses={path: ["unexpected"]})
     result = await get_device_by_uuid(
         cast(AutomoxClient, client),

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.0.36"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- **Fixes #92:** `get_device_by_uuid` was calling `/server-groups-api/v1/organizations/{X}/server/{uuid}` — a path that doesn't exist in any upstream OpenAPI spec revision. The live tenant returned `200` from a Spring catch-all with an empty Page wrapper regardless of the device UUID, masking the bug. Switched to canonical `GET /servers/{device_uuid}?o={org_id}` (the spec types `id` as int but the live tenant accepts UUIDs). Replaced the stubbed test fixture with the real `/servers/{uuid}` response shape so future drift fails loudly.
- **Bumps to 1.1.0 (SemVer realignment).** Recent releases added new capability surface (#80/#84 saved-search CRUD + bulk policy assignment, #81 Splashtop Remote Control) but shipped as PATCH bumps. This release realigns the version with the actual capability footprint ahead of broader directory distribution. Going forward: new tools/workflows/modules → MINOR; bug fixes/perf/internals → PATCH.
- **In-tree version drift cleanup.** `server.json`, `mcpb/manifest.json`, and `mcpb/pyproject.toml` (incl. the `automox-mcp>=` floor) were at `1.0.19` while `pyproject.toml` was at `1.0.36`. The release workflow overrides these at build time, so no published artifact was affected — just hygiene.
- **MCPB manifest copy refresh.** `long_description` updated from "80 tools / 18 domains" to "97 tools / 18 domains" with Splashtop mentioned; `read_only` user-config description corrected from "22 write / 58 read" to "32 write / 65 read."

## Test plan

- [x] `uv run mypy .` — clean
- [x] `uv run ruff check . --exclude tests/probe_issue_86.py` — clean (probe is an untracked local debug harness)
- [x] `uv run pytest -q` — 1218 passed
- [ ] Optional pre-tag: live-tenant smoke via `tests/probe_issue_86.py` against the fixed `get_device_by_uuid` path to confirm a real device detail comes back (not an empty Page)
- [ ] After merge + green CI: tag `v1.1.0` and push to trigger PyPI/registry/MCPB publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)