### PR TITLE
Prep for Anthropic Software Directory (MCPB) submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,74 @@ jobs:
             requirements-ci.txt
           virtual-environment: .venv
 
+  manifests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify manifest versions are in sync with pyproject
+        run: |
+          python3 <<'PY'
+          import json, pathlib, re, sys, tomllib
+
+          pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          source_version = pyproject["project"]["version"]
+          mismatches: list[str] = []
+
+          server = json.loads(pathlib.Path("server.json").read_text())
+          if server.get("version") != source_version:
+              mismatches.append(f"server.json .version = {server.get('version')!r} (expected {source_version!r})")
+          for i, pkg in enumerate(server.get("packages", [])):
+              if pkg.get("version") != source_version:
+                  mismatches.append(f"server.json .packages[{i}].version = {pkg.get('version')!r} (expected {source_version!r})")
+
+          mcpb_manifest = json.loads(pathlib.Path("mcpb/manifest.json").read_text())
+          if mcpb_manifest.get("version") != source_version:
+              mismatches.append(f"mcpb/manifest.json .version = {mcpb_manifest.get('version')!r} (expected {source_version!r})")
+
+          mcpb_pyproject = tomllib.loads(pathlib.Path("mcpb/pyproject.toml").read_text())
+          if mcpb_pyproject["project"]["version"] != source_version:
+              mismatches.append(
+                  f"mcpb/pyproject.toml .project.version = {mcpb_pyproject['project']['version']!r} "
+                  f"(expected {source_version!r})"
+              )
+          dep_floor_match = re.search(r'"automox-mcp>=([^"]+)"', pathlib.Path("mcpb/pyproject.toml").read_text())
+          if not dep_floor_match or dep_floor_match.group(1) != source_version:
+              found = dep_floor_match.group(1) if dep_floor_match else "<missing>"
+              mismatches.append(
+                  f"mcpb/pyproject.toml automox-mcp>= floor = {found!r} (expected {source_version!r})"
+              )
+
+          if mismatches:
+              for m in mismatches:
+                  print(f"::error::{m}")
+              print()
+              print(
+                  "Versions across pyproject.toml, server.json, mcpb/manifest.json, "
+                  "and mcpb/pyproject.toml must match. The release workflow rewrites "
+                  "these from the tag at publish time, but they should also be in "
+                  "sync on main so reviewers and packaging tools see consistent values."
+              )
+              sys.exit(1)
+          print(f"All manifest versions match pyproject ({source_version}).")
+          PY
+
+      - name: Install MCPB CLI
+        run: npm install -g @anthropic-ai/mcpb
+
+      - name: Validate MCPB manifest schema
+        run: mcpb validate mcpb/manifest.json
+
+      - name: Build MCPB bundle (smoke test)
+        run: mcpb pack mcpb /tmp/automox-mcp-ci.mcpb
+
   ci-pass:
     if: always()
-    needs: [lint, typecheck, test, build]
+    needs: [lint, typecheck, test, build, manifests]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -138,7 +203,8 @@ jobs:
           needs.lint.result != 'success' ||
           needs.typecheck.result != 'success' ||
           needs.test.result != 'success' ||
-          needs.build.result != 'success'
+          needs.build.result != 'success' ||
+          needs.manifests.result != 'success'
         run: |
           echo "::error::One or more CI jobs did not succeed."
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Anthropic Software Directory submission collateral.** Standalone `PRIVACY.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` at the repo root, promoted from inline README content / Contributor Covenant by reference, ahead of the MCPB Desktop Extension listing.
+- **CI manifest-consistency gate.** New `manifests` job in `.github/workflows/ci.yml` asserts that `pyproject.toml`, `server.json` (both `.version` and `.packages[].version`), `mcpb/manifest.json`, and `mcpb/pyproject.toml` (including the `automox-mcp>=` dependency floor) all carry the same version on `main`. The release workflow already rewrites these at publish time; this gate prevents drift from reaching `main` between releases.
+- **MCPB schema validation in CI.** The new `manifests` job also runs `mcpb validate mcpb/manifest.json` and a smoke `mcpb pack mcpb /tmp/automox-mcp-ci.mcpb` so manifest-schema or pack-time regressions fail PR review instead of release.
+
+### Fixed
+
+- **`docs/tool-reference.md` table-of-contents drift.** TOC link claimed "Vulnerability Sync (7 tools)" while the section header and actual `@server.tool` count are 6. Realigned to 6.
+
 ## [1.1.0] - 2026-05-28
 
 ### Fixed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct. Contributors, maintainers, and anyone interacting with the project's spaces are expected to follow it.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — the GitHub repository (issues, pull requests, discussions, code review), any project communication channels, and public spaces when an individual is representing the project.
