### PR TITLE
#91 category E: multi-zone patch-policy clone on clone_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-zone patch-policy clone on `clone_policy` (#91, category E).** New optional `target_zone_ids` argument routes to the server-side `POST /policies/{id}/clone` endpoint, cloning a patch policy into one or more zones/orgs (1–500 zone UUIDs) in a single atomic call and returning the per-zone `{policy_id, zone_id, org_id}` results. Upstream supports patch policies only; `target_zone_ids` is mutually exclusive with `name`/`server_groups`. Without it, `clone_policy` keeps its existing client-side GET-then-POST behavior, which works for all policy types but stays within the source org. No new tool, so the tool count is unchanged.
 - **Search & metadata enrichment — 4 device-search tools (#91, category D).**
   - `get_searchable_fields` — `GET /server-groups-api/device/metadata/fields`: searchable fields grouped by scope with per-field type metadata, richer than the existing flat `get_device_metadata_fields` (`device-fields`). Read-only.
   - `list_searches_for_device` — `GET …/device/saved-search/server/{deviceUUID}`: which saved searches currently contain a given device, with optional `type` filter. Read-only.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -77,7 +77,7 @@ Uses the Server Groups API v2 for structured device queries, saved searches, and
 - **`patch_approvals_summary`** - Summarize pending patch approvals and their severity.
 - **`decide_patch_approval`** - Approve or reject an Automox patch approval request.
 - **`execute_policy_now`** - Execute a policy immediately for remediation (all devices or specific device).
-- **`clone_policy`** - Clone an existing policy with optional name and server group overrides.
+- **`clone_policy`** - Clone an existing policy. By default an in-org copy with optional name and server-group overrides (all policy types). Pass `target_zone_ids` to clone a **patch** policy into one or more zones/orgs in a single server-side call (`POST /policies/{id}/clone`); mutually exclusive with name/server_groups.
 - **`delete_policy`** - Permanently delete a policy by ID.
 
 ## Policy History v2 (7 tools)

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -510,6 +510,28 @@ class ClonePolicyParams(OrgIdContextMixin, ForbidExtraModel):
         None, description="Name for the cloned policy (defaults to '<source> (Clone)')"
     )
     server_groups: list[int] | None = Field(None, description="Server group IDs for the clone")
+    target_zone_ids: list[str] | None = Field(
+        None,
+        description=(
+            "Target zone UUIDs for a multi-zone clone (patch policies only). When set, "
+            "clones the source patch policy into each zone in one server-side call; "
+            "cannot be combined with name or server_groups."
+        ),
+        min_length=1,
+        max_length=500,
+    )
+
+    @model_validator(mode="after")
+    def _validate_clone_mode(self) -> ClonePolicyParams:
+        if self.target_zone_ids is not None:
+            if self.name is not None or self.server_groups is not None:
+                raise ValueError(
+                    "target_zone_ids (multi-zone clone) cannot be combined with "
+                    "name or server_groups"
+                )
+            for zone_id in self.target_zone_ids:
+                UUID(zone_id)  # reject malformed zone UUIDs
+        return self
 
 
 class DeletePolicyToolParams(OrgIdContextMixin, ForbidExtraModel):

