### PR TITLE
Triage bandit findings + promote to gate (pre-push + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check --diff .
 
+      - name: Bandit security scan
+        run: uv run bandit -r src/ -c pyproject.toml
+
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,17 +24,15 @@ repos:
       - id: ruff-format
         stages: [pre-commit]
 
-  # bandit: kept available but NON-BLOCKING (manual stage) — it is not in the
-  # uv dev env or CI, and currently reports latent findings (B104 bind-all,
-  # B613) that need triage before it can gate commits/pushes. Run on demand:
-  #   uv run pre-commit run bandit --hook-stage manual --all-files
+  # bandit: gates at pre-push (findings triaged — B104 bind-all comparisons and
+  # the B613 sanitizer scan-target chars are nosec-justified inline in src/).
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.3
     hooks:
       - id: bandit
         args: ["-r", "src/", "-c", "pyproject.toml"]
         pass_filenames: false
-        stages: [manual]
+        stages: [pre-push]
 
   # ---------------------------------------------------------------------------
   # Pre-push gate — the deterministic backstop. Mirrors the CI lint/typecheck/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ uv run mypy .
 uv run pytest --cov=automox_mcp --cov-fail-under=90
 ```
 
-Coverage sits near the 90% floor — new branches (e.g. idempotency cache-hit / exception-release handlers on write tools) need their own tests or the floor breaks. `bandit` is configured but **manual/non-blocking** (has untriaged B104/B613 findings); run it with `uv run pre-commit run bandit --hook-stage manual --all-files`.
+Coverage sits near the 90% floor — new branches (e.g. idempotency cache-hit / exception-release handlers on write tools) need their own tests or the floor breaks. `bandit` (`-r src/ -c pyproject.toml`) runs at **pre-push and in the CI `lint` job**; existing findings are `# nosec`-justified inline (B104 bind-host string compares in `transport_security.py`; B613 sanitizer scan-target chars in `utils/sanitize.py`). A new bandit finding blocks the push and CI — `# nosec BXXX` it with a one-line reason only when genuinely safe.
 
 ## Release safety
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dev = [
   "mypy>=1.9",
   "build>=1.2.2",
   "twine>=5.1",
-  "pre-commit>=4.0"
+  "pre-commit>=4.0",
+  "bandit>=1.8"
 ]
 
 [project.urls]

--- a/src/automox_mcp/transport_security.py
+++ b/src/automox_mcp/transport_security.py
@@ -409,7 +409,7 @@ def build_transport_security_middleware(
         for lb in _LOOPBACK_HOSTS:
             _add_host_variants(lb, port)
     # For wildcard bind addresses, also add loopback aliases
-    if host in {"0.0.0.0", "::"}:
+    if host in {"0.0.0.0", "::"}:  # nosec B104 — string compare of the bound host, not a bind
         for lb in _LOOPBACK_HOSTS:
             _add_host_variants(lb, port)
     # User-supplied extras
@@ -431,7 +431,7 @@ def build_transport_security_middleware(
     if host in _LOOPBACK_HOSTS:
         for lb in _LOOPBACK_HOSTS:
             _add_origin_variants(lb, port)
-    if host in {"0.0.0.0", "::"}:
+    if host in {"0.0.0.0", "::"}:  # nosec B104 — string compare of the bound host, not a bind
         for lb in _LOOPBACK_HOSTS:
             _add_origin_variants(lb, port)
     # User-supplied extras (e.g. "https://app.example.com")

--- a/src/automox_mcp/utils/sanitize.py
+++ b/src/automox_mcp/utils/sanitize.py
@@ -66,7 +66,12 @@ _EVENT_HANDLER_RE = re.compile(r"^on\w+$", re.IGNORECASE)
 # downstream regex, so we run the full pipeline. ASCII strings containing none
 # of these characters cannot match any of our markdown/HTML/code-block regexes
 # and skip straight to the instruction-prefix check.
-_SANITIZE_TRIGGER_CHARS: frozenset[str] = frozenset("[!`<​‌‍‎‏﻿­⁠⁡⁢⁣⁤᠎")
+# The set deliberately includes bidirectional/zero-width control characters:
+# they are *scan targets* (TrojanSource-style payloads we detect), not source
+# obfuscation — hence the nosec on the literal below.
+_SANITIZE_TRIGGER_CHARS: frozenset[str] = frozenset(
+    "[!`<​‌‍‎‏﻿­⁠⁡⁢⁣⁤᠎"  # nosec B613
+)
 
 # Cheap prefix probe — matches the start of *any line* that might contain an
 # instruction prefix. Multi-line aware so the fast-path doesn't miss a prefix

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "build" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -102,6 +103,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "fastmcp", specifier = ">=3.2.0" },
@@ -126,6 +128,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
@@ -1836,6 +1853,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the dormant-security-scanner gap. bandit was configured only in the never-installed pre-commit env, so its findings were never enforced. Triaged + gated. No `src` behavior change (nosec comments + one cosmetic literal split).

## Triage — all three are false positives / intentional
| Finding | Location | Verdict |
|---|---|---|
| `B104` bind-all (×2) | `transport_security.py:412,434` | `if host in {"0.0.0.0","::"}` is a **string comparison** of the bound host (to add loopback aliases to the allow-list), not a bind. `# nosec B104`. |
| `B613` TrojanSource | `utils/sanitize.py` | `_SANITIZE_TRIGGER_CHARS` intentionally holds bidi/zero-width chars — they're **scan targets** the sanitizer detects, not obfuscation. `# nosec B613`, rationale in the comment block; literal split across lines so the nosec fits line-length. |

bandit now reports **0 findings**.

## Promotion to a gate
- **pre-push** (`.pre-commit-config.yaml`): bandit `manual` → `pre-push`. Verified it fired on this branch's own push.
- **CI** (`ci.yml` `lint` job): added `uv run bandit -r src/ -c pyproject.toml` — the un-bypassable layer (pre-push can be `--no-verify`'d or absent on a fresh clone).
- `bandit` added to the dev extra (so `uv run bandit` resolves); `uv.lock` refreshed.
- `CLAUDE.md`: documents bandit gates at pre-push + CI and how to `# nosec` a genuinely-safe new finding.

## Verification
Full gate green: ruff check + format, mypy, **bandit**, pytest @ 90%. No version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)