### PR TITLE
Establish destructive-operation gating policy + API coverage doc (1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-31
+
+Establishes and documents the server's capability model: a categorical policy for what the MCP server exposes, omits, and gates.
+
+### Added
+
+- **`docs/api-coverage.md` — coverage map and capability policy.** Documents, against the `2026-05-28` Console API bundle (115 documented operations), every intentional omission and the destructive-operation gating principle. README gains a **Capability model** section summarizing it.
+- **`AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` env gate.** New default-off flag controlling the fleet-scale `splashtop_bulk_install_uninstall` tool, parallel to `AUTOMOX_MCP_ALLOW_REMEDIATION`.
+
+### Changed
+
+- **`splashtop_bulk_install_uninstall` is now gated (behavioral change).** It installs/uninstalls the Splashtop client across an entire server group in one call — a fleet-scale blast radius per-call confirmation cannot meaningfully vet — so it now requires `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL=true` in addition to write mode. Previously it registered on write mode alone. **No grandfathering:** the destructive-gating standard is applied uniformly. Single-device Splashtop actions (`install`/`uninstall`/`force_disconnect`) are unaffected — they remain confirmation-gated (`destructiveHint`) only, since they are single-target and recoverable.
+
+### Policy (documented, no code change)
+
+- **Secrets are never handled** — no decrypt tools, no password-setting, secret fields redacted. `PUT /users/{id}` (full-replace, accepts `password`) stays omitted; the `PATCH` variant (`update_user`) is the wrapped one.
+- **Destructive operations are two-tier** — *ask-first* (`destructiveHint`, host confirmation) for single-target/recoverable actions; *gated* (default-off env flag) only when confirmation can't protect the operator: fleet-scale **(A)**, self-lockout **(B)**, or arbitrary model-authored code execution **(C)**.
+- **`DELETE /servers/{id}` (device deletion) intentionally omitted** — self-lockout + no create-counterpart. Build backlog (`PUT /servers/{id}`, action-set deletes) tracked in #111.
+
 ## [1.2.1] - 2026-05-30
 
 Directory-submission preparation for the Anthropic Connectors Directory. No new tools, endpoints, or behavioral changes — additive metadata, documentation accuracy, and tool-description clarifications.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 | `AUTOMOX_ORG_ID` | Recommended | — | Numeric organization ID (required by most tools) |
 | `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (84 of 127 tools remain) |
 | `AUTOMOX_MCP_ALLOW_REMEDIATION` | No | `false` | Opt in to the `apply_remediation_actions` tool, which patches/runs worklets on endpoints immediately. Off by default even in write mode. |
+| `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` | No | `false` | Opt in to the `splashtop_bulk_install_uninstall` tool, which installs/uninstalls the Splashtop client across an entire server group in one call. Off by default even in write mode. |
 | `AUTOMOX_MCP_MODULES` | No | all | Comma-separated list of modules to load (see below) |
 | `AUTOMOX_MCP_TOKEN_BUDGET` | No | `4000` | Max estimated tokens per response before truncation |
 | `AUTOMOX_MCP_SANITIZE_RESPONSES` | No | `true` | Sanitize API data to mitigate prompt injection |
@@ -202,6 +203,14 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 - **Remote bind protection** — non-loopback HTTP/SSE binding requires explicit `--allow-remote-bind` opt-in
 - **MCP Tool Annotations** on all 127 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
 - **60 security hardening items** (V-001 through V-181, S-001 through S-006) documented in CHANGELOG and SECURITY.md
+
+**Capability model.** What the server exposes follows three categorical rules:
+
+- **Secrets are never handled** — the server never returns secret material and never lets the model set it. Credentials enter only via environment/config; decrypt endpoints are not wrapped, password-setting is excluded, and secret fields are redacted from every projection.
+- **Destructive operations are two-tier.** Single-target, recoverable actions are **ask-first** (`destructiveHint: true`, surfaced as a host confirmation dialog, disabled entirely by read-only mode). Operations where per-call confirmation can't protect you — fleet-scale, self-lockout, or arbitrary model-authored code execution — are **gated** behind explicit, default-off env flags (`AUTOMOX_MCP_ALLOW_REMEDIATION`, `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL`).
+- **A few endpoints are intentionally omitted** (e.g. device deletion) on the same safety grounds.
+
+The full coverage map, the gating principle, and every intentional omission are documented in [API Coverage & Intentional Omissions](docs/api-coverage.md).
 
 For vulnerability reporting and the full threat model, see [SECURITY.md](SECURITY.md).
 For deployment hardening (containers, Kubernetes, MCP gateways, TLS, authentication), see the [Deployment Security Guide](docs/deployment-security.md).

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -1,0 +1,89 @@
+# API Coverage & Intentional Omissions
+
+This document records what the Automox MCP server deliberately does **not** expose, and the policy that governs destructive operations. It exists so that a coverage gap is never ambiguous: every documented Automox Console API operation is either wrapped, tracked for build, or intentionally omitted here with a rationale.
+
+Audited against the Automox Console API OpenAPI bundle (`ax-console-bundle.yaml`, version `2026-05-28`): **115 documented operations**. Coverage verified by registering the server and reading the live tool set, not by reading prose. Undocumented-but-wrapped paths (endpoints the live tenant serves that the spec omits) are tracked separately in [#95](https://github.com/AutomoxCommunity/automox-mcp/issues/95) and are **not** coverage gaps.
+
+The server exposes 127 tools (84 read / 43 write). Effectively every documented **read** operation is covered; the omissions below are all writes, deletes, or secret-exposing endpoints.
+
+## Three categories
+
+Everything the server chooses not to do falls into one of three buckets:
+
+1. **Secrets** — never handled, in or out. Permanent.
+2. **Destructive** — exposed under a two-tier safety policy (ask-first vs. gated), or omitted when neither tier is appropriate.
+3. **Everything else** — a build backlog, tracked as issues.
+
+---
+
+## 1. Secrets — never handled
+
+**Principle: the server never returns secret material and never lets the model set it.** Credentials enter only via environment/config (`AUTOMOX_API_KEY`, etc.) and are never logged, persisted, or echoed back through a tool. The model can neither read a secret nor write one.
+
+This is permanent policy, not a backlog item. It unifies several decisions:
+
+| Omitted / guarded | Operation | Rationale |
+|---|---|---|
+| `decryptOrganizationApiKey` | `POST /users/{userId}/api_keys/{id}/decrypt` | Returns a live plaintext API key. Never wrapped. |
+| `decryptGlobalApiKey` | `POST /global/api_keys/{keyId}/decrypt` | Returns a live plaintext account-scoped key. Never wrapped. |
+| `FullUpdateUserById` | `PUT /users/{userId}` | Full-replace body accepts `password`/`password1`/`password2`/`tfa_type` — an account-takeover write. We wrap the `PATCH` variant (`update_user`) instead, with password fields stripped. |
+| (field redaction) | User DTO `intercom_hmac`, Zone DTO `access_key` | Secret fields are redacted from every projection that would otherwise surface them. |
+
+API-key **metadata** (list/create/get/update) is wrapped — only the secret material is off-limits.
+
+---
+
+## 2. Destructive operations — a two-tier policy
+
+Most destructive operations **are** exposed; the server already ships create/update/delete tools across policies, webhooks, groups, saved searches, API keys, windows, users, and remote-control actions. The question for each is *how* it is exposed.
+
+**Meta-principle: gate (require an explicit, default-off env flag) only when per-call human confirmation cannot meaningfully protect the operator.** Otherwise, rely on the host client's confirmation dialog.
+
+### Tier 1 — Ask-first (default on, subject to `AUTOMOX_MCP_READ_ONLY`)
+
+Single-target, human-vettable, recoverable destructive or real-world actions. Each carries `readOnlyHint: false` and `destructiveHint: true`, so a compliant host surfaces a confirmation dialog. The human in the loop is genuinely sufficient.
+
+Examples: `delete_policy`, `delete_webhook`, `delete_server_group`, `delete_saved_search`, `delete_*_api_key`, `delete_policy_window`, `remove_user_from_account`, `execute_policy_now` (triggers a human-curated policy), `execute_device_command` (one device), `splashtop_install`/`uninstall`/`force_disconnect` (one device; `force_disconnect` is fully reversible — reconnect).
+
+**Reversibility and disruption are handled here, not by gating.** A reboot is disruptive but recoverable and single-target → confirm, don't gate.
+
+### Tier 2 — Gated (default-off env flag)
+
+An operation is gated when confirmation is insufficient because it is:
+
+- **(A) Uncontainable by scale** — acts across many endpoints in one call by design; the operator can't meaningfully reason about the blast radius from a confirmation prompt.
+- **(B) Unrecoverable / self-lockout** — removes your own ability to manage or recover the endpoint afterward; there is no undo and no remote path back in.
+- **(C) Opaque / arbitrary** — model-authored code execution on endpoints, where confirming the call doesn't reveal what will actually run.
+
+Note: *bulk alone is not a gate.* `batch_update_devices` is bulk but only applies tags (reversible metadata) → Tier 1. The gate is bulk **and** destructive/real-world.
+
+| Tool | Flag | Trigger |
+|---|---|---|
+| `apply_remediation_actions` | `AUTOMOX_MCP_ALLOW_REMEDIATION` | **(C)** `patch-with-worklet` runs a model-selected worklet (arbitrary script) on endpoints; a confirmation dialog can't convey the payload. (Triggering a *human-built* worklet policy via `execute_policy_now` stays Tier 1 — a human vetted that payload.) |
+| `splashtop_bulk_install_uninstall` | `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` | **(A)** one call installs/uninstalls the Splashtop client across an entire server group. |
+
+### Omitted on destructive grounds
+
+| Omitted | Operation | Rationale |
+|---|---|---|
+| `deleteDevice` | `DELETE /servers/{id}` | **(B)** destroys the device record and its history — not reconstructable through the MCP — and there is no create-device counterpart (agents self-register), so it fails the value test. Documented rather than gated. If a concrete need arises, it would ship gated, not ask-first. |
+
+---
+
+## 3. Build backlog
+
+Everything else uncovered is intended to be built. Tracked in [#111](https://github.com/AutomoxCommunity/automox-mcp/issues/111):
+
+| Operation | Tier when built |
+|---|---|
+| `PUT /servers/{id}` (`updateDevice`: `custom_name`, `server_group_id`, `exception`, `tags`, `ip_addrs`) | **Not destructive** — plain write, no gate. Fills the single-device-update hole `batch_update_devices` (tags only) doesn't cover. |
+| `DELETE /orgs/{org}/remediations/action-sets/{id}` (`deleteActionSet`) | Tier 1 ask-first (reconstructable via re-upload) |
+| `DELETE /orgs/{org}/remediations/action-sets` (`deleteActionSetsBulk`) | Tier 1 ask-first (console metadata, not endpoint state) |
+
+---
+
+## Not a gap — redundant
+
+| Operation | Why |
+|---|---|
+| `GET /policy-history/policies/{policy_uuid}/runs` (`policyExecutionHistory`) | Returns `{policy_id, policy_uuid, run_time, execution_token}` — the exact data already surfaced by `policy_runs_for_policy` with `summary_only=true` (DTO-verified). |

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -205,7 +205,7 @@ Manage maintenance/exclusion windows that prevent policy execution during schedu
 
 ## Splashtop Remote Control (10 tools)
 
-Wraps the ten `/remotecontrol-st/...` endpoints Automox shipped on 2026-01-14 (Splashtop partnership GA). Read-only tools (`splashtop_device_status`, `splashtop_session_status`, `splashtop_get_attended_access`) are always registered; write tools are gated by `read_only=False` and carry `destructiveHint: true`.
+Wraps the ten `/remotecontrol-st/...` endpoints Automox shipped on 2026-01-14 (Splashtop partnership GA). Read-only tools (`splashtop_device_status`, `splashtop_session_status`, `splashtop_get_attended_access`) are always registered; write tools are gated by `read_only=False` and carry `destructiveHint: true`. The fleet-scale `splashtop_bulk_install_uninstall` is additionally gated behind `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` (see [API Coverage & Omissions](api-coverage.md)).
 
 Tenants without an active Remote Control subscription (Core bundled with Automate Enterprise, or Resolve as a paid add-on) will receive 4XX errors from the upstream — tools surface these as standard `AutomoxApiError`. Module loads only when `splashtop` is included in `AUTOMOX_MCP_MODULES` (or no module filter is set).
 
@@ -213,7 +213,7 @@ Tenants without an active Remote Control subscription (Core bundled with Automat
 - **`splashtop_session_status`** - Active session count, max sessions, and whether a new session can be started.
 - **`splashtop_get_attended_access`** - Returns whether end-user consent is required before remote sessions can start.
 - **`splashtop_install`** *(write)* - Install the Splashtop RMM client on a device (asynchronous). `request_permission` controls install-time consent (`not_needed` or `ask_reject_on_timeout`), distinct from per-session attended access.
-- **`splashtop_bulk_install_uninstall`** *(write)* - Bulk install or uninstall across a server group. Returns 200 when queued, not when complete.
+- **`splashtop_bulk_install_uninstall`** *(write, gated)* - Bulk install or uninstall across a server group. Returns 200 when queued, not when complete. Fleet-scale, so **registered only when `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL=true`** and write mode is enabled.
 - **`splashtop_initiate_connection`** *(write)* - Generate a `splashtop-sos://...` deeplink for an operator. The API does NOT start the session — the operator opens the URL in their local Splashtop RMM App, and end-user consent still applies when attended access is enabled.
 - **`splashtop_force_disconnect`** *(write)* - Force-disconnect all active Splashtop sessions on a device. Interrupts any in-progress operator work.
 - **`splashtop_set_attended_access`** *(write)* - Enable or disable the end-user-consent requirement for a device. Setting to `false` allows unattended sessions — review your organization's policy.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 127 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "1.2.1"
+version = "1.3.0"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=1.2.1",
+  "automox-mcp>=1.3.0",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "1.2.1"
+version = "1.3.0"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "1.2.1",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/automox_mcp/tools/meta_tools.py
+++ b/src/automox_mcp/tools/meta_tools.py
@@ -158,7 +158,11 @@ _DOMAIN_CATALOG: dict[str, list[tuple[str, str]]] = {
         ("splashtop_session_status", "Active Splashtop sessions and capacity for a device"),
         ("splashtop_get_attended_access", "Current attended-access setting for a device"),
         ("splashtop_install", "Install the Splashtop RMM client on a device"),
-        ("splashtop_bulk_install_uninstall", "Bulk install/uninstall across a server group"),
+        (
+            "splashtop_bulk_install_uninstall",
+            "Bulk install/uninstall across a server group "
+            "(requires AUTOMOX_MCP_ALLOW_REMOTE_CONTROL)",
+        ),
         ("splashtop_initiate_connection", "Generate a splashtop-sos:// deeplink for an operator"),
         ("splashtop_force_disconnect", "Force-disconnect all active sessions on a device"),
         ("splashtop_set_attended_access", "Set the end-user-consent requirement for a device"),

--- a/src/automox_mcp/tools/splashtop_tools.py
+++ b/src/automox_mcp/tools/splashtop_tools.py
@@ -3,7 +3,10 @@
 Exposes the ten ``/remotecontrol-st/...`` endpoints Automox shipped on
 2026-01-14. Read-only tools (device status, session status, attended
 access lookup) are always registered; write tools are gated by
-``read_only=False`` and carry ``destructiveHint: true``.
+``read_only=False`` and carry ``destructiveHint: true``. The fleet-scale
+``splashtop_bulk_install_uninstall`` is additionally env-gated behind
+``AUTOMOX_MCP_ALLOW_REMOTE_CONTROL`` (default off): one call touches an
+entire server group, a blast radius per-call confirmation cannot vet.
 
 Why initiate_connection isn't gated more strictly: the API only returns
 a ``splashtop-sos://...`` deeplink. The actual session does not start
@@ -37,6 +40,7 @@ from ..schemas import (
 from ..utils.tooling import (
     call_tool_workflow,
     check_idempotency,
+    is_remote_control_allowed,
     maybe_format_markdown,
     release_idempotency,
     store_idempotency,
@@ -207,44 +211,52 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             await store_idempotency(request_id, "splashtop_install", result)
             return result
 
-        @server.tool(
-            name="splashtop_bulk_install_uninstall",
-            description=(
-                "Asynchronously install or uninstall the Splashtop RMM client "
-                "across a server group. Returns 200 when the operation is queued "
-                "(not when complete)."
-            ),
-            annotations={
-                "readOnlyHint": False,
-                "destructiveHint": True,
-                "idempotentHint": False,
-                "openWorldHint": True,
-            },
-        )
-        async def splashtop_bulk_install_uninstall(
-            action: str,
-            server_group_id: int | None = None,
-            request_id: str | None = None,
-        ) -> dict[str, Any]:
-            cached = await check_idempotency(request_id, "splashtop_bulk_install_uninstall")
-            if cached is not None:
-                return cached
+        # Fleet-scale remote-control execution is opt-in beyond write mode: a
+        # single call installs/uninstalls the Splashtop client across an entire
+        # server group, a blast radius per-call confirmation cannot meaningfully
+        # vet. Gated by AUTOMOX_MCP_ALLOW_REMOTE_CONTROL. Single-device Splashtop
+        # actions stay confirmation-gated only.
+        if is_remote_control_allowed():
 
-            params: dict[str, Any] = {"action": action}
-            if server_group_id is not None:
-                params["server_group_id"] = server_group_id
-            try:
-                result = await call_tool_workflow(
-                    client,
-                    _bulk_install_uninstall,
-                    params,
-                    params_model=SplashtopBulkActionParams,
-                )
-            except BaseException:
-                await release_idempotency(request_id, "splashtop_bulk_install_uninstall")
-                raise
-            await store_idempotency(request_id, "splashtop_bulk_install_uninstall", result)
-            return result
+            @server.tool(
+                name="splashtop_bulk_install_uninstall",
+                description=(
+                    "Asynchronously install or uninstall the Splashtop RMM client "
+                    "across an entire server group in one call. Returns 200 when the "
+                    "operation is queued (not when complete). Requires "
+                    "AUTOMOX_MCP_ALLOW_REMOTE_CONTROL=true."
+                ),
+                annotations={
+                    "readOnlyHint": False,
+                    "destructiveHint": True,
+                    "idempotentHint": False,
+                    "openWorldHint": True,
+                },
+            )
+            async def splashtop_bulk_install_uninstall(
+                action: str,
+                server_group_id: int | None = None,
+                request_id: str | None = None,
+            ) -> dict[str, Any]:
+                cached = await check_idempotency(request_id, "splashtop_bulk_install_uninstall")
+                if cached is not None:
+                    return cached
+
+                params: dict[str, Any] = {"action": action}
+                if server_group_id is not None:
+                    params["server_group_id"] = server_group_id
+                try:
+                    result = await call_tool_workflow(
+                        client,
+                        _bulk_install_uninstall,
+                        params,
+                        params_model=SplashtopBulkActionParams,
+                    )
+                except BaseException:
+                    await release_idempotency(request_id, "splashtop_bulk_install_uninstall")
+                    raise
+                await store_idempotency(request_id, "splashtop_bulk_install_uninstall", result)
+                return result
 
         @server.tool(
             name="splashtop_initiate_connection",

--- a/src/automox_mcp/utils/tooling.py
+++ b/src/automox_mcp/utils/tooling.py
@@ -78,6 +78,21 @@ def is_remediation_allowed() -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def is_remote_control_allowed() -> bool:
+    """Return True when fleet-scale remote-control actions are explicitly enabled.
+
+    Gated by ``AUTOMOX_MCP_ALLOW_REMOTE_CONTROL`` (default off). Controls the
+    ``splashtop_bulk_install_uninstall`` tool, which installs/uninstalls the
+    Splashtop RMM client across an entire server group in one call — a
+    fleet-scale change that per-call confirmation cannot meaningfully vet, so it
+    is opt-in even when write mode is enabled. Single-device Splashtop actions
+    (install/uninstall/force-disconnect one device) remain confirmation-gated
+    only, not env-gated.
+    """
+    value = os.environ.get("AUTOMOX_MCP_ALLOW_REMOTE_CONTROL", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def get_tool_prefix() -> str:
     """Return the configured tool name prefix, or empty string if none."""
     return os.environ.get("AUTOMOX_MCP_TOOL_PREFIX", "").strip()

--- a/tests/test_new_tool_registration.py
+++ b/tests/test_new_tool_registration.py
@@ -125,7 +125,6 @@ def test_splashtop_tools_register_with_writes() -> None:
     tool_names = automox_mcp.tools._get_tool_names(server)
     expected = {
         "splashtop_install",
-        "splashtop_bulk_install_uninstall",
         "splashtop_initiate_connection",
         "splashtop_force_disconnect",
         "splashtop_set_attended_access",
@@ -133,6 +132,20 @@ def test_splashtop_tools_register_with_writes() -> None:
         "splashtop_uninstall",
     }
     assert expected.issubset(tool_names)
+    # The fleet-scale bulk tool is gated separately (AUTOMOX_MCP_ALLOW_REMOTE_CONTROL)
+    # and must NOT register on write mode alone.
+    assert "splashtop_bulk_install_uninstall" not in tool_names
+
+
+def test_splashtop_bulk_gated_by_remote_control_flag(monkeypatch) -> None:
+    # Off by default even in write mode.
+    server = _make_server_with_module("splashtop_tools", has_writes=True)
+    assert "splashtop_bulk_install_uninstall" not in automox_mcp.tools._get_tool_names(server)
+
+    # Registers only when AUTOMOX_MCP_ALLOW_REMOTE_CONTROL is enabled.
+    monkeypatch.setenv("AUTOMOX_MCP_ALLOW_REMOTE_CONTROL", "true")
+    server = _make_server_with_module("splashtop_tools", has_writes=True)
+    assert "splashtop_bulk_install_uninstall" in automox_mcp.tools._get_tool_names(server)
 
 
 def test_vuln_sync_tools_register_read_only() -> None:

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -1741,6 +1741,7 @@ class TestSplashtopToolsDispatch:
             return _success()
 
         monkeypatch.setattr(splashtop_tools, "_bulk_install_uninstall", fake)
+        monkeypatch.setenv("AUTOMOX_MCP_ALLOW_REMOTE_CONTROL", "true")
 
         server = StubServer()
         splashtop_tools.register(server, read_only=False, client=FakeClient())
@@ -1938,6 +1939,8 @@ class TestSplashtopIdempotencyAndExceptionPaths:
 
         monkeypatch.setattr(splashtop_tools, "check_idempotency", fake_check)
         monkeypatch.setattr(splashtop_tools, wf_attr, fake_wf)
+        # Enable the gated bulk tool so the parametrized bulk case registers.
+        monkeypatch.setenv("AUTOMOX_MCP_ALLOW_REMOTE_CONTROL", "true")
 
         server = StubServer()
         splashtop_tools.register(server, read_only=False, client=FakeClient())
@@ -1965,6 +1968,8 @@ class TestSplashtopIdempotencyAndExceptionPaths:
 
         monkeypatch.setattr(splashtop_tools, "release_idempotency", fake_release)
         monkeypatch.setattr(splashtop_tools, wf_attr, fake_wf)
+        # Enable the gated bulk tool so the parametrized bulk case registers.
+        monkeypatch.setenv("AUTOMOX_MCP_ALLOW_REMOTE_CONTROL", "true")
 
         server = StubServer()
         splashtop_tools.register(server, read_only=False, client=FakeClient())

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Establishes the server's **capability model** as written policy and applies the destructive-gating standard uniformly — **no grandfathering**.

## Policy (the three categories)

1. **Secrets — never handled.** No decrypt tools, no password-setting, secret fields redacted. `PUT /users/{id}` (full-replace, accepts `password`) stays omitted; `update_user` (PATCH, password stripped) is the wrapped variant.
2. **Destructive — two tiers.** *Ask-first* (`destructiveHint`, host confirmation, off under `read_only`) for single-target/recoverable actions. *Gated* (default-off env flag) **only when per-call confirmation can't protect the operator**: **(A)** fleet-scale, **(B)** self-lockout, **(C)** arbitrary model-authored code execution.
3. **Everything else → build** (tracked in #111).

Full rationale, the coverage map (vs the `2026-05-28` Console API bundle, 115 ops), and every omission live in the new **[`docs/api-coverage.md`](docs/api-coverage.md)**; README gets a **Capability model** summary.

## Behavioral change (no grandfathering)

- **`splashtop_bulk_install_uninstall` is now gated** behind the new **`AUTOMOX_MCP_ALLOW_REMOTE_CONTROL`** flag (default off), parallel to `ALLOW_REMEDIATION`. It installs/uninstalls across an entire server group in one call (trigger A). Previously registered on write mode alone.
- **Single-device Splashtop actions unchanged** (`install`/`uninstall`/`force_disconnect`) — single-target and recoverable, so confirmation-only is correct. `force_disconnect` is reversible (reconnect), so it is deliberately *not* gated.
- `apply_remediation_actions` unchanged (already gated under trigger C — `patch-with-worklet` runs model-selected worklet code).

## Why these specific lines

- `DELETE /servers/{id}` **intentionally omitted** (B self-lockout + no create-counterpart) — documented, not gated.
- Reversibility/disruption (e.g. reboot) handled by confirmation, **not** gating.

## Verification

- Gate matrix verified by registering the server: default-visible **125**, +either flag **126**, both on **127** (catalog = 84 read / 43 write), `read_only` **84**.
- `mypy` clean, `ruff` clean, **1323 tests pass** (added a bulk-gate registration test; updated dispatch/registration tests to enable the flag where they exercise the bulk tool).
- `mcpb validate` passes; all gated versions aligned at 1.3.0.

Not tagged/published — release is a separate step, and immutable-release fix #110 is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)