### PR TITLE
CI/CD: post-publish verification + scheduled dependency audit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,3 +228,34 @@ jobs:
         run: |
           gh release upload "$GITHUB_REF_NAME" --clobber \
             "mcpb/automox-mcp-${BUNDLE_VERSION}.mcpb"
+
+  # Post-publish smoke: install the just-published version straight from PyPI and
+  # confirm the wheel resolves and the entry point boots. Catches a broken
+  # publish (bad wheel, missing dep, broken console-script) in minutes rather
+  # than via a user report. Runs after `publish`; no secrets, no approval gate.
+  verify-publish:
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: false
+
+      - name: Install published package from PyPI and boot it
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Verifying automox-mcp==${VERSION} installs from PyPI and boots..."
+          for i in $(seq 1 6); do
+            if uvx --from "automox-mcp==${VERSION}" automox-mcp --help > /dev/null 2>&1; then
+              echo "Published package installs and the entry point boots."
+              exit 0
+            fi
+            echo "  attempt ${i}/6: not installable yet (PyPI CDN propagation?), sleeping 20s..."
+            sleep 20
+          done
+          echo "::error::Published automox-mcp==${VERSION} failed to install/boot from PyPI."
+          exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -129,3 +129,34 @@ jobs:
           online-audits: false
           annotations: true
           advanced-security: false
+
+  # Dependency vulnerability audit on the weekly schedule (and on demand). The
+  # PR/push audit lives in the CI `build` job; this closes the quiet-period gap
+  # where a CVE is disclosed against a pinned dep with no intervening commit.
+  pip-audit:
+    name: Dependency vulnerability audit (scheduled)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+
+      - name: Export locked requirements
+        run: |
+          uv export --format requirements.txt --all-extras --no-editable --no-hashes --locked \
+            --output-file requirements-ci.txt
+
+      - name: Dependency vulnerability audit
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
+        with:
+          inputs: |
+            requirements-ci.txt


### PR DESCRIPTION
Closes the two real CI/CD gaps from the solo-maintainer review (the baseline is already strong — OIDC publish, Sigstore, SBOM, tag↔version guard, Dependabot, weekly security scans, CodeQL/TruffleHog/Zizmor/MCP-Scanner/bandit). CI-only YAML; no `src`/version change.

## Changes
- **`release.yml` — `verify-publish` job (`needs: publish`).** Installs the just-published version from PyPI (`uvx --from automox-mcp==<v> automox-mcp --help`, retry loop for CDN propagation) and confirms the wheel resolves + the console-script boots. Catches a broken publish (bad wheel, missing dep, broken entry point — cf. the `.mcpb` fragility in #110) in minutes rather than via a user. No secrets, no approval gate.
- **`security.yml` — `pip-audit` job on the weekly cron** (+ `workflow_dispatch`), `if`-gated off push/PR so it doesn't duplicate the CI `build`-job audit. Closes the window where a CVE is disclosed against a pinned dep with no intervening commit.

## Paired out-of-band change
The `release` environment now requires **`ax-jkikta`** as a reviewer — every publish pauses for manual approval (audit-logged). With `verify-publish`, the only irreversible action in the system is now both gated *and* verified.

## Considered, not changed
- **ci.yml concurrency** — already present (`cancel-in-progress` scoped to PRs, correctly not cancelling `main`).
- **Branch protection on `main`** — deliberately left to you (you've opted out; it's a workflow tradeoff, not done here).

## Notes
New jobs don't run on this PR: `verify-publish` is tag-only; `pip-audit` is schedule/dispatch-only. Zizmor audits the workflow changes here. Both files parse and job graphs verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)