### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-30
+
 ### Fixed
 
 - **Test-suite order-dependence (latent, pre-existing).** A test reimported the package (`sys.modules` pop + re-`import`), leaving duplicate class objects behind; later `issubclass(..., OrgIdRequiredMixin)` checks then compared classes across module copies and silently stopped injecting `org_id` — invisible in the fixed CI order, but failing up to ~100 tests under randomized order. Added a `conftest` autouse fixture that snapshots/restores `sys.modules` (and `os.environ`) per test, and added `pytest-randomly` (dev) so the suite now runs in randomized order and regressions surface immediately. Suite is green across 26 seeds.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
-  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 97 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
+  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 127 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {
     "name": "Automox",
     "url": "https://www.automox.com"

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "1.1.0"
+version = "1.2.0"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=1.1.0",
+  "automox-mcp>=1.2.0",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Release-prep for **1.2.0** — version bump + CHANGELOG roll-up. Merge this, then push the `v1.2.0` tag to trigger publish (the release workflow validates `tag == pyproject.version`).

## Version bump (all 6 manifest strings → 1.2.0)
- `pyproject.toml`, `server.json` (`.version` + `.packages[].version`), `mcpb/manifest.json`, `mcpb/pyproject.toml` (`.version` + `automox-mcp>=` floor), `uv.lock` re-locked.
- Manifests-consistency gate verified locally (all match `1.2.0`).
- MCPB manifest description tool count refreshed 97 → 127.

## CHANGELOG
- `[Unreleased]` rolled into **`[1.2.0]` — 2026-05-30**; fresh empty `[Unreleased]` left on top.

## What 1.2.0 ships
The #91 API-surface expansion — **+30 tools (97 → 127)**: identity/zone/API-key management, organization inspection, gated remediation execution (`AUTOMOX_MCP_ALLOW_REMEDIATION`), policy device-targeting preview + blast-radius + multi-zone clone, bulk device tagging, search/metadata enrichment, DND surfacing — plus the randomized-test-order hardening (#107). All additive, backward-compatible.

## Verification
- `ruff` + `mypy` clean, full suite **1308 passed** (randomized), coverage **90.42%**.
- No product code changes in this PR — version/docs/lock only.

After merge: `git tag v1.2.0 && git push origin v1.2.0` → `release.yml` publishes to PyPI + MCP Registry + MCPB.