### PR TITLE
Guard discover_capabilities catalog + add project CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# automox-mcp — project instructions
+
+Repo-specific invariants for this MCP server. These are **self-enforcing reminders**: follow them without waiting to be asked. (General working preferences live in the user-global `~/.claude/CLAUDE.md`.)
+
+## Adding / removing / renaming a tool
+
+A tool's name and count appear in several hand-maintained places. When you change the tool set, update **all** of these in the same change — CI guards some, but not all:
+
+| Location | What to update | CI-guarded? |
+|---|---|---|
+| `src/automox_mcp/tools/<domain>_tools.py` | the `@server.tool` registration | — |
+| `src/automox_mcp/tools/meta_tools.py` `_DOMAIN_CATALOG` | the `(name, description)` entry (the model-facing discovery directory) | ✅ `test_doc_tool_counts.py` |
+| `docs/tool-reference.md` | the bullet **and** its `## Domain (N tools)` section count **and** the top "all N tools" header | ✅ `test_doc_tool_counts.py` |
+| `README.md` + `mcpb/manifest.json` | total / read / write counts | ✅ `test_doc_tool_counts.py` |
+| `docs/api-coverage.md` | coverage map / omission rationale / build-backlog rows | ❌ **manual — easy to forget** |
+| `tests/smoke_production.py` | live read-side coverage for new read tools (not destructive writes) | ❌ **manual, not in CI** |
+| `CHANGELOG.md` | the entry under the active version | ❌ manual |
+
+The current split is **130 tools / 84 read / 46 write**. `discover_capabilities` is intentionally excluded from `_DOMAIN_CATALOG`.
+
+## Local gate before every push
+
+CI's `lint` job runs `ruff format --check` **in addition to** `ruff check` — these are different tools. Run the full gate locally first (a bare `pytest` does **not** enforce coverage, and pre-commit does **not** run pytest):
+
+```
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy .
+uv run pytest --cov=automox_mcp --cov-fail-under=90
+```
+
+Coverage sits near the 90% floor — new branches (e.g. idempotency cache-hit / exception-release handlers on write tools) need their own tests or the floor breaks.
+
+## Release safety
+
+- **Never push a tag without an explicit go-ahead.** A `vX.Y.Z` tag push triggers irreversible PyPI / registry / MCPB publishing. Releasing = merge PR → tag-push (never the GitHub "Publish release" UI).
+- Versions must match across `pyproject.toml`, `server.json` (incl. `packages[].version`), `mcpb/manifest.json` — the `manifests` CI job enforces this.
+- Capability/destructive-gating policy lives in `docs/api-coverage.md`; read it before adding any write/delete tool to pick the right safety tier.

--- a/tests/test_doc_tool_counts.py
+++ b/tests/test_doc_tool_counts.py
@@ -166,6 +166,34 @@ def test_tool_reference_documents_exactly_registered_tools(
 
 
 # ---------------------------------------------------------------------------
+# discover_capabilities catalog (meta_tools._DOMAIN_CATALOG)
+# ---------------------------------------------------------------------------
+
+# `discover_capabilities` is intentionally absent from every domain — you can't
+# discover the discovery tool through itself. Every *other* registered tool must
+# appear, or the model-facing capability directory silently drifts from reality.
+_CATALOG_EXCLUDED = {"discover_capabilities"}
+
+
+def test_discover_catalog_matches_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    from automox_mcp.tools.meta_tools import _DOMAIN_CATALOG
+
+    registered = _full_tool_names(monkeypatch)
+    catalog = {name for tools in _DOMAIN_CATALOG.values() for name, _ in tools}
+
+    # No phantom entries: every catalogued name must be a real registered tool.
+    assert catalog - registered == set(), (
+        f"discover_capabilities catalog lists unregistered tools: {sorted(catalog - registered)}"
+    )
+    # Completeness: every registered tool except the discovery meta-tool must be
+    # discoverable through the catalog.
+    missing = (registered - catalog) - _CATALOG_EXCLUDED
+    assert registered - catalog == _CATALOG_EXCLUDED, (
+        f"registered tools missing from the discover_capabilities catalog: {sorted(missing)}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # README.md
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to the safeguards audit. Tests + docs only, **no version bump**.

## 1. Catalog drift guard (`tests/test_doc_tool_counts.py`)

`discover_capabilities` (`meta_tools._DOMAIN_CATALOG`) is the directory the **model** reads to find tools, and it was unguarded — `test_meta_tools.py` only checked domain keys + tuple shape, so a new tool added to code + `tool-reference.md` (which *is* guarded) but forgotten in the catalog would pass CI.

New `test_discover_catalog_matches_registered` makes the registered server the source of truth:
- no phantom entries (catalog ⊆ registered), and
- completeness: `registered - catalog == {discover_capabilities}` — the discovery meta-tool is the one intentional exclusion (you can't discover the discovery tool through itself).

Verified it bites (dropping a tool from the catalog fails the test).

## 2. Project `CLAUDE.md` (self-enforcing reminders)

Sole-contributor safeguard so the conventions apply **without needing to be re-stated each session** — auto-loaded repo context, not GitHub-only enforcement. Covers:
- **Adding/removing a tool** — the full update checklist across registration, `_DOMAIN_CATALOG`, `tool-reference.md`, README/manifest counts, `api-coverage.md`, `smoke_production.py`, CHANGELOG — explicitly flagging which are **CI-guarded vs manual** (`api-coverage.md` and the smoke script are *not* guarded).
- **Local gate before push** — `ruff format --check` (separate from `ruff check`), `ruff check`, `mypy`, `pytest --cov-fail-under=90`.
- **Release/tag safety** — never tag without an explicit go; version-sync surfaces.

## Verification

`ruff check` + `ruff format --check` clean, `mypy` clean, **1345 tests pass**. Tool count unchanged (130).

🤖 Generated with [Claude Code](https://claude.com/claude-code)