### PR TITLE
release.yml: atomic asset attach (immutable-safe) — implements #110

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,53 @@ jobs:
       - name: Generate SBOM
         run: uv run --with cyclonedx-bom cyclonedx-py environment -o sbom.cdx.json --of json
 
+      # ---------------------------------------------------------------
+      # MCPB Desktop Extension — built up front (before the PyPI publish
+      # and the GitHub Release) so every asset, including the .mcpb,
+      # attaches in ONE atomic `gh release create`. Immutable releases
+      # snapshot the asset set at publication, so nothing can be added
+      # afterward (#110). Building first also means a pack failure aborts
+      # before the irreversible PyPI push.
+      #
+      # The bundle is a uvx-shim — real code is pulled from PyPI at install
+      # time; the version is overridden from the tag so the bundle pins the
+      # matching automox-mcp release.
+      #
+      # Node + npm are pre-installed on ubuntu-latest; we skip
+      # actions/setup-node (only need `npm install -g`, and its implicit
+      # cache trips zizmor's cache-poisoning audit).
+      #
+      # TODO(supply chain): pin @anthropic-ai/mcpb once we settle a version.
+      # ---------------------------------------------------------------
+      - name: Install MCPB CLI
+        run: |
+          node --version
+          npm install -g @anthropic-ai/mcpb
+
+      - name: Compute MCPB bundle version
+        run: echo "BUNDLE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Set MCPB bundle version in manifest and pyproject
+        run: |
+          jq --arg v "$BUNDLE_VERSION" '.version = $v' mcpb/manifest.json > mcpb/manifest.tmp
+          mv mcpb/manifest.tmp mcpb/manifest.json
+          # Quoted heredoc — version is read from the env, never interpolated
+          # by the shell. Prevents any shell metacharacters in the tag name
+          # from being expanded inside the Python script.
+          python3 <<'PY'
+          import os, re, pathlib
+          v = os.environ["BUNDLE_VERSION"]
+          path = pathlib.Path("mcpb/pyproject.toml")
+          text = path.read_text()
+          text = re.sub(r'^version\s*=\s*"[^"]+"', f'version = "{v}"', text, count=1, flags=re.M)
+          text = re.sub(r'"automox-mcp>=[^"]+"', f'"automox-mcp>={v}"', text, count=1)
+          path.write_text(text)
+          PY
+          echo "MCPB bundle version set to $BUNDLE_VERSION"
+
+      - name: Build MCPB bundle
+        run: mcpb pack mcpb "mcpb/automox-mcp-${BUNDLE_VERSION}.mcpb"
+
       - name: Publish to PyPI
         if: steps.pypi_check.outputs.exists != 'true'
         # `skip-existing` is a defense against race conditions when two