--- a/src/automox_mcp/tools/meta_tools.py
+++ b/src/automox_mcp/tools/meta_tools.py
@@ -48,7 +48,7 @@ _DOMAIN_CATALOG: dict[str, list[tuple[str, str]]] = {
         ("policy_run_results", "Per-device results for a policy execution"),
         ("policy_compliance_stats", "Per-policy compliance statistics"),
         ("apply_policy_changes", "Create or update policies"),
-        ("clone_policy", "Clone an existing policy"),
+        ("clone_policy", "Clone a policy (in-org, or multi-zone for patch policies)"),
         ("delete_policy", "Delete a policy permanently"),
         ("execute_policy_now", "Execute a policy immediately"),
     ],

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -321,8 +321,11 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         @server.tool(
             name="clone_policy",
             description=(
-                "Clone an existing Automox policy. Creates a copy with an optional "
-                "new name and server group assignments."
+                "Clone an existing Automox policy. By default creates an in-org copy "
+                "with an optional new name and server group assignments. Pass "
+                "target_zone_ids to instead clone a patch policy into one or more "
+                "zones/orgs in a single server-side call (patch policies only; "
+                "mutually exclusive with name/server_groups)."
             ),
             annotations={
                 "readOnlyHint": False,
@@ -335,6 +338,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             policy_id: int,
             name: str | None = None,
             server_groups: list[int] | None = None,
+            target_zone_ids: list[str] | None = None,
             request_id: str | None = None,
         ) -> dict[str, Any]:
             cached = await check_idempotency(request_id, "clone_policy")
@@ -346,6 +350,8 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 params["name"] = name
             if server_groups is not None:
                 params["server_groups"] = server_groups
+            if target_zone_ids is not None:
+                params["target_zone_ids"] = target_zone_ids
             try:
                 result = await call_tool_workflow(
                     client,

--- a/src/automox_mcp/workflows/policy_crud.py
+++ b/src/automox_mcp/workflows/policy_crud.py
@@ -1049,13 +1049,49 @@ async def clone_policy(
     policy_id: int,
     name: str | None = None,
     server_groups: list[int] | None = None,
+    target_zone_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Clone an existing Automox policy.
 
-    Fetches the source policy, strips read-only fields, optionally overrides
-    name and server_groups, then creates a new policy via POST.
+    Two modes:
+
+    - **Multi-zone** (``target_zone_ids`` set): clone a *patch* policy into one
+      or more zones/orgs in a single server-side call via
+      ``POST /policies/{id}/clone``. The upstream endpoint only supports patch
+      policies.
+    - **In-org** (default): fetch the source policy, strip read-only fields,
+      optionally override name/server_groups, then create a new policy via POST.
+      Works for all policy types but stays within the source org.
     """
     resolved_org_id = require_org_id(client, org_id)
+
+    if target_zone_ids:
+        response = await client.post(
+            f"/policies/{policy_id}/clone",
+            json_data={"target_zone_ids": list(target_zone_ids)},
+            params={"o": resolved_org_id},
+        )
+        clones = response.get("data") if isinstance(response, Mapping) else None
+        clones = clones if isinstance(clones, list) else []
+        return {
+            "data": {
+                "source_policy_id": policy_id,
+                "multi_zone": True,
+                "policy_name": response.get("policy_name")
+                if isinstance(response, Mapping)
+                else None,
+                "policy_type_name": response.get("policy_type_name")
+                if isinstance(response, Mapping)
+                else None,
+                "total_clones": len(clones),
+                "clones": clones,
+                "response": response,
+            },
+            "metadata": {
+                "deprecated_endpoint": False,
+                "org_id": resolved_org_id,
+            },
+        }
 
     params = {"o": resolved_org_id}
     source = await client.get(f"/policies/{policy_id}", params=params)

--- a/tests/test_workflows_policy_crud.py
+++ b/tests/test_workflows_policy_crud.py
@@ -280,6 +280,86 @@ async def test_clone_policy_raises_on_non_mapping_source() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Multi-zone clone (issue #91 category E)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clone_policy_multi_zone_uses_clone_endpoint() -> None:
+    clone_response = {
+        "policy_name": "Clone of Patch All Policy",
+        "policy_type_name": "patch",
+        "data": [
+            {
+                "policy_id": 38421,
+                "zone_id": "59f574fe-04ec-4a38-ad96-1854fc95db20",
+                "org_id": 100343,
+            },
+            {
+                "policy_id": 38422,
+                "zone_id": "6a1b2c3d-04ec-4a38-ad96-1854fc95db21",
+                "org_id": 100344,
+            },
+        ],
+    }
+    client = StubClient(post_responses={"/policies/901/clone": [clone_response]})
+
+    result = await clone_policy(
+        cast(AutomoxClient, client),
+        org_id=555,
+        policy_id=901,
+        target_zone_ids=[
+            "59f574fe-04ec-4a38-ad96-1854fc95db20",
+            "6a1b2c3d-04ec-4a38-ad96-1854fc95db21",
+        ],
+    )
+
+    data = result["data"]
+    assert data["multi_zone"] is True
+    assert data["source_policy_id"] == 901
+    assert data["total_clones"] == 2
+    assert data["policy_type_name"] == "patch"
+    assert data["clones"][0]["zone_id"] == "59f574fe-04ec-4a38-ad96-1854fc95db20"
+
+    # It must NOT do the client-side GET-then-POST; only the clone endpoint is hit.
+    post_calls = [c for c in client.calls if c[0] == "POST"]
+    assert len(post_calls) == 1
+    _, path, params, body = post_calls[0]
+    assert path == "/policies/901/clone"
+    assert params == {"o": 555}
+    assert body == {
+        "target_zone_ids": [
+            "59f574fe-04ec-4a38-ad96-1854fc95db20",
+            "6a1b2c3d-04ec-4a38-ad96-1854fc95db21",
+        ]
+    }
+    assert not any(c[0] == "GET" for c in client.calls)
+
+
+def test_clone_policy_params_rejects_zone_ids_with_overrides() -> None:
+    from pydantic import ValidationError
+
+    from automox_mcp.schemas import ClonePolicyParams
+
+    with pytest.raises(ValidationError, match="cannot be combined"):
+        ClonePolicyParams(
+            org_id=555,
+            policy_id=901,
+            name="Nope",
+            target_zone_ids=["59f574fe-04ec-4a38-ad96-1854fc95db20"],
+        )
+
+
+def test_clone_policy_params_rejects_malformed_zone_uuid() -> None:
+    from pydantic import ValidationError
+
+    from automox_mcp.schemas import ClonePolicyParams
+
+    with pytest.raises(ValidationError):
+        ClonePolicyParams(org_id=555, policy_id=901, target_zone_ids=["not-a-uuid"])
+
+
+# ---------------------------------------------------------------------------
 # Tests: get_policy_compliance_stats
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implements **category E** of the #91 API-surface gap audit. No new tool — `clone_policy` gains an optional `target_zone_ids` argument, so the tool count is unchanged (103).

## Behavior

- **Multi-zone** (`target_zone_ids` set): routes to the server-side `POST /policies/{id}/clone`, cloning a **patch** policy into one or more zones/orgs (1–500 zone UUIDs) in a single atomic call. Returns the per-zone `{policy_id, zone_id, org_id}` rows plus `policy_name` / `policy_type_name`.
- **In-org** (default, unchanged): the existing client-side GET-then-POST clone — works for all policy types but stays within the source org.

## DTO grounding

The request body was a `$ref` into `components/requestBodies/clonePolicy` (not inline), which is why a naive read shows "no body." Resolved it: `{ "target_zone_ids": [uuid, …] }`, required, `minItems: 1` / `maxItems: 500`. The Pydantic schema matches (no guessed shapes). Upstream summary is explicitly "Clone a **Patch** Policy."

## Guard rails

- `target_zone_ids` is **mutually exclusive** with `name`/`server_groups` (ValidationError in `ClonePolicyParams`) — the clone endpoint takes no name/group overrides.
- Each zone ID is UUID-validated.
- Multi-zone path skips the client-side GET-then-POST entirely (asserted in tests).

## Verification

- `ruff` clean, `ruff format` clean, `mypy` clean (69 files), full suite **1236 passed**.
- New tests: multi-zone routing + body/params assertions + "no GET" check; mutual-exclusivity rejection; malformed-UUID rejection.
- Docs: `tool-reference.md` `clone_policy` entry + `discover_capabilities` catalog description. CHANGELOG under `[Unreleased]`.

## Note (pre-existing, not from this PR)

`pytest tests/test_workflows_policy_crud.py tests/test_tools.py tests/test_tool_registration.py` fails ~6 tests when run as that subset, on clean `main` too — a test-isolation issue in `test_tool_registration.py` when it runs after `test_tools.py`. The full `pytest` run (what CI executes) passes. Flagging for a separate cleanup; out of scope here.

## Remaining in #91

A (identity — large; per-user-key decrypt needs sign-off), B (global keys — decrypt sensitivity), C (bulk/execution writes — includes remediation *apply*), G (binary uploads — mechanism decision).

Refs #91