+
+## Reporting
+
+Report concerns privately to <conduct@automox.com>. Reports are handled confidentially by the maintainers. We will respond as quickly as we can and take whatever action we judge appropriate and proportionate.
+
+If a report concerns one of the maintainers, send it to <security@automox.com> instead so it can be routed independently.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing the standards in the Contributor Covenant. They may remove, edit, or reject contributions and may temporarily or permanently restrict any contributor whose behavior is judged inconsistent with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+Thanks for your interest in `automox-mcp`. This project is the official Automox Model Context Protocol (MCP) server. We welcome external contributions — issues, bug reports, documentation fixes, and new tools or workflows.
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ground rules
+
+* **Open an issue before large changes.** Quick fixes (typos, obvious bugs, missing annotations) can go straight to a PR. For new tools, new workflows, or anything that changes externally visible behavior, file an issue first so we can align on scope and avoid wasted work.
+* **Don't include credentials.** Never commit real API keys, account UUIDs, org IDs, device IDs, or customer data. The `.env.example` file enumerates the variables we expect; real values live in your local `.env` (gitignored) or in `~/automox/.env`.
+* **Security issues go through `SECURITY.md`.** Don't file vulnerabilities as public GitHub issues — see [`SECURITY.md`](SECURITY.md) for the private disclosure path.
+
+## Development setup
+
+```bash
+git clone https://github.com/AutomoxCommunity/automox-mcp.git
+cd automox-mcp
+uv python install
+uv sync --python 3.13 --dev
+```
+
+Run the server against MCP Inspector for interactive debugging:
+
+```bash
+fastmcp dev
+```
+
+## Running checks locally
+
+Run the same checks CI runs before pushing:
+
+```bash
+uv run --python 3.13 ruff check .
+uv run --python 3.13 mypy .
+uv run --python 3.13 pytest
+```
+
+We target ≥90% line coverage. New tools and workflows are expected to ship with tests.
+
+Optional but encouraged:
+
+```bash
+uv run --python 3.13 bandit -r src/
+```
+
+## Adding a new tool
+
+1. Add the implementation under `src/automox_mcp/tools/<domain>_tools.py`, registering it via `@server.tool(...)` in the module's `register()` function.
+2. **Always include MCP tool annotations**: `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. Write tools (anything that mutates state in Automox) must set `destructiveHint=True`; read-only tools must set `readOnlyHint=True`.
+3. Keep the description narrow and behavior-accurate. Don't over-promise. Reviewers and LLM hosts use the description verbatim — vague or aspirational language causes wrong tool selection.
+4. Add unit tests under `tests/`. Mock the HTTP layer; do not hit the real Automox API in CI.
+5. Update [`docs/tool-reference.md`](docs/tool-reference.md) and bump the tool counts in `mcpb/manifest.json`'s `long_description` and the `README.md` summary if your change crosses a count boundary.
+
+## Pull request checklist
+
+Before opening a PR:
+
+- [ ] `ruff check .` clean
+- [ ] `mypy .` clean
+- [ ] `pytest` green, coverage ≥90%
+- [ ] Tool annotations present on any new `@server.tool(...)` registration
+- [ ] `docs/tool-reference.md` updated if tools/domains changed
+- [ ] `CHANGELOG.md` entry under the next version
+- [ ] `pyproject.toml` `version` bumped if this PR is a release
+
+## Releases
+
+Releases are driven by Git tags. The release workflow validates that the tag matches `pyproject.toml`'s `version` and publishes to PyPI plus the MCP registry. Do not publish manually.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's MIT License (see [`LICENSE`](LICENSE)).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,43 @@
+# Privacy Policy
+
+_Last updated: 2026-05-29_
+
+The Automox MCP server is an open-source, locally executed Model Context Protocol (MCP) server that lets a user's own AI assistant interact with the Automox API. It runs on the user's machine (typically inside a desktop AI client such as Claude Desktop, packaged as an MCPB Desktop Extension) and acts as a stateless proxy between that assistant and `console.automox.com`.
+
+This document describes how data is handled when the server is run as distributed (PyPI package, Docker image, or MCPB bundle published by Automox). Self-hosted deployments may differ; this policy applies to the upstream artifact only.
+
+## Data collection
+
+The Automox MCP server does not collect, store, or transmit any user data beyond what is required to fulfill API requests to the Automox platform.
+
+API credentials (`AUTOMOX_API_KEY`, `AUTOMOX_ACCOUNT_UUID`, `AUTOMOX_ORG_ID`) are read from environment variables at startup and used solely for authenticating requests to the Automox API. Credentials are held in process memory for the lifetime of the server process and are never logged, persisted to disk, or sent to any host other than `console.automox.com`.
+
+## Data usage
+
+All data retrieved from the Automox API is returned directly to the AI assistant that initiated the request. The server performs response sanitization (Unicode normalization, HTML stripping) for prompt-injection defense, but does not analyze, aggregate, or repurpose API data for any other purpose.
+
+The server does not phone home. There is no telemetry, no crash reporting, no usage analytics, and no remote configuration channel.
+
+## Third-party sharing
+
+The server does not share data with any third parties. It communicates exclusively with the Automox API at `console.automox.com` using the credentials the user provides. No telemetry, analytics, or usage data is sent to the server authors or any other service.
+
+Tool calls that contact additional Automox-controlled endpoints (for example, Splashtop remote-control flows initiated through the Automox console) follow the same model: they hit Automox-operated infrastructure, not third-party services.
+
+## Data retention
+
+The server retains no persistent data between sessions. In-memory caches (idempotency keys, rate-limit counters, paginated cursors) are cleared when the process exits. Structured logs, when enabled, are written to `stderr` and are the deployer's responsibility to manage and retain — Automox does not collect those logs.
+
+## User control
+
+* **Read-only mode** — Setting `AUTOMOX_MCP_READ_ONLY=true` (or toggling "Read-only mode" in the MCPB user-config UI) disables every write tool. Only read-only tools are registered with the host.
+* **Tool annotations** — Every tool exposes MCP `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` annotations so the host client can surface confirmation prompts before destructive actions.
+* **Credential revocation** — API keys can be rotated or revoked at any time in the Automox Console under **Settings → Secrets & Keys**. Revocation takes effect immediately on the Automox side; the local server holds no cached authorization beyond the live credential.
+
+## Source code and verification
+
+The full source code is available at <https://github.com/AutomoxCommunity/automox-mcp>. Network egress can be verified at runtime — the server only opens HTTPS connections to `console.automox.com` (plus any Automox-operated subdomains required by the specific tool being invoked).
+
+## Contact
+
+Security or privacy questions: see [`SECURITY.md`](SECURITY.md) for the disclosure process, or contact <security@automox.com>.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ The Automox MCP server acts as a stateless proxy between your AI assistant and t
 
 **Data retention:** The server retains no persistent data between sessions. In-memory caches (idempotency keys, rate-limit counters) are cleared when the process exits. Structured logs, when enabled, are written to stderr and are the deployer's responsibility to manage and retain.
 
+See [`PRIVACY.md`](PRIVACY.md) for the full privacy policy.
+
 ## Alternative Installation
 
 The Quick Start above uses `uvx` which requires no installation. If you prefer a persistent install:

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -15,7 +15,7 @@ Complete reference for all 97 tools, 6 workflow prompts, MCP resources, paramete
 - [Webhook Management (8 tools)](#webhook-management-8-tools)
 - [Worklet Catalog (2 tools)](#worklet-catalog-2-tools)
 - [Data Extracts (3 tools)](#data-extracts-3-tools)
-- [Vulnerability Sync (7 tools)](#vulnerability-sync-7-tools)
+- [Vulnerability Sync (6 tools)](#vulnerability-sync-6-tools)
 - [Compound Workflows (3 tools)](#compound-workflows-3-tools)
 - [Events (1 tool)](#events-1-tool)
 - [Reports (2 tools)](#reports-2-tools)


### PR DESCRIPTION
## Summary

- Adds the standalone policy/contributing docs the Anthropic Software Directory review expects: `PRIVACY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`.
- Adds a `manifests` CI job that asserts `pyproject.toml`, `server.json` (top-level + `packages[]`), `mcpb/manifest.json`, and `mcpb/pyproject.toml` (including the `automox-mcp>=` floor) all share the same version, then runs `mcpb validate` and a smoke `mcpb pack`. Closes the drift gap between releases — the release workflow already rewrites these from the tag at publish time.
- Fixes a TOC drift in `docs/tool-reference.md` (Vulnerability Sync 7 → 6).

## Why now

We're listing `automox-mcp` in the Anthropic Software Directory via the MCPB / Desktop Extension track. The directory submission form needs a hosted privacy policy URL and a clean contributing/code-of-conduct story; the CI gate stops manifest version drift from being a recurring submission risk.

## Out of scope (handled separately)

- Hosting `PRIVACY.md` on `automox.com` and using that URL in the submission form.
- Provisioning the dedicated reviewer test tenant and verifying the example prompts against it.
- Submission collateral (screenshots, demo video, tagline).

## Test plan

- [x] `uv run ruff check . --exclude tests/probe_issue_86.py` clean (the untracked probe file is unrelated)
- [x] `uv run mypy .` clean (69 source files)
- [x] `uv run pytest --cov=automox_mcp --cov-fail-under=90` — 1218 passed, coverage 90.16%
- [x] `mcpb validate mcpb/manifest.json` — passes
- [x] `mcpb pack mcpb /tmp/automox-mcp-ci.mcpb` — packs cleanly (86.5 kB, 4 files)
- [x] Local replay of the new `manifests` Python version-check — reports "All manifest versions match pyproject (1.1.0)."
- [ ] CI green on this PR (the new `manifests` job runs against the merge head)

🤖 Generated with [Claude Code](https://claude.com/claude-code)