@@ -81,17 +128,25 @@ jobs:
       - name: Sign artifacts with Sigstore
         run: uvx sigstore sign dist/*.whl dist/*.tar.gz
 
-      - name: Create or update GitHub Release
+      - name: Create GitHub Release (atomic — all assets)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Single atomic create with the COMPLETE asset set, so the release
+          # is immutable-safe: immutable releases snapshot assets at publish
+          # and reject any later add/clobber (#110).
           if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" --clobber \
-              dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json
+            # The release already exists (a re-run). Under immutability its
+            # assets can't be patched, so this is a deliberate no-op rather
+            # than a (now-impossible) --clobber. Recovery from a *partial*
+            # release is delete-then-recreate, done deliberately by the
+            # operator: `gh release delete <tag> --yes` then re-run.
+            echo "::notice::Release $GITHUB_REF_NAME already exists — leaving as-is."
           else
             gh release create "$GITHUB_REF_NAME" \
               --generate-notes \
-              dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json
+              dist/*.whl dist/*.tar.gz dist/*.sigstore.json sbom.cdx.json \
+              "mcpb/automox-mcp-${BUNDLE_VERSION}.mcpb"
           fi
 
       # ---------------------------------------------------------------
@@ -174,60 +229,9 @@ jobs:
           echo "::error::MCP Registry publish failed after 6 attempts (~2.5 min total). Re-run via 'gh workflow run release.yml --ref ${GITHUB_REF_NAME}'."
           exit 1
 
-      # ---------------------------------------------------------------
-      # MCPB Desktop Extension build & upload
-      #
-      # Builds the .mcpb archive from the `mcpb/` directory and attaches
-      # it to the GitHub Release. End users install via Claude Desktop's
-      # Settings → Extensions UI by dragging the .mcpb file in.
-      #
-      # The bundle is a uvx-shim — the real Python code is pulled from
-      # PyPI at install time. Version is overridden from the tag so a
-      # freshly built bundle always pins the matching automox-mcp PyPI
-      # release.
-      #
-      # TODO(supply chain): pin @anthropic-ai/mcpb to a specific release
-      # once we settle on a version. Currently uses npm latest.
-      # ---------------------------------------------------------------
-      # Use the Node + npm pre-installed on ubuntu-latest. We deliberately
-      # skip actions/setup-node because (a) we only need `npm install -g`
-      # without version pinning, and (b) setup-node's implicit cache
-      # behavior trips zizmor's cache-poisoning audit.
-      - name: Install MCPB CLI
-        run: |
-          node --version
-          npm install -g @anthropic-ai/mcpb
-
-      - name: Compute MCPB bundle version
-        run: echo "BUNDLE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-
-      - name: Set MCPB bundle version in manifest and pyproject
-        run: |
-          jq --arg v "$BUNDLE_VERSION" '.version = $v' mcpb/manifest.json > mcpb/manifest.tmp
-          mv mcpb/manifest.tmp mcpb/manifest.json
-          # Quoted heredoc — version is read from the env, never interpolated
-          # by the shell. Prevents any shell metacharacters in the tag name
-          # from being expanded inside the Python script.
-          python3 <<'PY'
-          import os, re, pathlib
-          v = os.environ["BUNDLE_VERSION"]
-          path = pathlib.Path("mcpb/pyproject.toml")
-          text = path.read_text()
-          text = re.sub(r'^version\s*=\s*"[^"]+"', f'version = "{v}"', text, count=1, flags=re.M)
-          text = re.sub(r'"automox-mcp>=[^"]+"', f'"automox-mcp>={v}"', text, count=1)
-          path.write_text(text)
-          PY
-          echo "MCPB bundle version set to $BUNDLE_VERSION"
-
-      - name: Build MCPB bundle
-        run: mcpb pack mcpb "mcpb/automox-mcp-${BUNDLE_VERSION}.mcpb"
-
-      - name: Attach MCPB bundle to GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "$GITHUB_REF_NAME" --clobber \
-            "mcpb/automox-mcp-${BUNDLE_VERSION}.mcpb"
+      # (MCPB build moved earlier — before PyPI publish and the GitHub
+      # Release create — so all assets, including the .mcpb, attach in a
+      # single atomic `gh release create`. See #110.)
 
   # Post-publish smoke: install the just-published version straight from PyPI and
   # confirm the wheel resolves and the entry point boots. Catches a broken


### PR DESCRIPTION
Makes `release.yml` immutable-release-safe by attaching **all** assets in a single atomic `gh release create`, instead of adding the `.mcpb` in a later `--clobber` step. Workflow-only; no `src`/version change.

> **Flagging:** #110 was marked CLOSED/COMPLETED earlier but **the fix never landed** — the workflow still attached the `.mcpb` post-publish with `--clobber`, exactly what immutable releases reject (`HTTP 422`, the 1.2.1 failure). This PR actually implements it.

## Changes
1. **MCPB build moved before the PyPI publish** (Install CLI → Compute version → Set version → Build). A `mcpb pack` failure now aborts *before* the irreversible PyPI push, and the `.mcpb` exists before the release is created.
2. **Single atomic `gh release create`** with the full asset set: `whl + tar + sigstore + sbom + mcpb`.
3. **Deleted** the separate "Attach MCPB" step and its `--clobber` upload.
4. **Existing-release path is now a deliberate no-op** (immutable releases can't be patched). Recovery from a *partial* release is delete-then-recreate by the operator — documented inline; the old `--clobber`-re-run backfill no longer applies under immutability.

## Rollout (immutable stays OFF here)
Per the agreed sequence: ship **1.3.0** through this flow with immutable **off**, confirm the single create yields a release with every asset (incl. `.mcpb`), **then** flip the repo's immutable-releases setting so 1.3.1+ are tamper-proof. This is a workflow change only — it rides 1.3.0, doesn't block it.

## Validation
Workflows parse; step-order asserted (MCPB before publish *and* before create); embedded Python heredoc compiles after YAML dedent; no `--clobber` commands remain. Zizmor audits the change in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)