### PR TITLE
#111: single-device update_device + action-set delete tools (1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Establishes and documents the server's capability model: a categorical policy fo
 
 - **`docs/api-coverage.md` — coverage map and capability policy.** Documents, against the `2026-05-28` Console API bundle (115 documented operations), every intentional omission and the destructive-operation gating principle. README gains a **Capability model** section summarizing it.
 - **`AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` env gate.** New default-off flag controlling the fleet-scale `splashtop_bulk_install_uninstall` tool, parallel to `AUTOMOX_MCP_ALLOW_REMEDIATION`.
+- **`update_device` tool (#111).** Updates a single device's `custom_name`, `server_group_id`, `exception`, `tags`, or `ip_addrs` via `PUT /servers/{id}`. Fills the single-device-update gap that `batch_update_devices` (tags-only) leaves; not destructive, plain write (off under `read_only`).
+- **`delete_action_set` / `delete_action_sets_bulk` tools (#111).** Delete Vuln Sync action sets — Tier-1 ask-first (`destructiveHint`, reconstructable via re-upload). The bulk tool iterates the single-delete endpoint (the native bulk-delete body shape is undocumented; per-ID results, non-atomic) — see `docs/api-coverage.md`.
+- Tool count is now **130** (84 read / 46 write); read-only mode still exposes 84.
 
 ### Changed
 
@@ -24,7 +27,7 @@ Establishes and documents the server's capability model: a categorical policy fo
 
 - **Secrets are never handled** — no decrypt tools, no password-setting, secret fields redacted. `PUT /users/{id}` (full-replace, accepts `password`) stays omitted; the `PATCH` variant (`update_user`) is the wrapped one.
 - **Destructive operations are two-tier** — *ask-first* (`destructiveHint`, host confirmation) for single-target/recoverable actions; *gated* (default-off env flag) only when confirmation can't protect the operator: fleet-scale **(A)**, self-lockout **(B)**, or arbitrary model-authored code execution **(C)**.
-- **`DELETE /servers/{id}` (device deletion) intentionally omitted** — self-lockout + no create-counterpart. Build backlog (`PUT /servers/{id}`, action-set deletes) tracked in #111.
+- **`DELETE /servers/{id}` (device deletion) intentionally omitted** — self-lockout + no create-counterpart. The documented-surface build backlog (`PUT /servers/{id}`, action-set deletes) is now covered (#111); binary/multipart uploads remain tracked in #106.
 
 ## [1.2.1] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ That's it. Start asking questions.
 
 ## What Can I Ask?
 
-The server exposes 127 tools across devices, policies, patches, groups, webhooks, worklets, vulnerability sync, maintenance windows, and more. You don't need to know the tool names — just describe what you want:
+The server exposes 130 tools across devices, policies, patches, groups, webhooks, worklets, vulnerability sync, maintenance windows, and more. You don't need to know the tool names — just describe what you want:
 
 | Ask this | What happens |
 |---|---|
@@ -103,7 +103,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 | `AUTOMOX_API_KEY` | Yes | — | Automox API key |
 | `AUTOMOX_ACCOUNT_UUID` | Yes | — | Account UUID from Secrets & Keys |
 | `AUTOMOX_ORG_ID` | Recommended | — | Numeric organization ID (required by most tools) |
-| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (84 of 127 tools remain) |
+| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (84 of 130 tools remain) |
 | `AUTOMOX_MCP_ALLOW_REMEDIATION` | No | `false` | Opt in to the `apply_remediation_actions` tool, which patches/runs worklets on endpoints immediately. Off by default even in write mode. |
 | `AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` | No | `false` | Opt in to the `splashtop_bulk_install_uninstall` tool, which installs/uninstalls the Splashtop client across an entire server group in one call. Off by default even in write mode. |
 | `AUTOMOX_MCP_MODULES` | No | all | Comma-separated list of modules to load (see below) |
@@ -132,7 +132,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 AUTOMOX_MCP_READ_ONLY=true
 ```
 
-Disables all write operations. Only read-only tools are registered (84 of 127). Useful for auditing and monitoring.
+Disables all write operations. Only read-only tools are registered (84 of 130). Useful for auditing and monitoring.
 
 ### Modular Loading
 
@@ -184,7 +184,7 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 
 **Highlights:**
 
-- **Read-only mode** (`AUTOMOX_MCP_READ_ONLY`) disables all 43 write tools
+- **Read-only mode** (`AUTOMOX_MCP_READ_ONLY`) disables all 46 write tools
 - **Module filtering** (`AUTOMOX_MCP_MODULES`) for least-privilege tool loading
 - **Correlation IDs** on every tool call, forwarded to Automox API as `X-Correlation-ID`
 - **Rate limiting** (30 calls/60s) with token budget estimation and auto-truncation
@@ -201,7 +201,7 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 - **Security response headers** — `X-Content-Type-Options`, `X-Frame-Options`, `CSP`, `Cache-Control: no-store`, `Strict-Transport-Security` on all HTTP responses
 - **Authentication rate limiting** — blocks IPs after repeated auth failures to mitigate brute-force attacks
 - **Remote bind protection** — non-loopback HTTP/SSE binding requires explicit `--allow-remote-bind` opt-in
-- **MCP Tool Annotations** on all 127 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
+- **MCP Tool Annotations** on all 130 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
 - **60 security hardening items** (V-001 through V-181, S-001 through S-006) documented in CHANGELOG and SECURITY.md
 
 **Capability model.** What the server exposes follows three categorical rules:

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -4,7 +4,7 @@ This document records what the Automox MCP server deliberately does **not** expo
 
 Audited against the Automox Console API OpenAPI bundle (`ax-console-bundle.yaml`, version `2026-05-28`): **115 documented operations**. Coverage verified by registering the server and reading the live tool set, not by reading prose. Undocumented-but-wrapped paths (endpoints the live tenant serves that the spec omits) are tracked separately in [#95](https://github.com/AutomoxCommunity/automox-mcp/issues/95) and are **not** coverage gaps.
 
-The server exposes 127 tools (84 read / 43 write). Effectively every documented **read** operation is covered; the omissions below are all writes, deletes, or secret-exposing endpoints.
+The server exposes 130 tools (84 read / 46 write). Effectively every documented **read** operation is covered; the omissions below are all writes, deletes, or secret-exposing endpoints.
 
 ## Three categories
 
@@ -43,7 +43,7 @@ Most destructive operations **are** exposed; the server already ships create/upd
 
 Single-target, human-vettable, recoverable destructive or real-world actions. Each carries `readOnlyHint: false` and `destructiveHint: true`, so a compliant host surfaces a confirmation dialog. The human in the loop is genuinely sufficient.
 
-Examples: `delete_policy`, `delete_webhook`, `delete_server_group`, `delete_saved_search`, `delete_*_api_key`, `delete_policy_window`, `remove_user_from_account`, `execute_policy_now` (triggers a human-curated policy), `execute_device_command` (one device), `splashtop_install`/`uninstall`/`force_disconnect` (one device; `force_disconnect` is fully reversible — reconnect).
+Examples: `delete_policy`, `delete_webhook`, `delete_server_group`, `delete_saved_search`, `delete_*_api_key`, `delete_policy_window`, `delete_action_set`/`delete_action_sets_bulk` (reconstructable via re-upload), `remove_user_from_account`, `execute_policy_now` (triggers a human-curated policy), `execute_device_command` (one device), `splashtop_install`/`uninstall`/`force_disconnect` (one device; `force_disconnect` is fully reversible — reconnect).
 
 **Reversibility and disruption are handled here, not by gating.** A reboot is disruptive but recoverable and single-target → confirm, don't gate.
 
@@ -72,13 +72,17 @@ Note: *bulk alone is not a gate.* `batch_update_devices` is bulk but only applie
 
 ## 3. Build backlog
 
-Everything else uncovered is intended to be built. Tracked in [#111](https://github.com/AutomoxCommunity/automox-mcp/issues/111):
+The documented-surface build items from [#111](https://github.com/AutomoxCommunity/automox-mcp/issues/111) are now **covered**:
 
-| Operation | Tier when built |
-|---|---|
-| `PUT /servers/{id}` (`updateDevice`: `custom_name`, `server_group_id`, `exception`, `tags`, `ip_addrs`) | **Not destructive** — plain write, no gate. Fills the single-device-update hole `batch_update_devices` (tags only) doesn't cover. |
-| `DELETE /orgs/{org}/remediations/action-sets/{id}` (`deleteActionSet`) | Tier 1 ask-first (reconstructable via re-upload) |
-| `DELETE /orgs/{org}/remediations/action-sets` (`deleteActionSetsBulk`) | Tier 1 ask-first (console metadata, not endpoint state) |
+| Operation | Tool | Tier |
+|---|---|---|
+| `PUT /servers/{id}` (`updateDevice`: `custom_name`, `server_group_id`, `exception`, `tags`, `ip_addrs`) | `update_device` | **Not destructive** — plain write, no gate. Fills the single-device-update hole `batch_update_devices` (tags only) doesn't cover. |
+| `DELETE /orgs/{org}/remediations/action-sets/{id}` (`deleteActionSet`) | `delete_action_set` | Tier 1 ask-first (reconstructable via re-upload) |
+| `DELETE /orgs/{org}/remediations/action-sets` (`deleteActionSetsBulk`) | `delete_action_sets_bulk` | Tier 1 ask-first (console metadata, not endpoint state) |
+
+**Implementation note — `delete_action_sets_bulk`:** implemented by iterating the single-delete endpoint (`DELETE /…/action-sets/{id}`) rather than the native bulk endpoint (`DELETE /…/action-sets`), whose request-body shape is undocumented in the OpenAPI bundle and was unverifiable at build time. Deletion is non-atomic (per-ID results; a mid-list failure leaves earlier deletes applied — safe, since action sets are re-uploadable). **Actionable follow-on:** confirm the native bulk-delete contract (rendered docs or a console cURL capture) and swap to a single round-trip — tracked as a perf optimization, not a coverage gap.
+
+Remaining uncovered documented surface (binary/multipart uploads) is tracked in [#106](https://github.com/AutomoxCommunity/automox-mcp/issues/106).
 
 ---
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Complete reference for all 127 tools, 6 workflow prompts, MCP resources, parameters, and enterprise features exposed by the Automox MCP server.
+Complete reference for all 130 tools, 6 workflow prompts, MCP resources, parameters, and enterprise features exposed by the Automox MCP server.
 
 > **Tip:** You don't need to memorize this. Call `discover_capabilities` from your AI assistant to get a live summary of available tools organized by domain.
 
@@ -31,7 +31,7 @@ Complete reference for all 127 tools, 6 workflow prompts, MCP resources, paramet
 
 ---
 
-## Device Management (9 tools)
+## Device Management (10 tools)
 
 - **`list_devices`** - Summarize device inventory and policy status across the organization. Returns each device's `uuid` (needed by policy windows tools). Includes unmanaged devices by default and supports `policy_status`/`managed` filters so you can zero in on, for example, non-compliant managed endpoints.
 - **`device_detail`** - Return curated device context (recent policy status, assignments, queued commands, key facts). Pass `include_raw_details=true` only when you explicitly need a sanitized slice of the raw Automox payload.
@@ -42,6 +42,7 @@ Complete reference for all 127 tools, 6 workflow prompts, MCP resources, paramet
 - **`get_device_inventory_categories`** - List available inventory categories for a device. Categories are dynamic per device.
 - **`execute_device_command`** - Issue an immediate command to a device (scan, patch_all, patch_specific, reboot).
 - **`batch_update_devices`** *(write)* - Apply bulk attribute actions to up to 500 devices at once (currently tag apply/remove, e.g. `{"attribute": "tags", "action": "apply", "value": ["env:prod"]}`).
+- **`update_device`** *(write)* - Update a single device's mutable attributes (`custom_name`, `server_group_id`, `exception`, `tags`, `ip_addrs`); supply at least one. Fills the single-device gap that `batch_update_devices` (tags-only, bulk) does not cover — e.g. renaming a device or moving it to a server group.
 
 ## Advanced Device Search (18 tools)
 
@@ -130,7 +131,7 @@ Richer policy execution reporting via the `/policy-history` API with UUID-based 
 - **`get_data_extract`** - Get details and download information for a specific data extract.
 - **`create_data_extract`** - Request a new data extract for bulk reporting. Returns the extract ID and initial status.
 
-## Vulnerability Sync (7 tools)
+## Vulnerability Sync (9 tools)
 
 Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-based import from vulnerability scanners (Qualys, Tenable, etc.).
 
@@ -140,6 +141,8 @@ Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-b
 - **`get_action_set_solutions`** - Get solutions for an action set. Shows recommended patches or configurations.
 - **`get_upload_formats`** - Get supported CSV upload formats for vulnerability remediation action sets.
 - **`upload_action_set`** *(write)* - Upload a CSV-based vulnerability remediation action set.
+- **`delete_action_set`** *(write)* - Delete a single remediation action set by ID. Console metadata, reconstructable via re-upload.
+- **`delete_action_sets_bulk`** *(write)* - Delete multiple action sets by ID (up to 100). Deletes each individually with per-ID results; a partial failure leaves earlier deletes applied.
 - **`apply_remediation_actions`** *(write, gated)* - Execute remediations now (`patch-now` / `patch-with-worklet`) on explicit devices for an action set. Immediately changes endpoint state (async, returns 202). **Registered only when `AUTOMOX_MCP_ALLOW_REMEDIATION=true`** and write mode is enabled.
 
 ## Compound Workflows (3 tools)

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Automox",
   "version": "1.3.0",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
-  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 127 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
+  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 130 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {
     "name": "Automox",
     "url": "https://www.automox.com"
@@ -73,7 +73,7 @@
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "Disable all 43 write operations. 84 read tools remain available. Recommended for auditing and exploration.",
+      "description": "Disable all 46 write operations. 84 read tools remain available. Recommended for auditing and exploration.",
       "default": false,
       "required": false
     }

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -578,6 +578,43 @@ class BatchUpdateDevicesParams(OrgIdRequiredMixin, ForbidExtraModel):
         return self
 
 
+class UpdateDeviceParams(OrgIdRequiredMixin, ForbidExtraModel):
+    device_id: int = Field(description="Device (server) ID to update", ge=1)
+    custom_name: str | None = Field(
+        None, description="Friendly display name for the device", max_length=255
+    )
+    server_group_id: int | None = Field(
+        None, ge=0, description="Server group to move the device into"
+    )
+    exception: bool | None = Field(
+        None, description="Whether the device is excluded from policy enforcement"
+    )
+    tags: list[str] | None = Field(
+        None, description="Replacement tag list for the device", max_length=200
+    )
+    ip_addrs: list[str] | None = Field(
+        None, description="Replacement IP address list for the device", max_length=200
+    )
+
+    @model_validator(mode="after")
+    def _require_at_least_one_field(self) -> UpdateDeviceParams:
+        if all(
+            value is None
+            for value in (
+                self.custom_name,
+                self.server_group_id,
+                self.exception,
+                self.tags,
+                self.ip_addrs,
+            )
+        ):
+            raise ValueError(
+                "update_device requires at least one of: custom_name, server_group_id, "
+                "exception, tags, ip_addrs"
+            )
+        return self
+
+
 class ClonePolicyParams(OrgIdContextMixin, ForbidExtraModel):
     policy_id: int = Field(description="Policy ID to clone")
     name: str | None = Field(
@@ -848,6 +885,25 @@ class GetActionSetUploadFormatsParams(OrgIdRequiredMixin, ForbidExtraModel):
 
 class GetActionSetParams(OrgIdRequiredMixin, ForbidExtraModel):
     action_set_id: int = Field(description="Action set ID")
+
+
+class DeleteActionSetParams(OrgIdRequiredMixin, ForbidExtraModel):
+    action_set_id: int = Field(description="Action set ID to delete", ge=1)
+
+
+class DeleteActionSetsBulkParams(OrgIdRequiredMixin, ForbidExtraModel):
+    action_set_ids: list[int] = Field(
+        description="Action set IDs to delete",
+        min_length=1,
+        max_length=100,
+    )
+
+    @model_validator(mode="after")
+    def _validate_ids(self) -> DeleteActionSetsBulkParams:
+        for action_set_id in self.action_set_ids:
+            if action_set_id < 1:
+                raise ValueError("each action_set_id must be >= 1")
+        return self
 
 
 class GetActionSetIssuesParams(OrgIdRequiredMixin, ForbidExtraModel):

--- a/src/automox_mcp/tools/device_tools.py
+++ b/src/automox_mcp/tools/device_tools.py
@@ -19,6 +19,7 @@ from ..schemas import (
     DeviceSearchParams,
     DevicesNeedingAttentionParams,
     IssueDeviceCommandParams,
+    UpdateDeviceParams,
 )
 from ..utils.tooling import (
     call_tool_workflow,
@@ -332,6 +333,57 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 await release_idempotency(request_id, "batch_update_devices")
                 raise
             await store_idempotency(request_id, "batch_update_devices", result)
+            return result
+
+        @server.tool(
+            name="update_device",
+            description=(
+                "Update a single device's mutable attributes: custom_name, "
+                "server_group_id, exception (policy-enforcement exclusion), tags, and "
+                "ip_addrs. Fills the single-device gap that batch_update_devices "
+                "(tags-only, bulk) does not cover — e.g. renaming a device or moving it "
+                "to a server group. Supply only the fields you want to change; at least "
+                "one is required."
+            ),
+            annotations={
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "idempotentHint": True,
+                "openWorldHint": True,
+            },
+        )
+        async def update_device(
+            device_id: int,
+            custom_name: str | None = None,
+            server_group_id: int | None = None,
+            exception: bool | None = None,
+            tags: list[str] | None = None,
+            ip_addrs: list[str] | None = None,
+            request_id: str | None = None,
+        ) -> dict[str, Any]:
+            cached = await check_idempotency(request_id, "update_device")
+            if cached is not None:
+                return cached
+
+            params = {
+                "device_id": device_id,
+                "custom_name": custom_name,
+                "server_group_id": server_group_id,
+                "exception": exception,
+                "tags": tags,
+                "ip_addrs": ip_addrs,
+            }
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.update_device,
+                    params,
+                    params_model=UpdateDeviceParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "update_device")
+                raise
+            await store_idempotency(request_id, "update_device", result)
             return result
 
 

--- a/src/automox_mcp/tools/meta_tools.py
+++ b/src/automox_mcp/tools/meta_tools.py
@@ -19,6 +19,7 @@ _DOMAIN_CATALOG: dict[str, list[tuple[str, str]]] = {
         ("get_device_inventory_categories", "Available inventory categories"),
         ("execute_device_command", "Issue scan/patch/reboot command"),
         ("batch_update_devices", "Bulk attribute actions (e.g. tags) on many devices"),
+        ("update_device", "Update one device: name, group, exception, tags, IPs"),
         ("get_device_full_profile", "Complete profile: detail + inventory + packages"),
     ],
     "device_search": [
@@ -117,6 +118,8 @@ _DOMAIN_CATALOG: dict[str, list[tuple[str, str]]] = {
         ("get_action_set_solutions", "Solutions for an action set"),
         ("get_upload_formats", "Supported CSV upload formats"),
         ("upload_action_set", "Upload CSV remediation data"),
+        ("delete_action_set", "Delete one remediation action set"),
+        ("delete_action_sets_bulk", "Delete multiple action sets by ID"),
         (
             "apply_remediation_actions",
             "Execute remediations now (requires AUTOMOX_MCP_ALLOW_REMEDIATION)",

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -9,6 +9,8 @@ from fastmcp import FastMCP
 
 from ..client import AutomoxClient
 from ..schemas import (
+    DeleteActionSetParams,
+    DeleteActionSetsBulkParams,
     GetActionSetIssuesParams,
     GetActionSetParams,
     GetActionSetSolutionsParams,
@@ -27,6 +29,12 @@ from ..utils.tooling import (
 )
 from ..workflows.vuln_sync import (
     apply_remediation_actions as _apply_remediation_actions,
+)
+from ..workflows.vuln_sync import (
+    delete_action_set as _delete_action_set,
+)
+from ..workflows.vuln_sync import (
+    delete_action_sets_bulk as _delete_action_sets_bulk,
 )
 from ..workflows.vuln_sync import (
     get_action_set_detail as _get_action_set_detail,
@@ -199,6 +207,75 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 params_model=UploadActionSetParams,
             )
             await store_idempotency(request_id, "upload_action_set", result)
+            return result
+
+        @server.tool(
+            name="delete_action_set",
+            description=(
+                "Delete a single vulnerability remediation action set by ID. "
+                "Action sets are console metadata (not endpoint state) and are "
+                "reconstructable by re-uploading the source CSV."
+            ),
+            annotations={
+                "readOnlyHint": False,
+                "destructiveHint": True,
+                "idempotentHint": True,
+                "openWorldHint": True,
+            },
+        )
+        async def delete_action_set(
+            action_set_id: int,
+            request_id: str | None = None,
+        ) -> dict[str, Any]:
+            cached = await check_idempotency(request_id, "delete_action_set")
+            if cached is not None:
+                return cached
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    _delete_action_set,
+                    {"action_set_id": action_set_id},
+                    params_model=DeleteActionSetParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "delete_action_set")
+                raise
+            await store_idempotency(request_id, "delete_action_set", result)
+            return result
+
+        @server.tool(
+            name="delete_action_sets_bulk",
+            description=(
+                "Delete multiple vulnerability remediation action sets by ID (up to "
+                "100). Deletes each ID individually and reports per-ID results, so a "
+                "partial failure leaves earlier deletions applied. Action sets are "
+                "reconstructable by re-uploading the source CSV."
+            ),
+            annotations={
+                "readOnlyHint": False,
+                "destructiveHint": True,
+                "idempotentHint": True,
+                "openWorldHint": True,
+            },
+        )
+        async def delete_action_sets_bulk(
+            action_set_ids: list[int],
+            request_id: str | None = None,
+        ) -> dict[str, Any]:
+            cached = await check_idempotency(request_id, "delete_action_sets_bulk")
+            if cached is not None:
+                return cached
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    _delete_action_sets_bulk,
+                    {"action_set_ids": action_set_ids},
+                    params_model=DeleteActionSetsBulkParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "delete_action_sets_bulk")
+                raise
+            await store_idempotency(request_id, "delete_action_sets_bulk", result)
             return result
 
         # Remediation EXECUTION is opt-in beyond write mode: it immediately

--- a/src/automox_mcp/workflows/__init__.py
+++ b/src/automox_mcp/workflows/__init__.py
@@ -83,6 +83,7 @@ from .devices import (
     list_devices_needing_attention,
     search_devices,
     summarize_device_health,
+    update_device,
 )
 from .events import list_events
 from .groups import (
@@ -211,6 +212,7 @@ __all__ = [
     "audit_events_ocsf",
     "audit_trail_user_activity",
     "batch_update_devices",
+    "update_device",
     "clone_policy",
     "create_data_extract",
     "create_global_api_key",

--- a/src/automox_mcp/workflows/devices.py
+++ b/src/automox_mcp/workflows/devices.py
@@ -1283,3 +1283,54 @@ async def batch_update_devices(
         "data": data,
         "metadata": {"deprecated_endpoint": False, "org_id": resolved_org_id},
     }
+
+
+async def update_device(
+    client: AutomoxClient,
+    *,
+    org_id: int | None = None,
+    device_id: int,
+    custom_name: str | None = None,
+    server_group_id: int | None = None,
+    exception: bool | None = None,
+    tags: list[str] | None = None,
+    ip_addrs: list[str] | None = None,
+) -> dict[str, Any]:
+    """Update a single device's mutable attributes.
+
+    Wraps ``PUT /servers/{id}`` (``updateDevice``). Fills the single-device-update
+    gap that ``batch_update_devices`` (``POST /servers/batch``) does not cover:
+    that endpoint only applies/removes tags, so renaming a device, moving it to a
+    server group, or toggling its policy ``exception`` flag is otherwise
+    unreachable. Only the fields the caller supplies are sent; omitted fields are
+    left to the upstream endpoint's documented per-field update semantics. At
+    least one field is required (enforced by ``UpdateDeviceParams``).
+    """
+    resolved_org_id = require_org_id(client, org_id)
+
+    body: dict[str, Any] = {}
+    if custom_name is not None:
+        body["custom_name"] = custom_name
+    if server_group_id is not None:
+        body["server_group_id"] = server_group_id
+    if exception is not None:
+        body["exception"] = exception
+    if tags is not None:
+        body["tags"] = list(tags)
+    if ip_addrs is not None:
+        body["ip_addrs"] = list(ip_addrs)
+
+    await client.put(
+        f"/servers/{device_id}",
+        json_data=body,
+        params={"o": resolved_org_id},
+    )
+
+    return {
+        "data": {
+            "device_id": device_id,
+            "updated": True,
+            "updated_fields": sorted(body.keys()),
+        },
+        "metadata": {"deprecated_endpoint": False, "org_id": resolved_org_id},
+    }

--- a/src/automox_mcp/workflows/vuln_sync.py
+++ b/src/automox_mcp/workflows/vuln_sync.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from ..client import AutomoxClient
+from ..client import AutomoxAPIError, AutomoxClient
 from ..utils.response import extract_list as _extract_list
 
 
@@ -250,6 +250,71 @@ async def upload_action_set(
             "message": "Action set upload submitted.",
         },
         "metadata": {"deprecated_endpoint": False},
+    }
+
+
+async def delete_action_set(
+    client: AutomoxClient,
+    *,
+    org_id: int,
+    action_set_id: int,
+) -> dict[str, Any]:
+    """Delete a single Vuln Sync action set.
+
+    Wraps ``DELETE /orgs/{org}/remediations/action-sets/{actionSetID}``. This is
+    console metadata (not endpoint state) and is reconstructable by re-uploading
+    the source CSV, so it is exposed as Tier-1 ask-first (confirmation-only, no
+    env gate).
+    """
+    await client.delete(
+        f"/orgs/{org_id}/remediations/action-sets/{action_set_id}",
+    )
+
+    return {
+        "data": {
+            "action_set_id": action_set_id,
+            "deleted": True,
+        },
+        "metadata": {"deprecated_endpoint": False, "org_id": org_id},
+    }
+
+
+async def delete_action_sets_bulk(
+    client: AutomoxClient,
+    *,
+    org_id: int,
+    action_set_ids: list[int],
+) -> dict[str, Any]:
+    """Delete multiple Vuln Sync action sets.
+
+    Implemented by iterating the confirmed single-delete endpoint
+    (``DELETE /orgs/{org}/remediations/action-sets/{actionSetID}``) rather than the
+    native bulk endpoint (``DELETE /orgs/{org}/remediations/action-sets``), whose
+    request-body shape is not documented in the OpenAPI bundle and could not be
+    verified at build time. Deletion is therefore non-atomic: each ID is reported
+    individually and a mid-list failure leaves earlier deletions applied (safe —
+    action sets are reconstructable via re-upload). Swapping to the native bulk
+    endpoint is a tracked perf optimization once its contract is confirmed.
+    """
+    deleted: list[int] = []
+    failed: list[dict[str, Any]] = []
+    for action_set_id in action_set_ids:
+        try:
+            await client.delete(
+                f"/orgs/{org_id}/remediations/action-sets/{action_set_id}",
+            )
+            deleted.append(action_set_id)
+        except AutomoxAPIError as exc:
+            failed.append({"action_set_id": action_set_id, "error": str(exc)})
+
+    return {
+        "data": {
+            "requested": len(action_set_ids),
+            "deleted_count": len(deleted),
+            "deleted": deleted,
+            "failed": failed,
+        },
+        "metadata": {"deprecated_endpoint": False, "org_id": org_id},
     }
 
 

--- a/tests/test_new_tool_registration.py
+++ b/tests/test_new_tool_registration.py
@@ -154,12 +154,25 @@ def test_vuln_sync_tools_register_read_only() -> None:
     assert "list_remediation_action_sets" in tool_names
     assert "get_action_set_detail" in tool_names
     assert "upload_action_set" not in tool_names
+    # Ask-first deletes are writes — absent in read-only mode.
+    assert "delete_action_set" not in tool_names
+    assert "delete_action_sets_bulk" not in tool_names
 
 
 def test_vuln_sync_tools_register_with_writes() -> None:
     server = _make_server_with_module("vuln_sync_tools", has_writes=True)
     tool_names = automox_mcp.tools._get_tool_names(server)
     assert "upload_action_set" in tool_names
+    # Tier-1 ask-first deletes register on write mode (no env gate).
+    assert "delete_action_set" in tool_names
+    assert "delete_action_sets_bulk" in tool_names
+
+
+def test_device_tools_update_device_gated_by_write() -> None:
+    ro = _make_server_with_module("device_tools", has_writes=False)
+    assert "update_device" not in automox_mcp.tools._get_tool_names(ro)
+    rw = _make_server_with_module("device_tools", has_writes=True)
+    assert "update_device" in automox_mcp.tools._get_tool_names(rw)
 
 
 def test_account_tools_register_includes_api_keys() -> None:

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -450,6 +450,81 @@ class TestDeviceToolsDispatch:
         assert recorded.get("device_id") == 88
 
     @pytest.mark.asyncio
+    async def test_update_device_calls_workflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorded: dict[str, Any] = {}
+
+        async def fake_update(client, **kwargs):
+            recorded.update(kwargs)
+            return _success()
+
+        monkeypatch.setattr(device_tools.workflows, "update_device", fake_update)
+
+        server = StubServer()
+        device_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+
+        await server.tools["update_device"](device_id=99, custom_name="web-01", server_group_id=7)
+
+        assert recorded.get("device_id") == 99
+        assert recorded.get("custom_name") == "web-01"
+        assert recorded.get("server_group_id") == 7
+        # Omitted optional fields are stripped before reaching the workflow.
+        assert "tags" not in recorded
+
+    @pytest.mark.asyncio
+    async def test_update_device_absent_in_read_only(self) -> None:
+        server = StubServer()
+        device_tools.register(server, read_only=True, client=FakeClient(org_id=42))
+        assert "update_device" not in server.tools
+
+    @pytest.mark.asyncio
+    async def test_update_device_cache_hit_short_circuits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called: list[bool] = []
+
+        async def fake_check(request_id: str | None, name: str):
+            return {"data": {"cached": True}, "metadata": {"deprecated_endpoint": False}}
+
+        async def fake_wf(client, **_):
+            called.append(True)
+            return _success()
+
+        monkeypatch.setattr(device_tools, "check_idempotency", fake_check)
+        monkeypatch.setattr(device_tools.workflows, "update_device", fake_wf)
+
+        server = StubServer()
+        device_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+        result = await server.tools["update_device"](
+            device_id=99, custom_name="x", request_id="req-1"
+        )
+        assert result["data"] == {"cached": True}
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_update_device_exception_releases_idempotency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        released: list[str] = []
+
+        async def fake_release(request_id: str | None, name: str):
+            released.append(name)
+
+        async def fake_wf(client, **_):
+            raise RuntimeError("upstream blew up")
+
+        monkeypatch.setattr(device_tools, "release_idempotency", fake_release)
+        monkeypatch.setattr(device_tools.workflows, "update_device", fake_wf)
+
+        server = StubServer()
+        device_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+
+        from fastmcp.exceptions import ToolError
+
+        with pytest.raises((RuntimeError, ToolError)):
+            await server.tools["update_device"](device_id=99, custom_name="x", request_id="req-2")
+        assert released == ["update_device"]
+
+    @pytest.mark.asyncio
     async def test_execute_device_command_absent_in_read_only(self) -> None:
         server = StubServer()
         device_tools.register(server, read_only=True, client=FakeClient(org_id=42))
@@ -2157,6 +2232,105 @@ class TestVulnSyncRemediationDispatch:
         )
         assert recorded["action_set_id"] == 7
         assert recorded["org_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_delete_action_set_calls_workflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorded: dict[str, Any] = {}
+
+        async def fake(client, **kwargs):
+            recorded.update(kwargs)
+            return _success()
+
+        monkeypatch.setattr(vuln_sync_tools, "_delete_action_set", fake)
+
+        server = StubServer()
+        vuln_sync_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+        await server.tools["delete_action_set"](action_set_id=7)
+        assert recorded["action_set_id"] == 7
+        assert recorded["org_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_delete_action_sets_bulk_calls_workflow(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded: dict[str, Any] = {}
+
+        async def fake(client, **kwargs):
+            recorded.update(kwargs)
+            return _success()
+
+        monkeypatch.setattr(vuln_sync_tools, "_delete_action_sets_bulk", fake)
+
+        server = StubServer()
+        vuln_sync_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+        await server.tools["delete_action_sets_bulk"](action_set_ids=[1, 2, 3])
+        assert recorded["action_set_ids"] == [1, 2, 3]
+        assert recorded["org_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_delete_action_tools_absent_in_read_only(self) -> None:
+        server = StubServer()
+        vuln_sync_tools.register(server, read_only=True, client=FakeClient(org_id=42))
+        assert "delete_action_set" not in server.tools
+        assert "delete_action_sets_bulk" not in server.tools
+
+
+class TestVulnSyncDeleteIdempotencyAndExceptionPaths:
+    """Cache-hit + exception-release branches for the action-set delete tools."""
+
+    _WRITE_CASES = [
+        ("delete_action_set", "_delete_action_set", {"action_set_id": 7}),
+        ("delete_action_sets_bulk", "_delete_action_sets_bulk", {"action_set_ids": [1, 2]}),
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name,wf_attr,kwargs", _WRITE_CASES)
+    async def test_cache_hit_short_circuits_workflow(
+        self, tool_name: str, wf_attr: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called: list[bool] = []
+
+        async def fake_check(request_id: str | None, name: str):
+            return {"data": {"cached": True}, "metadata": {"deprecated_endpoint": False}}
+
+        async def fake_wf(client, **_):
+            called.append(True)
+            return _success()
+
+        monkeypatch.setattr(vuln_sync_tools, "check_idempotency", fake_check)
+        monkeypatch.setattr(vuln_sync_tools, wf_attr, fake_wf)
+
+        server = StubServer()
+        vuln_sync_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+
+        result = await server.tools[tool_name](request_id="req-1", **kwargs)
+        assert result == {"data": {"cached": True}, "metadata": {"deprecated_endpoint": False}}
+        assert called == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name,wf_attr,kwargs", _WRITE_CASES)
+    async def test_workflow_exception_releases_idempotency(
+        self, tool_name: str, wf_attr: str, kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        released: list[str] = []
+
+        async def fake_release(request_id: str | None, name: str):
+            released.append(name)
+
+        async def fake_wf(client, **_):
+            raise RuntimeError("upstream blew up")
+
+        monkeypatch.setattr(vuln_sync_tools, "release_idempotency", fake_release)
+        monkeypatch.setattr(vuln_sync_tools, wf_attr, fake_wf)
+
+        server = StubServer()
+        vuln_sync_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+
+        from fastmcp.exceptions import ToolError
+
+        with pytest.raises((RuntimeError, ToolError)):
+            await server.tools[tool_name](request_id="req-2", **kwargs)
+        assert released == [tool_name]
 
 
 class TestCategoryCAssessmentDispatch:

--- a/tests/test_workflows_devices_extended.py
+++ b/tests/test_workflows_devices_extended.py
@@ -26,6 +26,7 @@ from automox_mcp.workflows.devices import (
     list_devices_needing_attention,
     search_devices,
     summarize_device_health,
+    update_device,
 )
 
 # ---------------------------------------------------------------------------
@@ -1584,3 +1585,46 @@ async def test_batch_update_devices_posts_devices_and_actions() -> None:
     assert method == "POST"
     assert path == "/servers/batch"
     assert body == {"devices": [1, 2, 3], "actions": actions}
+
+
+# ---------------------------------------------------------------------------
+# update_device (#111 single-device PUT /servers/{id})
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_device_sends_only_supplied_fields() -> None:
+    client = StubClient(put_responses={"/servers/99": [{"id": 99}]})
+    client.org_id = 555
+    result = await update_device(
+        cast(AutomoxClient, client),
+        org_id=555,
+        device_id=99,
+        custom_name="web-01",
+        server_group_id=7,
+    )
+    method, path, body = client.calls[0]
+    assert method == "PUT"
+    assert path == "/servers/99"
+    # Omitted fields (exception/tags/ip_addrs) must not be sent.
+    assert body == {"custom_name": "web-01", "server_group_id": 7}
+    assert result["data"]["device_id"] == 99
+    assert result["data"]["updated"] is True
+    assert result["data"]["updated_fields"] == ["custom_name", "server_group_id"]
+    assert result["metadata"]["org_id"] == 555
+
+
+@pytest.mark.asyncio
+async def test_update_device_sends_falsey_exception_flag() -> None:
+    client = StubClient(put_responses={"/servers/12": [{}]})
+    client.org_id = 42
+    await update_device(
+        cast(AutomoxClient, client),
+        org_id=42,
+        device_id=12,
+        exception=False,
+        tags=["a", "b"],
+    )
+    _method, _path, body = client.calls[0]
+    # exception=False is a meaningful value and must be sent, not dropped.
+    assert body == {"exception": False, "tags": ["a", "b"]}

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -292,9 +292,7 @@ def test_apply_remediation_tool_gated_by_env(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_delete_action_set_calls_endpoint() -> None:
     client = StubClient()
-    result = await delete_action_set(
-        cast(AutomoxClient, client), org_id=42, action_set_id=7
-    )
+    result = await delete_action_set(cast(AutomoxClient, client), org_id=42, action_set_id=7)
     assert ("DELETE", "/orgs/42/remediations/action-sets/7", None) in client.calls
     assert result["data"] == {"action_set_id": 7, "deleted": True}
     assert result["metadata"]["org_id"] == 42

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -5,9 +5,11 @@ from typing import cast
 import pytest
 from conftest import StubClient
 
-from automox_mcp.client import AutomoxClient
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
 from automox_mcp.workflows.vuln_sync import (
     apply_remediation_actions,
+    delete_action_set,
+    delete_action_sets_bulk,
     get_action_set_detail,
     get_action_set_issues,
     get_action_set_solutions,
@@ -285,3 +287,50 @@ def test_apply_remediation_tool_gated_by_env(monkeypatch) -> None:
     ro = StubServer()
     vuln_sync_tools.register(ro, read_only=True, client=FakeClient())
     assert "apply_remediation_actions" not in ro.tools
+
+
+@pytest.mark.asyncio
+async def test_delete_action_set_calls_endpoint() -> None:
+    client = StubClient()
+    result = await delete_action_set(
+        cast(AutomoxClient, client), org_id=42, action_set_id=7
+    )
+    assert ("DELETE", "/orgs/42/remediations/action-sets/7", None) in client.calls
+    assert result["data"] == {"action_set_id": 7, "deleted": True}
+    assert result["metadata"]["org_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_delete_action_sets_bulk_iterates_single_endpoint() -> None:
+    client = StubClient()
+    result = await delete_action_sets_bulk(
+        cast(AutomoxClient, client), org_id=42, action_set_ids=[1, 2, 3]
+    )
+    deleted_paths = [c[1] for c in client.calls if c[0] == "DELETE"]
+    assert deleted_paths == [
+        "/orgs/42/remediations/action-sets/1",
+        "/orgs/42/remediations/action-sets/2",
+        "/orgs/42/remediations/action-sets/3",
+    ]
+    assert result["data"]["deleted_count"] == 3
+    assert result["data"]["deleted"] == [1, 2, 3]
+    assert result["data"]["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_delete_action_sets_bulk_reports_partial_failure() -> None:
+    class _RaisingClient(StubClient):
+        async def delete(self, path: str, *, params=None, headers=None):
+            self.calls.append(("DELETE", path, params))
+            if path.endswith("/2"):
+                raise AutomoxAPIError("boom", status_code=500)
+            return None
+
+    client = _RaisingClient()
+    result = await delete_action_sets_bulk(
+        cast(AutomoxClient, client), org_id=42, action_set_ids=[1, 2, 3]
+    )
+    assert result["data"]["deleted"] == [1, 3]
+    assert result["data"]["deleted_count"] == 2
+    assert result["data"]["requested"] == 3
+    assert [f["action_set_id"] for f in result["data"]["failed"]] == [2]


### PR DESCRIPTION
Closes the documented-surface **build backlog** from #111. Folded into the **untagged 1.3.0** (per the in-flight release plan), so no separate version bump.

## Tools added (3)

| Tool | Endpoint | Tier |
|---|---|---|
| `update_device` | `PUT /servers/{id}` | **Not destructive** — plain write (`destructiveHint: false`), off under `read_only`. |
| `delete_action_set` | `DELETE /…/action-sets/{id}` | Tier-1 ask-first (`destructiveHint: true`, no env gate). |
| `delete_action_sets_bulk` | (iterates single-delete) | Tier-1 ask-first. |

- **`update_device`** fills the single-device-update gap that `batch_update_devices` (tags-only, bulk) doesn't cover — rename, server-group move, `exception` flag, `ip_addrs`. Sends **only the fields supplied**; at least one required. Idempotency-keyed.
- **`delete_action_set` / `delete_action_sets_bulk`** — action sets are console metadata, reconstructable via re-upload, so confirmation-only (Tier 1) is correct.

## Load-bearing decision — bulk delete

`delete_action_sets_bulk` **iterates the confirmed single-delete endpoint** rather than wrapping the native `DELETE /…/action-sets`, whose request-body shape is **undocumented in the OpenAPI bundle and was unverifiable at build time** (the developer portal is a JS-rendered SPA; the bundle isn't on disk). This avoids shipping a guessed body for a destructive endpoint — same caution #106 applied to the CSV upload. Deletion is therefore **non-atomic**: per-ID results, a mid-list failure leaves earlier deletes applied (safe — re-uploadable). Swapping to the native bulk endpoint is a **tracked perf optimization** (recorded in `docs/api-coverage.md`), not a coverage gap.

## Counts reconciled

Tool count **127 → 130** (84 read / **46** write); `read_only` still **84**. Updated across `README.md`, `mcpb/manifest.json`, `docs/tool-reference.md`, `docs/api-coverage.md` (build-backlog rows moved to covered), and the `CHANGELOG.md` 1.3.0 entry.

Registration gate matrix re-verified: default-visible **128**, +either env flag **129**, both on **130**, `read_only` **84**.

## Verification

- `mypy` clean, `ruff` clean, **1340 tests pass** (+17: workflow, dispatch, registration, idempotency/exception-release paths), coverage **91%**, `mcpb validate` passes.
- Not tagged/published — release is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)