### PR TITLE
delete_action_sets_bulk: use native atomic endpoint (1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Establishes and documents the server's capability model: a categorical policy fo
 - **`docs/api-coverage.md` — coverage map and capability policy.** Documents, against the `2026-05-28` Console API bundle (115 documented operations), every intentional omission and the destructive-operation gating principle. README gains a **Capability model** section summarizing it.
 - **`AUTOMOX_MCP_ALLOW_REMOTE_CONTROL` env gate.** New default-off flag controlling the fleet-scale `splashtop_bulk_install_uninstall` tool, parallel to `AUTOMOX_MCP_ALLOW_REMEDIATION`.
 - **`update_device` tool (#111).** Updates a single device's `custom_name`, `server_group_id`, `exception`, `tags`, or `ip_addrs` via `PUT /servers/{id}`. Fills the single-device-update gap that `batch_update_devices` (tags-only) leaves; not destructive, plain write (off under `read_only`).
-- **`delete_action_set` / `delete_action_sets_bulk` tools (#111).** Delete Vuln Sync action sets — Tier-1 ask-first (`destructiveHint`, reconstructable via re-upload). The bulk tool iterates the single-delete endpoint (the native bulk-delete body shape is undocumented; per-ID results, non-atomic) — see `docs/api-coverage.md`.
+- **`delete_action_set` / `delete_action_sets_bulk` tools (#111).** Delete Vuln Sync action sets — Tier-1 ask-first (`destructiveHint`, reconstructable via re-upload). The bulk tool issues one atomic `DELETE /…/action-sets` with a `{"ids": [...]}` body; `AutomoxClient.delete` gained JSON-body support to enable it.
 - Tool count is now **130** (84 read / 46 write); read-only mode still exposes 84.
 
 ### Changed

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -80,7 +80,7 @@ The documented-surface build items from [#111](https://github.com/AutomoxCommuni
 | `DELETE /orgs/{org}/remediations/action-sets/{id}` (`deleteActionSet`) | `delete_action_set` | Tier 1 ask-first (reconstructable via re-upload) |
 | `DELETE /orgs/{org}/remediations/action-sets` (`deleteActionSetsBulk`) | `delete_action_sets_bulk` | Tier 1 ask-first (console metadata, not endpoint state) |
 
-**Implementation note — `delete_action_sets_bulk`:** implemented by iterating the single-delete endpoint (`DELETE /…/action-sets/{id}`) rather than the native bulk endpoint (`DELETE /…/action-sets`), whose request-body shape is undocumented in the OpenAPI bundle and was unverifiable at build time. Deletion is non-atomic (per-ID results; a mid-list failure leaves earlier deletes applied — safe, since action sets are re-uploadable). **Actionable follow-on:** confirm the native bulk-delete contract (rendered docs or a console cURL capture) and swap to a single round-trip — tracked as a perf optimization, not a coverage gap.
+**Implementation note — `delete_action_sets_bulk`:** wraps the native bulk endpoint `DELETE /…/action-sets` with a JSON body `{"ids": [...]}` (schema `delete-action-set`, `console-api.yaml` `2026-05-08`; responds `204`) — a single atomic call.
 
 Remaining uncovered documented surface (binary/multipart uploads) is tracked in [#106](https://github.com/AutomoxCommunity/automox-mcp/issues/106).
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -142,7 +142,7 @@ Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-b
 - **`get_upload_formats`** - Get supported CSV upload formats for vulnerability remediation action sets.
 - **`upload_action_set`** *(write)* - Upload a CSV-based vulnerability remediation action set.
 - **`delete_action_set`** *(write)* - Delete a single remediation action set by ID. Console metadata, reconstructable via re-upload.
-- **`delete_action_sets_bulk`** *(write)* - Delete multiple action sets by ID (up to 100). Deletes each individually with per-ID results; a partial failure leaves earlier deletes applied.
+- **`delete_action_sets_bulk`** *(write)* - Delete multiple action sets by ID (up to 100) in one atomic call. Console metadata, reconstructable via re-upload.
 - **`apply_remediation_actions`** *(write, gated)* - Execute remediations now (`patch-now` / `patch-with-worklet`) on explicit devices for an action set. Immediately changes endpoint state (async, returns 202). **Registered only when `AUTOMOX_MCP_ALLOW_REMEDIATION=true`** and write mode is enabled.
 
 ## Compound Workflows (3 tools)

--- a/src/automox_mcp/client.py
+++ b/src/automox_mcp/client.py
@@ -195,6 +195,7 @@ class AutomoxClient:
         self,
         path: str,
         *,
+        json_data: Mapping[str, Any] | None = None,
         params: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> AutomoxResponse:
@@ -202,6 +203,7 @@ class AutomoxClient:
             "DELETE",
             path,
             params=params,
+            json_data=json_data,
             headers=headers,
         )
 

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -247,9 +247,8 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             name="delete_action_sets_bulk",
             description=(
                 "Delete multiple vulnerability remediation action sets by ID (up to "
-                "100). Deletes each ID individually and reports per-ID results, so a "
-                "partial failure leaves earlier deletions applied. Action sets are "
-                "reconstructable by re-uploading the source CSV."
+                "100) in one atomic call. Action sets are reconstructable by "
+                "re-uploading the source CSV."
             ),
             annotations={
                 "readOnlyHint": False,

--- a/src/automox_mcp/workflows/vuln_sync.py
+++ b/src/automox_mcp/workflows/vuln_sync.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from ..client import AutomoxAPIError, AutomoxClient
+from ..client import AutomoxClient
 from ..utils.response import extract_list as _extract_list
 
 
@@ -285,34 +285,25 @@ async def delete_action_sets_bulk(
     org_id: int,
     action_set_ids: list[int],
 ) -> dict[str, Any]:
-    """Delete multiple Vuln Sync action sets.
+    """Delete multiple Vuln Sync action sets in one atomic call.
 
-    Implemented by iterating the confirmed single-delete endpoint
-    (``DELETE /orgs/{org}/remediations/action-sets/{actionSetID}``) rather than the
-    native bulk endpoint (``DELETE /orgs/{org}/remediations/action-sets``), whose
-    request-body shape is not documented in the OpenAPI bundle and could not be
-    verified at build time. Deletion is therefore non-atomic: each ID is reported
-    individually and a mid-list failure leaves earlier deletions applied (safe —
-    action sets are reconstructable via re-upload). Swapping to the native bulk
-    endpoint is a tracked perf optimization once its contract is confirmed.
+    Wraps the native bulk endpoint ``DELETE /orgs/{org}/remediations/action-sets``
+    with a JSON body of ``{"ids": [...]}`` (schema ``delete-action-set``,
+    ``console-api.yaml`` ``2026-05-08``); the upstream responds ``204``. Action
+    sets are console metadata, reconstructable via re-upload, so this is exposed
+    Tier-1 ask-first (confirmation-only, no env gate).
     """
-    deleted: list[int] = []
-    failed: list[dict[str, Any]] = []
-    for action_set_id in action_set_ids:
-        try:
-            await client.delete(
-                f"/orgs/{org_id}/remediations/action-sets/{action_set_id}",
-            )
-            deleted.append(action_set_id)
-        except AutomoxAPIError as exc:
-            failed.append({"action_set_id": action_set_id, "error": str(exc)})
+    ids = list(action_set_ids)
+    await client.delete(
+        f"/orgs/{org_id}/remediations/action-sets",
+        json_data={"ids": ids},
+    )
 
     return {
         "data": {
-            "requested": len(action_set_ids),
-            "deleted_count": len(deleted),
-            "deleted": deleted,
-            "failed": failed,
+            "requested": len(ids),
+            "deleted_count": len(ids),
+            "deleted": ids,
         },
         "metadata": {"deprecated_endpoint": False, "org_id": org_id},
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,10 @@ class StubClient:
         self.calls.append(("PATCH", path, json_data))
         return self._pop(self._patch, path)
 
-    async def delete(self, path: str, *, params: Any = None, headers: Any = None) -> Any:
-        self.calls.append(("DELETE", path, params))
+    async def delete(
+        self, path: str, *, json_data: Any = None, params: Any = None, headers: Any = None
+    ) -> Any:
+        # Record json_data when present (body-bearing DELETE), else params, so
+        # existing param-only delete assertions stay unchanged.
+        self.calls.append(("DELETE", path, json_data if json_data is not None else params))
         return self._pop(self._delete, path, default=None)

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -5,7 +5,7 @@ from typing import cast
 import pytest
 from conftest import StubClient
 
-from automox_mcp.client import AutomoxAPIError, AutomoxClient
+from automox_mcp.client import AutomoxClient
 from automox_mcp.workflows.vuln_sync import (
     apply_remediation_actions,
     delete_action_set,
@@ -299,36 +299,17 @@ async def test_delete_action_set_calls_endpoint() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_action_sets_bulk_iterates_single_endpoint() -> None:
+async def test_delete_action_sets_bulk_single_atomic_call() -> None:
     client = StubClient()
     result = await delete_action_sets_bulk(
         cast(AutomoxClient, client), org_id=42, action_set_ids=[1, 2, 3]
     )
-    deleted_paths = [c[1] for c in client.calls if c[0] == "DELETE"]
-    assert deleted_paths == [
-        "/orgs/42/remediations/action-sets/1",
-        "/orgs/42/remediations/action-sets/2",
-        "/orgs/42/remediations/action-sets/3",
-    ]
+    deletes = [c for c in client.calls if c[0] == "DELETE"]
+    # Exactly one round-trip to the native bulk endpoint with an `ids` body.
+    assert len(deletes) == 1
+    method, path, body = deletes[0]
+    assert path == "/orgs/42/remediations/action-sets"
+    assert body == {"ids": [1, 2, 3]}
     assert result["data"]["deleted_count"] == 3
     assert result["data"]["deleted"] == [1, 2, 3]
-    assert result["data"]["failed"] == []
-
-
-@pytest.mark.asyncio
-async def test_delete_action_sets_bulk_reports_partial_failure() -> None:
-    class _RaisingClient(StubClient):
-        async def delete(self, path: str, *, params=None, headers=None):
-            self.calls.append(("DELETE", path, params))
-            if path.endswith("/2"):
-                raise AutomoxAPIError("boom", status_code=500)
-            return None
-
-    client = _RaisingClient()
-    result = await delete_action_sets_bulk(
-        cast(AutomoxClient, client), org_id=42, action_set_ids=[1, 2, 3]
-    )
-    assert result["data"]["deleted"] == [1, 3]
-    assert result["data"]["deleted_count"] == 2
     assert result["data"]["requested"] == 3
-    assert [f["action_set_id"] for f in result["data"]["failed"]] == [2]


### PR DESCRIPTION
Follow-up to #114, folded into the **untagged 1.3.0**. Replaces the iteration workaround for `delete_action_sets_bulk` with the native bulk endpoint.

## Correction

#114 documented the bulk-delete body shape as **"undocumented in the OpenAPI bundle and unverifiable at build time"** and shipped a client-side iteration over the single-delete endpoint. That rationale was **inaccurate**: the contract *is* documented — I just couldn't access the spec during that build. Confirmed against `console-api.yaml` `2026-05-08`:

- **`DELETE /orgs/{orgID}/remediations/action-sets`** — required JSON body `{"ids": [<int>, …]}` (schema `delete-action-set`, `ids` = required integer array), responds `204`.

## Change

Since 1.3.0 isn't tagged, swapping to the native call now ships the correct implementation in the release rather than the workaround:

- **`AutomoxClient.delete`** gains `json_data` support (forwarded to `_request`, mirroring `post`/`put`).
- **`delete_action_sets_bulk`** issues **one atomic `DELETE`** with `{"ids": [...]}` instead of N single deletes. Drops the non-atomic per-ID/partial-failure result shape.
- **Docs** (`api-coverage.md`, `tool-reference.md`, `CHANGELOG`, tool description) corrected to describe the atomic native call; removed the "undocumented" rationale.
- **Tests**: `conftest` `StubClient.delete` accepts `json_data` (records body when present, params otherwise — existing param-only delete assertions unchanged); bulk workflow test asserts a single DELETE with the `ids` body; removed the partial-failure test.

## Verification

Tool count unchanged (**130**). `mypy` clean, `ruff check` + `ruff format --check` clean, **1339 tests pass**, coverage 90%, `client.delete` JSON-body path covered. Not tagged/published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)