### PR TITLE
Fix latent test order-dependence; run suite in randomized order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ automox-mcp-design-guide.md
 # Upstream OpenAPI spec — local reference only, never commit
 console-api.yaml
 
+# Live-tenant probe harnesses — manual debugging, never commit (not in CI)
+tests/probe_*.py
+
 # MCP Registry tooling — local only, never commit
 mcp-publisher
 mcp-registry-key.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Test-suite order-dependence (latent, pre-existing).** A test reimported the package (`sys.modules` pop + re-`import`), leaving duplicate class objects behind; later `issubclass(..., OrgIdRequiredMixin)` checks then compared classes across module copies and silently stopped injecting `org_id` — invisible in the fixed CI order, but failing up to ~100 tests under randomized order. Added a `conftest` autouse fixture that snapshots/restores `sys.modules` (and `os.environ`) per test, and added `pytest-randomly` (dev) so the suite now runs in randomized order and regressions surface immediately. Suite is green across 26 seeds.
+
 ### Added
 
 - **Global (account-scoped) API keys — 4 tools (#91, category B).** `list_global_api_keys` (metadata only), `create_global_api_key`, `update_global_api_key` (enable/disable), `delete_global_api_key`. Same secret-handling as the per-user keys: list/create return metadata only (verified against the DTOs — no secret), and the `decrypt` endpoint is deliberately not wrapped. Writes are `read_only`-gated and idempotency-keyed. Tool count 123 → 127 (read-only 83 → 84).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
   "pytest>=9.0.3",
   "pytest-asyncio>=0.23",
   "pytest-cov>=6.0",
+  "pytest-randomly>=3.15",
   "ruff>=0.4",
   "mypy>=1.9",
   "build>=1.2.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,44 @@
 import copy
+import os
+import sys
 from typing import Any
 
 import pytest
+
+
+def _automox_modules(modules: dict) -> set[str]:
+    return {k for k in modules if k == "automox_mcp" or k.startswith("automox_mcp.")}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_state():
+    """Contain per-test mutations of process-global state.
+
+    Some tests reimport the package (pop ``automox_mcp.*`` from ``sys.modules``
+    and ``import`` again) or mutate ``os.environ``. ``monkeypatch`` restores
+    ``sys.path``/env but NOT ``sys.modules`` — so a reimport leaves duplicate
+    class objects behind, and an ``issubclass(..., OrgIdRequiredMixin)`` check
+    later compares classes from different module copies and silently returns
+    False (org_id stops being injected). That is invisible in the fixed CI
+    order but breaks ~100 tests under randomized order. Snapshot + restore both
+    here so any such surgery is contained to the test that does it.
+    """
+    env_snapshot = dict(os.environ)
+    module_snapshot = {k: sys.modules[k] for k in _automox_modules(sys.modules)}
+
+    yield
+
+    if os.environ != env_snapshot:
+        os.environ.clear()
+        os.environ.update(env_snapshot)
+
+    current = _automox_modules(sys.modules)
+    if current != set(module_snapshot) or any(
+        sys.modules[k] is not module_snapshot[k] for k in module_snapshot
+    ):
+        for name in current - set(module_snapshot):
+            del sys.modules[name]
+        sys.modules.update(module_snapshot)
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "ruff" },
     { name = "twine" },
 ]
@@ -109,6 +110,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15" },
     { name = "python-dotenv", specifier = ">=1.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.1" },
@@ -1383,6 +1385,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
You asked whether older-model-authored tests were quietly broken before we release 1.2.0. They were — here's the finding and fix.

## The bug (pre-existing, masked by CI's fixed order)

`test_create_server_registers_core_tools` (`tests/test_tools.py`) pops every `automox_mcp.*` module out of `sys.modules` and re-imports the package. `monkeypatch` restores `sys.path` and env but **not `sys.modules`** — so the reimport leaves a **duplicate set of class objects** behind. Afterward, `call_tool_workflow`'s `issubclass(params_model, (OrgIdContextMixin, OrgIdRequiredMixin))` compares classes from *different module copies*, silently returns `False`, and **stops injecting `org_id`** → cascade of `org_id required` / `ValidationError`.

It's invisible in CI because `pytest` collects in a fixed (alphabetical) order where the damage lands harmlessly late. Under randomized order it fails **up to ~102 tests** (seed-dependent: I measured 0–102).

## Scope check (the question you actually asked)

- Every test file **passes in isolation** — no test is a false-pass relying on a neighbor to pass.
- The failures are tests *breaking* under reorder (fragility), not the **product** misbehaving. The shipped 1.2.0 tools have their own self-contained tests.
- So: a real test-suite hygiene defect, but **no evidence of a hidden product bug**.

## Fix

- `conftest` autouse fixture snapshots/restores **`sys.modules` (automox_mcp.\*)** and **`os.environ`** per test — containing any module/env surgery to the test that performs it.
- Added **`pytest-randomly`** (dev dep) so the suite now runs in **randomized order by default**; any new order-dependence fails immediately, with the seed printed for reproduction (`--randomly-seed=N`). CI picks this up automatically (`uv sync --extra dev` → plugin auto-activates).
- Also `.gitignore`s `tests/probe_*.py` (manual live-tenant probes).

## Verification

- **Green across 26 seeds** (0 failures); previously 4 of the first 6 seeds failed (up to 102 tests).
- `ruff` + `mypy` clean; coverage unchanged at **90.42%** (gate 90%).
- `uv.lock` re-locked (CI uses `--frozen`); no product/version change — purely test + dev-tooling.

Recommend landing this **before** the 1.2.0 release, per the "don't ship with bugs falling out" goal.