### PR TITLE
Close #106: working CSV upload + gated local installer upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ console-api.yaml
 # Live-tenant probe harnesses — manual debugging, never commit (not in CI)
 tests/probe_*.py
 
+# Local OpenAPI spec exports — reference only, never commit (5+ MB dumps)
+Automox Console API.json
+*.openapi.json
+
 # MCP Registry tooling — local only, never commit
 mcp-publisher
 mcp-registry-key.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`upload_policy_file` tool (#106), gated + local-only.** Uploads a local installer file (up to 10 GB) to a Required Software policy via `POST /policies/{id}/files`. Mechanism: `file_path` (server reads a local file) — `base64` is impractical at GB scale and `file_url` was rejected to avoid building SSRF defense from scratch. Confined by a new default-off gate `AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE`, a **required** directory allowlist `AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS` (paths canonicalized; `..`/symlink escape rejected), a size cap `AUTOMOX_MCP_UPLOAD_MAX_BYTES` (default 10 GB), and **stdio-only** registration — `main()` refuses to start a remote transport while the flag is on, so it can never be served over a network. The installer streams to Automox and never passes through the model. Tool count **131 → 132** (84 read / 48 write). *(Spec-derived; the simple `file`-only multipart shape is unverified against a live tenant — smoke-test before relying on it.)*
+
+### Fixed
+
+- **`upload_action_set` now works — sends real `multipart/form-data` (#106).** The previous implementation POSTed JSON and was non-functional; the live endpoint requires a multipart file. Added `AutomoxClient.post_multipart`, which overrides the client's default `application/json` content-type with the boundary httpx encodes. Contract confirmed against the live tenant (2026-05-31): `source` is a **query parameter** (enum `generic|qualys|tenable|crowd-strike|rapid7`) and the multipart body carries `file` + `format` (same enum) — the earlier opaque `500` was `source` sent as a form field with an empty query string.
+
+### Changed
+
+- **`upload_action_set` tool signature.** Replaces the freeform `action_set_data` dict with `csv_content` (raw CSV text), `source` (format enum), and `filename` (becomes the action set's display name). CSV arrives inline as text — no URL fetch or local-file read, so no SSRF/file-read surface. (The Required-Software installer upload, the other half of #106, ships as `upload_policy_file` — see Added.)
+
 ## [1.3.0] - 2026-05-31
 
 Establishes and documents the server's capability model: a categorical policy for what the MCP server exposes, omits, and gates.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ That's it. Start asking questions.
 
 ## What Can I Ask?
 
-The server exposes 131 tools across devices, policies, patches, groups, webhooks, worklets, vulnerability sync, maintenance windows, and more. You don't need to know the tool names — just describe what you want:
+The server exposes 132 tools across devices, policies, patches, groups, webhooks, worklets, vulnerability sync, maintenance windows, and more. You don't need to know the tool names — just describe what you want:
 
 | Ask this | What happens |
 |---|---|
@@ -103,10 +103,14 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 | `AUTOMOX_API_KEY` | Yes | — | Automox API key |
 | `AUTOMOX_ACCOUNT_UUID` | Yes | — | Account UUID from Secrets & Keys |
 | `AUTOMOX_ORG_ID` | Recommended | — | Numeric organization ID (required by most tools) |
-| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (84 of 131 tools remain) |
+| `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (84 of 132 tools remain) |
 | `AUTOMOX_MCP_ALLOW_APPLY_REMEDIATION_ACTIONS` | No | `false` | Opt in to the `apply_remediation_actions` tool, which patches/runs worklets on endpoints immediately. Off by default even in write mode. |
 | `AUTOMOX_MCP_ALLOW_SPLASHTOP_BULK_INSTALL_UNINSTALL` | No | `false` | Opt in to the `splashtop_bulk_install_uninstall` tool, which installs/uninstalls the Splashtop client across an entire server group in one call. Off by default even in write mode. |
 | `AUTOMOX_MCP_ALLOW_DELETE_DEVICE` | No | `false` | Opt in to the `delete_device` tool, which permanently deletes a device record and its history (`DELETE /servers/{id}`). Irreversible and not reconstructable through the MCP. Off by default even in write mode. |
+| `AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE` | No | `false` | Opt in to the `upload_policy_file` tool, which uploads a **local** installer file to a Required Software policy. Reads from the local filesystem, so it also requires `AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS` and only works on the stdio (local) transport. Off by default even in write mode. |
+| `AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS` | No | — | Comma-separated absolute directories `upload_policy_file` may read installers from. Required for that tool to register; paths are canonicalized and must resolve inside an allowed dir. |
+| `AUTOMOX_MCP_UPLOAD_MAX_BYTES` | No | `10737418240` | Max installer size for `upload_policy_file` (default 10 GB, Automox's ceiling). |
+| `AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS` | No | `3600` | Upload read/write timeout for `upload_policy_file` (large installers need more than the default request timeout). |
 | `AUTOMOX_MCP_MODULES` | No | all | Comma-separated list of modules to load (see below) |
 | `AUTOMOX_MCP_TOKEN_BUDGET` | No | `4000` | Max estimated tokens per response before truncation |
 | `AUTOMOX_MCP_SANITIZE_RESPONSES` | No | `true` | Sanitize API data to mitigate prompt injection |
@@ -133,7 +137,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 AUTOMOX_MCP_READ_ONLY=true
 ```
 
-Disables all write operations. Only read-only tools are registered (84 of 131). Useful for auditing and monitoring.
+Disables all write operations. Only read-only tools are registered (84 of 132). Useful for auditing and monitoring.
 
 ### Modular Loading
 
@@ -185,7 +189,7 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 
 **Highlights:**
 
-- **Read-only mode** (`AUTOMOX_MCP_READ_ONLY`) disables all 47 write tools
+- **Read-only mode** (`AUTOMOX_MCP_READ_ONLY`) disables all 48 write tools
 - **Module filtering** (`AUTOMOX_MCP_MODULES`) for least-privilege tool loading
 - **Correlation IDs** on every tool call, forwarded to Automox API as `X-Correlation-ID`
 - **Rate limiting** (30 calls/60s) with token budget estimation and auto-truncation
@@ -202,7 +206,7 @@ The Automox MCP server is designed for enterprise deployment with defense-in-dep
 - **Security response headers** — `X-Content-Type-Options`, `X-Frame-Options`, `CSP`, `Cache-Control: no-store`, `Strict-Transport-Security` on all HTTP responses
 - **Authentication rate limiting** — blocks IPs after repeated auth failures to mitigate brute-force attacks
 - **Remote bind protection** — non-loopback HTTP/SSE binding requires explicit `--allow-remote-bind` opt-in
-- **MCP Tool Annotations** on all 131 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
+- **MCP Tool Annotations** on all 132 tools — `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` per the MCP Protocol specification, enabling client-side confirmation dialogs and safety guardrails
 - **60 security hardening items** (V-001 through V-181, S-001 through S-006) documented in CHANGELOG and SECURITY.md
 
 **Capability model.** What the server exposes follows three categorical rules:

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -4,7 +4,7 @@ This document records what the Automox MCP server deliberately does **not** expo
 
 Audited against the Automox Console API OpenAPI bundle (`ax-console-bundle.yaml`, version `2026-05-28`): **115 documented operations**. Coverage verified by registering the server and reading the live tool set, not by reading prose. Undocumented-but-wrapped paths (endpoints the live tenant serves that the spec omits) are tracked separately in [#95](https://github.com/AutomoxCommunity/automox-mcp/issues/95) and are **not** coverage gaps.
 
-The server exposes 131 tools (84 read / 47 write). Effectively every documented **read** operation is covered; the omissions below are all secret-exposing endpoints (every documented write/delete is now either wrapped or gated).
+The server exposes 132 tools (84 read / 48 write). Effectively every documented **read** operation is covered; the omissions below are all secret-exposing endpoints (every documented write/delete/upload is now either wrapped or gated).
 
 ## Three categories
 
@@ -81,7 +81,12 @@ The documented-surface build items from [#111](https://github.com/AutomoxCommuni
 
 **Implementation note — `delete_action_sets_bulk`:** wraps the native bulk endpoint `DELETE /…/action-sets` with a JSON body `{"ids": [...]}` (schema `delete-action-set`, `console-api.yaml` `2026-05-08`; responds `204`) — a single atomic call.
 
-Remaining uncovered documented surface (binary/multipart uploads) is tracked in [#106](https://github.com/AutomoxCommunity/automox-mcp/issues/106).
+**Multipart uploads ([#106](https://github.com/AutomoxCommunity/automox-mcp/issues/106)) — both covered:**
+
+| Operation | Tool | Status |
+|---|---|---|
+| `POST /orgs/{org}/remediations/action-sets/upload` (`uploadRemediationCSV`) | `upload_action_set` | **Covered.** `AutomoxClient.post_multipart` now sends real `multipart/form-data`. Contract confirmed live 2026-05-31: `source` is a **query param** (enum); the body carries `file` + `format` (same enum). The earlier 500 was `source` sent as a form field with an empty query string. CSV arrives as inline `csv_content` text — no SSRF/file-read surface. |
+| `POST /policies/{policyID}/files` (`uploadPolicyFile`) | `upload_policy_file` | **Covered, gated, local-only.** Required-Software installer upload (up to 10 GB). Mechanism decision: **`file_path`** (server reads a local file) — `base64` is impractical at GB scale and `file_url` was rejected (would require building SSRF defense from scratch for marginal value). Confined by: env-gate `AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE` (default off) + a required directory allowlist `AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS` (paths canonicalized; `..`/symlink escape rejected) + **stdio-only** (the tool isn't registered under a remote transport, and `main()` refuses to start a remote transport while the flag is on). The installer streams to Automox and never passes through the model. |
 
 ---
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Complete reference for all 131 tools, 6 workflow prompts, MCP resources, parameters, and enterprise features exposed by the Automox MCP server.
+Complete reference for all 132 tools, 6 workflow prompts, MCP resources, parameters, and enterprise features exposed by the Automox MCP server.
 
 > **Tip:** You don't need to memorize this. Call `discover_capabilities` from your AI assistant to get a live summary of available tools organized by domain.
 
@@ -8,7 +8,7 @@ Complete reference for all 131 tools, 6 workflow prompts, MCP resources, paramet
 
 - [Device Management (9 tools)](#device-management-9-tools)
 - [Advanced Device Search (18 tools)](#advanced-device-search-18-tools)
-- [Policy Management (14 tools)](#policy-management-14-tools)
+- [Policy Management (15 tools)](#policy-management-15-tools)
 - [Policy History v2 (7 tools)](#policy-history-v2-7-tools)
 - [Package Management (2 tools)](#package-management-2-tools)
 - [Group Management (5 tools)](#group-management-5-tools)
@@ -68,7 +68,7 @@ Uses the Server Groups API v2 for structured device queries, saved searches, and
 - **`assign_policies_to_saved_search`** *(write)* - Bulk-assign one or more policies to the result set of a saved search.
 - **`refresh_saved_search_cache`** *(write)* - Force a re-cache of a saved search's results when they may be stale.
 
-## Policy Management (14 tools)
+## Policy Management (15 tools)
 
 - **`policy_health_overview`** - Summarize recent Automox policy activity. Omit `org_uuid` to let the server resolve it from `AUTOMOX_ORG_ID` / `AUTOMOX_ORG_UUID`.
 - **`policy_execution_timeline`** - Review recent executions for a policy.
@@ -82,6 +82,7 @@ Uses the Server Groups API v2 for structured device queries, saved searches, and
 - **`patch_approvals_summary`** - Summarize pending patch approvals and their severity.
 - **`decide_patch_approval`** - Approve or reject an Automox patch approval request.
 - **`execute_policy_now`** - Execute a policy immediately for remediation (all devices or specific device).
+- **`upload_policy_file`** *(write, gated, local-only)* - Upload an installer file from the local filesystem to a Required Software policy (`POST /policies/{id}/files`, up to 10 GB). The path must resolve inside an `AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS` directory; bytes stream straight to Automox and never pass through the model. **Registered only when `AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE=true`, a directory allowlist is set, write mode is on, and the transport is stdio (local).** See [API Coverage & Omissions](api-coverage.md).
 - **`clone_policy`** - Clone an existing policy. By default an in-org copy with optional name and server-group overrides (all policy types). Pass `target_zone_ids` to clone a **patch** policy into one or more zones/orgs in a single server-side call (`POST /policies/{id}/clone`); mutually exclusive with name/server_groups.
 - **`delete_policy`** - Permanently delete a policy by ID.
 
@@ -141,7 +142,7 @@ Manage vulnerability remediation workflows via the Vuln Sync API. Supports CSV-b
 - **`get_action_set_issues`** - Get vulnerability issues (CVEs) associated with an action set.
 - **`get_action_set_solutions`** - Get solutions for an action set. Shows recommended patches or configurations.
 - **`get_upload_formats`** - Get supported CSV upload formats for vulnerability remediation action sets.
-- **`upload_action_set`** *(write)* - Upload a CSV-based vulnerability remediation action set.
+- **`upload_action_set`** *(write)* - Upload a CSV-based vulnerability remediation action set. Pass the CSV as text in `csv_content`; `source` picks the format (`generic`/`qualys`/`tenable`/`crowd-strike`/`rapid7`) and `filename` becomes the action set's display name. Sent as real `multipart/form-data`; returns the created action set (`status` usually `building` — processing is async). Call `get_upload_formats` first for the required columns.
 - **`delete_action_set`** *(write)* - Delete a single remediation action set by ID. Console metadata, reconstructable via re-upload.
 - **`delete_action_sets_bulk`** *(write)* - Delete multiple action sets by ID (up to 100) in one atomic call. Console metadata, reconstructable via re-upload.
 - **`apply_remediation_actions`** *(write, gated)* - Execute remediations now (`patch-now` / `patch-with-worklet`) on explicit devices for an action set. Immediately changes endpoint state (async, returns 202). **Registered only when `AUTOMOX_MCP_ALLOW_APPLY_REMEDIATION_ACTIONS=true`** and write mode is enabled.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Automox",
   "version": "1.3.0",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
-  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 131 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
+  "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 132 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {
     "name": "Automox",
     "url": "https://www.automox.com"
@@ -73,7 +73,7 @@
     "read_only": {
       "type": "boolean",
       "title": "Read-only mode",
-      "description": "Disable all 47 write operations. 84 read tools remain available. Recommended for auditing and exploration.",
+      "description": "Disable all 48 write operations. 84 read tools remain available. Recommended for auditing and exploration.",
       "default": false,
       "required": false
     }

--- a/src/automox_mcp/__init__.py
+++ b/src/automox_mcp/__init__.py
@@ -130,6 +130,20 @@ def main(argv: Sequence[str] | None = None) -> None:
             f"Unsupported transport '{transport}'. Expected stdio, http, sse, or streamable-http."
         )
 
+    # Authoritative local-only guarantee for upload_policy_file: it reads local
+    # files, so it must never be served over a network transport. Registration
+    # also skips it under a non-stdio env, but the CLI --transport flag is only
+    # resolved here (after the server is built at import), so this is the
+    # chokepoint that closes the flag-vs-env divergence. Fail closed.
+    from .utils.tooling import is_upload_policy_file_allowed
+
+    if transport != "stdio" and is_upload_policy_file_allowed():
+        raise SystemExit(
+            "AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE is set but the transport is "
+            f"'{transport}'. upload_policy_file reads local files and is supported "
+            "only on the stdio (local) transport. Unset the flag or use stdio."
+        )
+
     host = args.host or _env_str("AUTOMOX_MCP_HOST")
     port = args.port
     if port is None:

--- a/src/automox_mcp/client.py
+++ b/src/automox_mcp/client.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, NoReturn
 
 import httpx
 
@@ -232,11 +232,7 @@ class AutomoxClient:
         json_data: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> AutomoxResponse:
-        merged_headers: dict[str, str] = dict(headers) if headers else {}
-        correlation_id = get_correlation_id()
-        if correlation_id:
-            merged_headers["X-Correlation-ID"] = correlation_id
-
+        merged_headers, correlation_id = self._prepare_headers(headers)
         logger.debug(
             "Request: %s %s%s correlation_id=%s",
             method,
@@ -255,20 +251,100 @@ class AutomoxClient:
                 headers=merged_headers or None,
             )
         except httpx.RequestError as exc:
-            latency_ms = (time.monotonic() - start) * 1000.0
-            logger.warning(
-                "upstream request failed: %s %s exc=%s:%s latency_ms=%.1f correlation_id=%s",
-                method,
-                path,
-                type(exc).__name__,
-                exc,
-                latency_ms,
-                correlation_id,
-            )
-            raise AutomoxAPIError(
-                f"network error calling Automox API at {self._base_url_str}", status_code=0
-            ) from exc
+            self._raise_network_error(exc, method, path, start, correlation_id)
+        return self._process_response(
+            response, method=method, path=path, correlation_id=correlation_id, start=start
+        )
 
+    async def post_multipart(
+        self,
+        path: str,
+        *,
+        files: Mapping[str, Any],
+        data: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | None = None,  # noqa: ASYNC109 - httpx request timeout, not an asyncio scope
+    ) -> AutomoxResponse:
+        """POST ``multipart/form-data`` (file uploads).
+
+        The client sets a default ``Content-Type: application/json`` header,
+        which clobbers the boundary httpx computes for a multipart body. We build
+        the request (so httpx encodes the parts and derives the boundary), then
+        force the multipart content-type from the encoded stream before sending.
+
+        ``timeout`` (seconds) overrides the client default for large uploads; the
+        connect timeout stays short while read/write/pool scale to ``timeout``.
+        """
+        merged_headers, correlation_id = self._prepare_headers(headers)
+        logger.debug(
+            "Request: POST %s%s (multipart) correlation_id=%s",
+            self._base_url_str,
+            path,
+            correlation_id,
+        )
+
+        start = time.monotonic()
+        build_kwargs: dict[str, Any] = {}
+        if timeout is not None:
+            build_kwargs["timeout"] = httpx.Timeout(timeout, connect=min(15.0, timeout))
+        try:
+            request = self._http.build_request(
+                "POST",
+                path,
+                params=params,  # type: ignore[arg-type]
+                data=dict(data) if data else None,
+                files=files,
+                headers=merged_headers or None,
+                **build_kwargs,
+            )
+            # Override the client-level application/json default with the
+            # boundary-bearing multipart content-type httpx just encoded.
+            stream_content_type = getattr(request.stream, "content_type", None)
+            if stream_content_type:
+                request.headers["Content-Type"] = stream_content_type
+            response = await self._http.send(request)
+        except httpx.RequestError as exc:
+            self._raise_network_error(exc, "POST", path, start, correlation_id)
+        return self._process_response(
+            response, method="POST", path=path, correlation_id=correlation_id, start=start
+        )
+
+    def _prepare_headers(
+        self, headers: Mapping[str, str] | None
+    ) -> tuple[dict[str, str], str | None]:
+        merged_headers: dict[str, str] = dict(headers) if headers else {}
+        correlation_id = get_correlation_id()
+        if correlation_id:
+            merged_headers["X-Correlation-ID"] = correlation_id
+        return merged_headers, correlation_id
+
+    def _raise_network_error(
+        self, exc: Exception, method: str, path: str, start: float, correlation_id: str | None
+    ) -> NoReturn:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        logger.warning(
+            "upstream request failed: %s %s exc=%s:%s latency_ms=%.1f correlation_id=%s",
+            method,
+            path,
+            type(exc).__name__,
+            exc,
+            latency_ms,
+            correlation_id,
+        )
+        raise AutomoxAPIError(
+            f"network error calling Automox API at {self._base_url_str}", status_code=0
+        ) from exc
+
+    def _process_response(
+        self,
+        response: httpx.Response,
+        *,
+        method: str,
+        path: str,
+        correlation_id: str | None,
+        start: float,
+    ) -> AutomoxResponse:
         latency_ms = (time.monotonic() - start) * 1000.0
         retry_after = response.headers.get("Retry-After")
         log_extra = {

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -945,16 +945,43 @@ class CreateDataExtractParams(OrgIdRequiredMixin, ForbidExtraModel):
 
 
 class UploadActionSetParams(OrgIdRequiredMixin, ForbidExtraModel):
-    action_set_data: dict[str, Any] = Field(description="Action set upload data")
+    csv_content: str = Field(
+        description=(
+            "Raw CSV text of the remediation action set, e.g. "
+            "'Hostname,CVE ID,Severity\\nhost1,CVE-2021-1234,High'. The required "
+            "columns depend on the source — call get_upload_formats first."
+        ),
+        min_length=1,
+        max_length=1_000_000,
+    )
+    source: Literal["generic", "qualys", "tenable", "crowd-strike", "rapid7"] = Field(
+        "generic",
+        description=(
+            "CSV source/format. Sent as both the `source` query param and the "
+            "`format` body field, which the endpoint requires to agree."
+        ),
+    )
+    filename: str = Field(
+        "action-set.csv",
+        description="Upload filename; becomes the action set's display name in the console.",
+        min_length=1,
+        max_length=255,
+    )
 
-    @model_validator(mode="after")
-    def _limit_action_set_data_size(self) -> UploadActionSetParams:
-        import json
 
-        raw = json.dumps(self.action_set_data, default=str)
-        if len(raw) > 50_000:
-            raise ValueError("action_set_data payload exceeds 50 KB limit")
-        return self
+class UploadPolicyFileParams(OrgIdContextMixin, ForbidExtraModel):
+    policy_id: int = Field(
+        description="Required Software policy ID to attach the installer to.", ge=1
+    )
+    file_path: str = Field(
+        description=(
+            "Absolute path to the installer file on the machine running the MCP "
+            "server. Must resolve to a regular file inside one of the "
+            "AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS directories."
+        ),
+        min_length=1,
+        max_length=4096,
+    )
 
 
 # ============================================================================

--- a/src/automox_mcp/tools/meta_tools.py
+++ b/src/automox_mcp/tools/meta_tools.py
@@ -56,6 +56,11 @@ _DOMAIN_CATALOG: dict[str, list[tuple[str, str]]] = {
         ("clone_policy", "Clone a policy (in-org, or multi-zone for patch policies)"),
         ("delete_policy", "Delete a policy permanently"),
         ("execute_policy_now", "Execute a policy immediately"),
+        (
+            "upload_policy_file",
+            "Upload a local installer to a Required Software policy "
+            "(requires AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE + allowlist, stdio only)",
+        ),
     ],
     "policy_history": [
         ("policy_runs_v2", "List policy runs with time-range and status filters"),

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -24,14 +24,18 @@ from ..schemas import (
     PolicyHealthSummaryParams,
     PolicySummaryParams,
     RunDetailParams,
+    UploadPolicyFileParams,
 )
 from ..utils.tooling import (
     call_tool_workflow,
     check_idempotency,
+    is_stdio_transport,
+    is_upload_policy_file_allowed,
     maybe_format_markdown,
     release_idempotency,
     store_idempotency,
 )
+from ..utils.upload import get_upload_allowed_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -504,6 +508,54 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 raise
             await store_idempotency(request_id, "execute_policy_now", result)
             return result
+
+        # Local-file installer upload: reads a file off disk, so it is opt-in
+        # (AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE), restricted to a directory
+        # allowlist (AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS, must be non-empty), and
+        # local-transport only. main() additionally refuses to start a remote
+        # transport while the flag is on, so the tool can never be served
+        # remotely even if this env-based stdio check is somehow bypassed.
+        if is_upload_policy_file_allowed() and is_stdio_transport() and get_upload_allowed_dirs():
+
+            @server.tool(
+                name="upload_policy_file",
+                description=(
+                    "Upload an installer file to a Required Software policy from the "
+                    "local filesystem. `file_path` must be an absolute path resolving "
+                    "inside an AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS directory; the bytes "
+                    "stream straight to Automox and never pass through the model. "
+                    "Requires AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE=true, a configured "
+                    "AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS, and a local (stdio) transport."
+                ),
+                annotations={
+                    "readOnlyHint": False,
+                    "destructiveHint": True,
+                    "idempotentHint": False,
+                    "openWorldHint": True,
+                },
+            )
+            async def upload_policy_file(
+                policy_id: int,
+                file_path: str,
+                request_id: str | None = None,
+            ) -> dict[str, Any]:
+                cached = await check_idempotency(request_id, "upload_policy_file")
+                if cached is not None:
+                    return cached
+
+                params = {"policy_id": policy_id, "file_path": file_path}
+                try:
+                    result = await call_tool_workflow(
+                        client,
+                        workflows.upload_policy_file,
+                        params,
+                        params_model=UploadPolicyFileParams,
+                    )
+                except BaseException:
+                    await release_idempotency(request_id, "upload_policy_file")
+                    raise
+                await store_idempotency(request_id, "upload_policy_file", result)
+                return result
 
 
 __all__ = ["register"]

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -183,8 +183,13 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         @server.tool(
             name="upload_action_set",
             description=(
-                "Upload a CSV-based vulnerability remediation action set. "
-                "Use get_upload_formats to see supported formats first."
+                "Upload a CSV-based vulnerability remediation action set. Provide "
+                "the CSV as text in `csv_content`; `source` selects the format "
+                "(generic | qualys | tenable | crowd-strike | rapid7). Call "
+                "get_upload_formats first to see the required columns per source. "
+                "The `filename` becomes the action set's display name. Returns the "
+                "created action set (status is usually 'building' — processing is "
+                "async)."
             ),
             annotations={
                 "readOnlyHint": False,
@@ -194,7 +199,9 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             },
         )
         async def upload_action_set(
-            action_set_data: dict[str, Any],
+            csv_content: str,
+            source: str = "generic",
+            filename: str = "action-set.csv",
             request_id: str | None = None,
         ) -> dict[str, Any]:
             cached = await check_idempotency(request_id, "upload_action_set")
@@ -203,7 +210,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             result = await call_tool_workflow(
                 client,
                 _upload_action_set,
-                {"action_set_data": action_set_data},
+                {"csv_content": csv_content, "source": source, "filename": filename},
                 params_model=UploadActionSetParams,
             )
             await store_idempotency(request_id, "upload_action_set", result)

--- a/src/automox_mcp/utils/tooling.py
+++ b/src/automox_mcp/utils/tooling.py
@@ -96,6 +96,39 @@ def is_splashtop_bulk_allowed() -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def is_upload_policy_file_allowed() -> bool:
+    """Return True when local-file installer upload is explicitly enabled.
+
+    Gated by ``AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE`` (default off). Controls the
+    ``upload_policy_file`` tool, which reads an installer **from the local
+    filesystem** and uploads it to a Required Software policy. Because it reads
+    local files, it is opt-in, restricted to a directory allowlist
+    (``AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS``), and **local-transport only** — see
+    ``utils/upload.py`` and the stdio guard in ``__init__.py`` /
+    ``policy_tools.py``.
+    """
+    value = os.environ.get("AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def is_stdio_transport() -> bool:
+    """Return True when the configured transport is stdio (local).
+
+    Reads ``AUTOMOX_MCP_TRANSPORT`` (default ``stdio``). This is a best-effort
+    registration-time check; the authoritative local-only guarantee for
+    ``upload_policy_file`` is enforced in ``main()`` (which refuses to start a
+    non-stdio transport while the upload flag is on) so a CLI ``--transport``
+    flag cannot diverge from it.
+
+    Caveat: the ``main()`` guarantee covers the CLI entrypoint. Code that embeds
+    the module-level ``mcp`` server and calls ``mcp.run(transport=...)`` directly
+    (bypassing ``main()``) is responsible for its own transport choice — set
+    ``AUTOMOX_MCP_TRANSPORT`` accordingly so this registration check still holds.
+    """
+    value = os.environ.get("AUTOMOX_MCP_TRANSPORT", "").strip().lower()
+    return value in {"", "stdio"}
+
+
 def is_device_deletion_allowed() -> bool:
     """Return True when device deletion is explicitly enabled.
 

--- a/src/automox_mcp/utils/upload.py
+++ b/src/automox_mcp/utils/upload.py
@@ -1,0 +1,114 @@
+"""Local-file upload guard for ``upload_policy_file`` (see docs/api-coverage.md).
+
+The installer upload reads a file from the **local filesystem** and streams it
+to Automox. To keep that arbitrary-file-read surface contained, every path is:
+
+  - canonicalized (``..`` and symlinks fully resolved) *before* any check,
+  - required to live inside one of the ``AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS``
+    directories,
+  - required to be an existing regular file within the size cap.
+
+Combined with stdio-only registration and ``main()`` refusing to start a remote
+transport while the upload flag is on, this confines reads to operator-approved
+directories on the operator's own machine.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Automox's Required Software ceiling is 10 GB (product docs). Default the cap to
+# that so valid installers are never rejected; operators may lower it.
+_DEFAULT_MAX_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
+_DEFAULT_TIMEOUT_SECONDS = 3600.0
+
+
+def get_upload_allowed_dirs() -> list[Path]:
+    """Resolved absolute directories the upload tool may read from.
+
+    From ``AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS`` (comma-separated). Entries that do
+    not resolve to an existing directory are dropped — fail-closed: a typo'd
+    entry silently narrows the allowlist rather than widening it.
+    """
+    raw = os.environ.get("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", "")
+    dirs: list[Path] = []
+    for part in raw.split(","):
+        candidate = part.strip()
+        if not candidate:
+            continue
+        try:
+            resolved = Path(candidate).resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if resolved.is_dir():
+            dirs.append(resolved)
+    return dirs
+
+
+def get_upload_max_bytes() -> int:
+    """Max upload size in bytes (``AUTOMOX_MCP_UPLOAD_MAX_BYTES``, default 10 GiB)."""
+    raw = os.environ.get("AUTOMOX_MCP_UPLOAD_MAX_BYTES", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            return _DEFAULT_MAX_BYTES
+        if value > 0:
+            return value
+    return _DEFAULT_MAX_BYTES
+
+
+def get_upload_timeout_seconds() -> float:
+    """Upload read/write timeout (``AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS``, default 3600)."""
+    raw = os.environ.get("AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS", "").strip()
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            return _DEFAULT_TIMEOUT_SECONDS
+        if value > 0:
+            return value
+    return _DEFAULT_TIMEOUT_SECONDS
+
+
+def validate_upload_path(file_path: str) -> Path:
+    """Resolve and authorize *file_path* for upload, returning the resolved path.
+
+    Raises ``ValueError`` (surfaced to the model as a validation error) when the
+    allowlist is unset, or the path is missing, not a regular file, outside the
+    allowlist, empty, or too large. Returns the **resolved** path so the caller
+    opens the canonical target (not the original, possibly-symlinked input).
+    """
+    allowed = get_upload_allowed_dirs()
+    if not allowed:
+        raise ValueError(
+            "upload_policy_file is not configured: set AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS "
+            "to one or more absolute directories the server may read installers from."
+        )
+
+    try:
+        resolved = Path(file_path).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("file_path does not exist or could not be resolved.") from exc
+
+    if not resolved.is_file():
+        raise ValueError("file_path must point to a regular file.")
+
+    # Containment check on fully-resolved endpoints — defeats `..` traversal and
+    # symlink escape, since both the file and each base are canonicalized first.
+    if not any(resolved.is_relative_to(base) for base in allowed):
+        raise ValueError(
+            "file_path is outside the allowed upload directories (AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS)."
+        )
+
+    size = resolved.stat().st_size
+    if size == 0:
+        raise ValueError("file_path is an empty file.")
+    max_bytes = get_upload_max_bytes()
+    if size > max_bytes:
+        raise ValueError(
+            f"file is {size} bytes, exceeding the {max_bytes}-byte upload limit "
+            "(AUTOMOX_MCP_UPLOAD_MAX_BYTES)."
+        )
+    return resolved

--- a/src/automox_mcp/workflows/__init__.py
+++ b/src/automox_mcp/workflows/__init__.py
@@ -113,6 +113,7 @@ from .policy_crud import (
     normalize_policy_operations_input,
     preview_policy_device_filters,
     resolve_patch_approval,
+    upload_policy_file,
 )
 from .policy_history import (
     get_policy_history_detail,
@@ -326,6 +327,7 @@ __all__ = [
     "update_server_group",
     "update_webhook",
     "upload_action_set",
+    "upload_policy_file",
     "check_group_exclusion_status",
     "check_window_active",
     "create_policy_window",

--- a/src/automox_mcp/workflows/policy_crud.py
+++ b/src/automox_mcp/workflows/policy_crud.py
@@ -13,6 +13,7 @@ from fastmcp.exceptions import ToolError
 from ..client import AutomoxAPIError, AutomoxClient
 from ..utils.response import extract_list as _extract_list
 from ..utils.response import require_org_id
+from ..utils.upload import get_upload_timeout_seconds, validate_upload_path
 
 logger = logging.getLogger(__name__)
 
@@ -1213,6 +1214,49 @@ async def list_devices_for_policies(
     }
 
 
+async def upload_policy_file(
+    client: AutomoxClient,
+    *,
+    org_id: int | None = None,
+    policy_id: int,
+    file_path: str,
+) -> dict[str, Any]:
+    """Upload an installer to a Required Software policy (multipart, local file).
+
+    Wraps ``POST /policies/{policyID}/files`` (``uploadPolicyFile``). The installer
+    is read from the **local filesystem**: ``validate_upload_path`` canonicalizes
+    the path, requires it inside ``AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS`` (rejecting
+    ``..``/symlink escape), and enforces the size cap before anything is read. The
+    bytes are streamed straight to Automox — they never pass through the model.
+    ``org_id`` rides as the ``o`` query param only for child orgs (omitted for the
+    main org, per the API).
+    """
+    resolved = validate_upload_path(file_path)
+    params: dict[str, Any] = {}
+    if org_id is not None:
+        params["o"] = org_id
+
+    with resolved.open("rb") as handle:
+        response = await client.post_multipart(
+            f"/policies/{policy_id}/files",
+            params=params or None,
+            files={"file": (resolved.name, handle, "application/octet-stream")},
+            timeout=get_upload_timeout_seconds(),
+        )
+
+    result = dict(response) if isinstance(response, Mapping) else {}
+    return {
+        "data": {
+            "policy_id": policy_id,
+            "filename": resolved.name,
+            "size_bytes": resolved.stat().st_size,
+            "uploaded": True,
+            "response": result or None,
+        },
+        "metadata": {"deprecated_endpoint": False, "org_id": org_id},
+    }
+
+
 __all__ = [
     "apply_policy_changes",
     "clone_policy",
@@ -1222,4 +1266,5 @@ __all__ = [
     "normalize_policy_operations_input",
     "preview_policy_device_filters",
     "resolve_patch_approval",
+    "upload_policy_file",
 ]

--- a/src/automox_mcp/workflows/vuln_sync.py
+++ b/src/automox_mcp/workflows/vuln_sync.py
@@ -230,15 +230,35 @@ async def upload_action_set(
     client: AutomoxClient,
     *,
     org_id: int,
-    action_set_data: dict[str, Any],
+    csv_content: str,
+    source: str = "generic",
+    filename: str = "action-set.csv",
 ) -> dict[str, Any]:
-    """Upload a CSV-based remediation action set."""
-    response = await client.post(
+    """Upload a CSV-based remediation action set (``multipart/form-data``).
+
+    Wraps ``POST /orgs/{org}/remediations/action-sets/upload``. Per the live
+    contract (confirmed 2026-05-31): ``source`` is a **query parameter** (enum
+    ``generic|qualys|tenable|crowd-strike|rapid7``) and the multipart body
+    carries ``file`` (the CSV) plus ``format`` (the same enum). The action set's
+    display name is derived from the uploaded ``filename``. Returns the created
+    action set; ``status`` is typically ``building`` (processing is async).
+
+    The previous implementation POSTed JSON and was non-functional — the live
+    endpoint requires a real multipart upload (see #106).
+    """
+    response = await client.post_multipart(
         f"/orgs/{org_id}/remediations/action-sets/upload",
-        json_data=action_set_data,
+        params={"source": source},
+        files={"file": (filename, csv_content.encode("utf-8"), "text/csv")},
+        data={"format": source},
     )
 
-    if isinstance(response, Mapping):
+    # The endpoint returns the created action set (the live tenant returns a
+    # single object; the spec types it as a one-element array — handle both).
+    if isinstance(response, list) and response:
+        first = response[0]
+        result = dict(first) if isinstance(first, Mapping) else {}
+    elif isinstance(response, Mapping):
         result = dict(response)
     else:
         result = {}
@@ -246,10 +266,12 @@ async def upload_action_set(
     return {
         "data": {
             "id": result.get("id"),
-            "status": result.get("status", "pending"),
+            "status": result.get("status", "building"),
+            "source": result.get("source"),
+            "organization_id": result.get("organization_id"),
             "message": "Action set upload submitted.",
         },
-        "metadata": {"deprecated_endpoint": False},
+        "metadata": {"deprecated_endpoint": False, "org_id": org_id},
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,18 @@ class FakeClient:
     ) -> Any:
         return self._post_response
 
+    async def post_multipart(
+        self,
+        path: str,
+        *,
+        files: Any = None,
+        data: Any = None,
+        params: Any = None,
+        headers: Any = None,
+        timeout: Any = None,  # noqa: ASYNC109 - mirrors client.post_multipart (httpx timeout)
+    ) -> Any:
+        return self._post_response
+
 
 # ---------------------------------------------------------------------------
 # Shared StubClient for workflow tests
@@ -167,6 +179,22 @@ class StubClient:
         self, path: str, *, json_data: Any = None, params: Any = None, headers: Any = None
     ) -> Any:
         self.calls.append(("POST", path, json_data))
+        return self._pop(self._post, path)
+
+    async def post_multipart(
+        self,
+        path: str,
+        *,
+        files: Any = None,
+        data: Any = None,
+        params: Any = None,
+        headers: Any = None,
+        timeout: Any = None,  # noqa: ASYNC109 - mirrors client.post_multipart (httpx timeout)
+    ) -> Any:
+        # Record the multipart shape so tests can assert query/body/file parts.
+        self.calls.append(
+            ("POST_MULTIPART", path, {"params": params, "data": data, "files": files})
+        )
         return self._pop(self._post, path)
 
     async def put(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -223,6 +223,23 @@ def test_main_raises_on_unsupported_transport(monkeypatch):
         main([])
 
 
+def test_main_refuses_remote_transport_when_upload_flag_set(monkeypatch):
+    # upload_policy_file is local-only: main() must refuse to start a network
+    # transport while AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE is on, even when the
+    # transport comes from the CLI flag (which registration can't see).
+    from automox_mcp import main
+
+    monkeypatch.setenv("AUTOMOX_API_KEY", "env-key")
+    monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", "account-uuid")
+    monkeypatch.setenv("AUTOMOX_ORG_ID", "17")
+    monkeypatch.setenv("AUTOMOX_MCP_SKIP_DOTENV", "1")
+    monkeypatch.delenv("AUTOMOX_MCP_TRANSPORT", raising=False)
+    monkeypatch.setenv("AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE", "true")
+
+    with pytest.raises(SystemExit, match="upload_policy_file"):
+        main(["--transport", "http"])
+
+
 def test_main_stdio_transport_calls_run(monkeypatch):
     import automox_mcp as init_mod
 

--- a/tests/test_doc_tool_counts.py
+++ b/tests/test_doc_tool_counts.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import re
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -40,9 +41,25 @@ _GATING_ENV = (
     "AUTOMOX_MCP_ALLOW_APPLY_REMEDIATION_ACTIONS",
     "AUTOMOX_MCP_ALLOW_SPLASHTOP_BULK_INSTALL_UNINSTALL",
     "AUTOMOX_MCP_ALLOW_DELETE_DEVICE",
+    "AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE",
+    "AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS",
+    "AUTOMOX_MCP_TRANSPORT",
     "AUTOMOX_MCP_MODULES",
     "AUTOMOX_MCP_TOOL_PREFIX",
 )
+
+# upload_policy_file registers only with a non-empty, existing allowlist dir.
+_TMP_DIR = tempfile.gettempdir()
+
+# The opt-in gate flags the "full" configuration must set so every gated tool
+# registers (matches the "N tools" headline the docs advertise).
+_FULL_GATES = {
+    "AUTOMOX_MCP_ALLOW_APPLY_REMEDIATION_ACTIONS": "true",
+    "AUTOMOX_MCP_ALLOW_SPLASHTOP_BULK_INSTALL_UNINSTALL": "true",
+    "AUTOMOX_MCP_ALLOW_DELETE_DEVICE": "true",
+    "AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE": "true",
+    "AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS": _TMP_DIR,
+}
 
 
 def _register(monkeypatch: pytest.MonkeyPatch, **env: str) -> set[str]:
@@ -59,12 +76,7 @@ def _register(monkeypatch: pytest.MonkeyPatch, **env: str) -> set[str]:
 @pytest.fixture
 def registered_counts(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
     """Tool counts under the full / read-only gate configurations."""
-    full = _register(
-        monkeypatch,
-        AUTOMOX_MCP_ALLOW_APPLY_REMEDIATION_ACTIONS="true",
-        AUTOMOX_MCP_ALLOW_SPLASHTOP_BULK_INSTALL_UNINSTALL="true",
-        AUTOMOX_MCP_ALLOW_DELETE_DEVICE="true",
-    )
+    full = _register(monkeypatch, **_FULL_GATES)
     read_only = _register(monkeypatch, AUTOMOX_MCP_READ_ONLY="true")
     return {
         "total": len(full),
@@ -74,12 +86,7 @@ def registered_counts(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
 
 
 def _full_tool_names(monkeypatch: pytest.MonkeyPatch) -> set[str]:
-    return _register(
-        monkeypatch,
-        AUTOMOX_MCP_ALLOW_APPLY_REMEDIATION_ACTIONS="true",
-        AUTOMOX_MCP_ALLOW_SPLASHTOP_BULK_INSTALL_UNINSTALL="true",
-        AUTOMOX_MCP_ALLOW_DELETE_DEVICE="true",
-    )
+    return _register(monkeypatch, **_FULL_GATES)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_http_multipart.py
+++ b/tests/test_http_multipart.py
@@ -1,0 +1,98 @@
+"""Tests for AutomoxClient.post_multipart (file uploads).
+
+These use a real httpx.AsyncClient wired to a MockTransport — not the
+StubAsyncClient — because the behavior under test is the genuine httpx
+content-type handling: the client sets a default ``Content-Type:
+application/json`` that would clobber the multipart boundary, and
+``post_multipart`` must override it with the boundary httpx encodes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
+
+
+def _mock_client(client: AutomoxClient, handler: Any) -> None:
+    """Swap the client's transport for a MockTransport, keeping the json default."""
+    client._http = httpx.AsyncClient(
+        base_url="https://console.automox.com/api",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOMOX_API_KEY", "test-key")
+    monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", "abc-123")
+    monkeypatch.delenv("AUTOMOX_ORG_ID", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_post_multipart_overrides_json_content_type() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["content_type"] = request.headers.get("content-type")
+        captured["url"] = str(request.url)
+        captured["body"] = request.content
+        return httpx.Response(201, json={"id": 1, "status": "building"})
+
+    async with AutomoxClient(org_id=42) as client:
+        await client._http.aclose()
+        _mock_client(client, handler)
+        result = await client.post_multipart(
+            "/orgs/42/remediations/action-sets/upload",
+            params={"source": "generic"},
+            files={"file": ("export.csv", b"Hostname,CVE ID\nhost1,CVE-2021-1234\n", "text/csv")},
+            data={"format": "generic"},
+        )
+
+    assert result == {"id": 1, "status": "building"}
+    # The json default must NOT win — the boundary-bearing multipart CT does.
+    assert captured["content_type"].startswith("multipart/form-data; boundary=")
+    # source rides the query string.
+    assert "source=generic" in captured["url"]
+    # Body carries both the file part and the format field.
+    assert b'name="file"; filename="export.csv"' in captured["body"]
+    assert b'name="format"' in captured["body"]
+    assert b"CVE-2021-1234" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_post_multipart_raises_on_api_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"errors": {"file": ["bad csv"]}})
+
+    async with AutomoxClient(org_id=42) as client:
+        await client._http.aclose()
+        _mock_client(client, handler)
+        with pytest.raises(AutomoxAPIError):
+            await client.post_multipart(
+                "/orgs/42/remediations/action-sets/upload",
+                params={"source": "generic"},
+                files={"file": ("x.csv", b"bad", "text/csv")},
+                data={"format": "generic"},
+            )
+
+
+@pytest.mark.asyncio
+async def test_post_multipart_wraps_network_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    async with AutomoxClient(org_id=42) as client:
+        await client._http.aclose()
+        _mock_client(client, handler)
+        with pytest.raises(AutomoxAPIError) as excinfo:
+            await client.post_multipart(
+                "/orgs/42/remediations/action-sets/upload",
+                files={"file": ("x.csv", b"a,b\n1,2\n", "text/csv")},
+                data={"format": "generic"},
+            )
+        assert excinfo.value.status_code == 0

--- a/tests/test_phase3_edge_cases.py
+++ b/tests/test_phase3_edge_cases.py
@@ -221,9 +221,12 @@ async def test_upload_action_set_non_mapping_response() -> None:
     result = await upload_action_set(
         cast(AutomoxClient, client),
         org_id=42,
-        action_set_data={"format": "qualys"},
+        csv_content="a,b\n1,2",
+        source="qualys",
     )
-    assert result["data"]["status"] == "pending"
+    # A non-mapping/non-list response degrades to defaults rather than raising.
+    assert result["data"]["status"] == "building"
+    assert result["data"]["id"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_phase3_tool_errors.py
+++ b/tests/test_phase3_tool_errors.py
@@ -334,9 +334,11 @@ async def test_vs_formats_success() -> None:
 @pytest.mark.asyncio
 async def test_vs_upload_success() -> None:
     client = FakeClient()
-    client._post_response = {"id": 3, "status": "pending"}
+    client._post_response = {"id": 3, "status": "building"}
     server = _register(vuln_sync_tools, client, read_only=False)
-    result = await server.tools["upload_action_set"](action_set_data={"format": "qualys"})
+    result = await server.tools["upload_action_set"](
+        csv_content="a,b\n1,2", source="qualys", filename="q.csv"
+    )
     assert result["data"]["id"] == 3
 
 
@@ -345,8 +347,8 @@ async def test_vs_upload_idempotent() -> None:
     client = FakeClient()
     client._post_response = {"id": 3}
     server = _register(vuln_sync_tools, client, read_only=False)
-    r1 = await server.tools["upload_action_set"](action_set_data={}, request_id="dup-1")
-    r2 = await server.tools["upload_action_set"](action_set_data={}, request_id="dup-1")
+    r1 = await server.tools["upload_action_set"](csv_content="a,b\n1,2", request_id="dup-1")
+    r2 = await server.tools["upload_action_set"](csv_content="a,b\n1,2", request_id="dup-1")
     assert r1 == r2
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -152,19 +152,35 @@ class TestCreateDataExtractParams:
 
 
 # ---------------------------------------------------------------------------
-# UploadActionSetParams — payload size validator
+# UploadActionSetParams — CSV upload (multipart contract)
 # ---------------------------------------------------------------------------
 
 
 class TestUploadActionSetParams:
-    def test_small_payload_accepted(self):
-        p = UploadActionSetParams(org_id=1, action_set_data={"format": "qualys"})
-        assert p.action_set_data["format"] == "qualys"
+    def test_minimal_fields_accepted(self):
+        p = UploadActionSetParams(org_id=1, csv_content="Hostname,CVE ID\nhost1,CVE-2021-1234")
+        # source/filename default; source mirrors into the body `format` downstream.
+        assert p.source == "generic"
+        assert p.filename == "action-set.csv"
 
-    def test_oversized_payload_rejected(self):
-        huge = {"data": "x" * 60_000}
-        with pytest.raises(ValidationError, match="50 KB"):
-            UploadActionSetParams(org_id=1, action_set_data=huge)
+    def test_source_and_filename_passthrough(self):
+        p = UploadActionSetParams(
+            org_id=1, csv_content="a,b\n1,2", source="qualys", filename="qualys-export.csv"
+        )
+        assert p.source == "qualys"
+        assert p.filename == "qualys-export.csv"
+
+    def test_invalid_source_rejected(self):
+        with pytest.raises(ValidationError):
+            UploadActionSetParams(org_id=1, csv_content="a,b\n1,2", source="not-a-source")
+
+    def test_empty_csv_rejected(self):
+        with pytest.raises(ValidationError):
+            UploadActionSetParams(org_id=1, csv_content="")
+
+    def test_oversized_csv_rejected(self):
+        with pytest.raises(ValidationError):
+            UploadActionSetParams(org_id=1, csv_content="x" * 1_000_001)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upload_guard.py
+++ b/tests/test_upload_guard.py
@@ -1,0 +1,143 @@
+"""Tests for the local-file upload guard (utils/upload.py).
+
+These cover the security-critical path validation for upload_policy_file:
+allowlist enforcement, `..` traversal, symlink escape, type/size checks, and
+the env-driven getters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from automox_mcp.utils.upload import (
+    get_upload_allowed_dirs,
+    get_upload_max_bytes,
+    get_upload_timeout_seconds,
+    validate_upload_path,
+)
+
+_GB = 10 * 1024 * 1024 * 1024
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS",
+        "AUTOMOX_MCP_UPLOAD_MAX_BYTES",
+        "AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_no_allowlist_is_fail_closed(tmp_path, monkeypatch) -> None:
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"x")
+    with pytest.raises(ValueError, match="not configured"):
+        validate_upload_path(str(f))
+
+
+def test_file_inside_allowlist_ok(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    f = tmp_path / "installer.pkg"
+    f.write_bytes(b"payload")
+    assert validate_upload_path(str(f)) == f.resolve()
+
+
+def test_file_outside_allowlist_rejected(tmp_path, monkeypatch) -> None:
+    allowed = tmp_path / "ok"
+    allowed.mkdir()
+    other = tmp_path / "secret"
+    other.mkdir()
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(allowed))
+    f = other / "x.bin"
+    f.write_bytes(b"x")
+    with pytest.raises(ValueError, match="outside the allowed"):
+        validate_upload_path(str(f))
+
+
+def test_dotdot_traversal_rejected(tmp_path, monkeypatch) -> None:
+    allowed = tmp_path / "ok"
+    allowed.mkdir()
+    secret = tmp_path / "secret.bin"
+    secret.write_bytes(b"x")
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(allowed))
+    # An in-allowlist prefix that climbs out via `..`.
+    sneaky = str(allowed / ".." / "secret.bin")
+    with pytest.raises(ValueError, match="outside the allowed"):
+        validate_upload_path(sneaky)
+
+
+def test_symlink_escape_rejected(tmp_path, monkeypatch) -> None:
+    allowed = tmp_path / "ok"
+    allowed.mkdir()
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"x")
+    link = allowed / "link.bin"
+    link.symlink_to(outside)
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(allowed))
+    # The symlink lives inside the allowlist but resolves outside it.
+    with pytest.raises(ValueError, match="outside the allowed"):
+        validate_upload_path(str(link))
+
+
+def test_missing_file_rejected(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    with pytest.raises(ValueError, match="does not exist"):
+        validate_upload_path(str(tmp_path / "nope.bin"))
+
+
+def test_directory_rejected(tmp_path, monkeypatch) -> None:
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    with pytest.raises(ValueError, match="regular file"):
+        validate_upload_path(str(sub))
+
+
+def test_empty_file_rejected(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    f = tmp_path / "empty.bin"
+    f.touch()
+    with pytest.raises(ValueError, match="empty"):
+        validate_upload_path(str(f))
+
+
+def test_oversized_file_rejected(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_MAX_BYTES", "4")
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"12345")
+    with pytest.raises(ValueError, match="exceeding"):
+        validate_upload_path(str(f))
+
+
+def test_getters_defaults() -> None:
+    assert get_upload_allowed_dirs() == []
+    assert get_upload_max_bytes() == _GB
+    assert get_upload_timeout_seconds() == 3600.0
+
+
+def test_allowlist_drops_nonexistent_entries(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", f"{tmp_path}, ,/does/not/exist/xyz")
+    assert get_upload_allowed_dirs() == [tmp_path.resolve()]
+
+
+def test_getters_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_MAX_BYTES", "123")
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS", "12.5")
+    assert get_upload_max_bytes() == 123
+    assert get_upload_timeout_seconds() == 12.5
+
+
+def test_getters_invalid_env_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_MAX_BYTES", "not-an-int")
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS", "not-a-float")
+    assert get_upload_max_bytes() == _GB
+    assert get_upload_timeout_seconds() == 3600.0
+
+
+def test_getters_nonpositive_env_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_MAX_BYTES", "0")
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS", "-5")
+    assert get_upload_max_bytes() == _GB
+    assert get_upload_timeout_seconds() == 3600.0

--- a/tests/test_upload_policy_file.py
+++ b/tests/test_upload_policy_file.py
@@ -1,0 +1,160 @@
+"""Tests for upload_policy_file: workflow, registration gating, and dispatch."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from conftest import FakeClient, StubClient, StubServer
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.tools import policy_tools
+from automox_mcp.workflows.policy_crud import upload_policy_file
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE",
+        "AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS",
+        "AUTOMOX_MCP_UPLOAD_MAX_BYTES",
+        "AUTOMOX_MCP_UPLOAD_TIMEOUT_SECONDS",
+        "AUTOMOX_MCP_TRANSPORT",
+        "AUTOMOX_MCP_READ_ONLY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _installer(tmp_path) -> str:
+    f = tmp_path / "setup.msi"
+    f.write_bytes(b"MZ\x90\x00binary-installer-bytes")
+    return str(f)
+
+
+# ---------------------------------------------------------------------------
+# workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_streams_file_and_omits_o_for_main_org(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    path = _installer(tmp_path)
+    client = StubClient(post_responses={"/policies/12/files": [{}]})
+
+    result = await upload_policy_file(
+        cast(AutomoxClient, client), org_id=None, policy_id=12, file_path=path
+    )
+
+    method, call_path, payload = client.calls[0]
+    assert method == "POST_MULTIPART"
+    assert call_path == "/policies/12/files"
+    # No `o` query param for the main org.
+    assert payload["params"] is None
+    fname, _handle, ctype = payload["files"]["file"]
+    assert fname == "setup.msi"
+    assert ctype == "application/octet-stream"
+    assert result["data"]["uploaded"] is True
+    assert result["data"]["policy_id"] == 12
+    assert result["data"]["size_bytes"] > 0
+
+
+@pytest.mark.asyncio
+async def test_workflow_sends_o_for_child_org(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    path = _installer(tmp_path)
+    client = StubClient(post_responses={"/policies/9/files": [{}]})
+
+    await upload_policy_file(cast(AutomoxClient, client), org_id=555, policy_id=9, file_path=path)
+
+    _method, _path, payload = client.calls[0]
+    assert payload["params"] == {"o": 555}
+
+
+@pytest.mark.asyncio
+async def test_workflow_rejects_path_outside_allowlist(tmp_path, monkeypatch) -> None:
+    allowed = tmp_path / "ok"
+    allowed.mkdir()
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(allowed))
+    outside = tmp_path / "evil.msi"
+    outside.write_bytes(b"x")
+    client = StubClient()
+
+    with pytest.raises(ValueError, match="outside the allowed"):
+        await upload_policy_file(cast(AutomoxClient, client), policy_id=1, file_path=str(outside))
+    # Nothing was uploaded.
+    assert client.calls == []
+
+
+# ---------------------------------------------------------------------------
+# registration gating
+# ---------------------------------------------------------------------------
+
+
+def _register(tmp_path, monkeypatch, *, read_only=False, **env: str) -> StubServer:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    server = StubServer()
+    policy_tools.register(server, read_only=read_only, client=FakeClient())
+    return server
+
+
+def test_not_registered_without_flag(tmp_path, monkeypatch) -> None:
+    server = _register(tmp_path, monkeypatch, AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS=str(tmp_path))
+    assert "upload_policy_file" not in server.tools
+
+
+def test_registered_with_flag_allowlist_stdio_writes(tmp_path, monkeypatch) -> None:
+    server = _register(
+        tmp_path,
+        monkeypatch,
+        AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE="true",
+        AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS=str(tmp_path),
+    )
+    assert "upload_policy_file" in server.tools
+
+
+def test_not_registered_without_allowlist(tmp_path, monkeypatch) -> None:
+    server = _register(tmp_path, monkeypatch, AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE="true")
+    assert "upload_policy_file" not in server.tools
+
+
+def test_not_registered_in_read_only(tmp_path, monkeypatch) -> None:
+    server = _register(
+        tmp_path,
+        monkeypatch,
+        read_only=True,
+        AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE="true",
+        AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS=str(tmp_path),
+    )
+    assert "upload_policy_file" not in server.tools
+
+
+def test_not_registered_under_remote_transport(tmp_path, monkeypatch) -> None:
+    server = _register(
+        tmp_path,
+        monkeypatch,
+        AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE="true",
+        AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS=str(tmp_path),
+        AUTOMOX_MCP_TRANSPORT="http",
+    )
+    assert "upload_policy_file" not in server.tools
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uploads(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE", "true")
+    monkeypatch.setenv("AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS", str(tmp_path))
+    path = _installer(tmp_path)
+
+    server = StubServer()
+    policy_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+
+    result = await server.tools["upload_policy_file"](policy_id=7, file_path=path)
+    assert result["data"]["uploaded"] is True
+    assert result["data"]["filename"] == "setup.msi"

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -191,17 +191,45 @@ async def test_formats_returns_list() -> None:
 
 
 @pytest.mark.asyncio
-async def test_upload_submits_request() -> None:
-    response = {"id": 3, "status": "pending"}
+async def test_upload_submits_multipart_request() -> None:
+    response = {"id": 3, "status": "building", "organization_id": 42}
     client = StubClient(post_responses={"/orgs/42/remediations/action-sets/upload": [response]})
     result = await upload_action_set(
         cast(AutomoxClient, client),
         org_id=42,
-        action_set_data={"format": "qualys", "csv_data": "..."},
+        csv_content="Hostname,CVE ID\nhost1,CVE-2021-1234",
+        source="qualys",
+        filename="qualys-export.csv",
     )
     assert result["data"]["id"] == 3
-    assert result["data"]["status"] == "pending"
-    assert client.calls[0][0] == "POST"
+    assert result["data"]["status"] == "building"
+
+    method, path, payload = client.calls[0]
+    assert method == "POST_MULTIPART"
+    assert path == "/orgs/42/remediations/action-sets/upload"
+    # source rides the query string; format mirrors it in the body.
+    assert payload["params"] == {"source": "qualys"}
+    assert payload["data"] == {"format": "qualys"}
+    fname, content, ctype = payload["files"]["file"]
+    assert fname == "qualys-export.csv"
+    assert content == b"Hostname,CVE ID\nhost1,CVE-2021-1234"
+    assert ctype == "text/csv"
+
+
+@pytest.mark.asyncio
+async def test_upload_handles_array_response() -> None:
+    # The spec types the 201 body as a one-element array; handle that shape too.
+    client = StubClient(
+        post_responses={
+            "/orgs/42/remediations/action-sets/upload": [[{"id": 9, "status": "building"}]]
+        }
+    )
+    result = await upload_action_set(
+        cast(AutomoxClient, client),
+        org_id=42,
+        csv_content="a,b\n1,2",
+    )
+    assert result["data"]["id"] == 9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #106 — both halves of the binary/multipart-upload backlog, on a new `AutomoxClient.post_multipart` that overrides the client's default `application/json` content-type with the boundary httpx encodes.

## 1. `upload_action_set` (CSV) — fixed
Was non-functional (POSTed JSON). Now sends real `multipart/form-data`. **Contract confirmed against the live tenant:** `source` is a **query param** (enum), the body carries `file` + `format`; the old opaque `500` was `source` sent as a form field with an empty query string. Tool signature moves from a freeform `action_set_data` dict to `csv_content` / `source` / `filename`.

## 2. `upload_policy_file` (installer) — new, gated, local-only
Uploads a local installer (up to **10 GB**) to a Required Software policy via `POST /policies/{id}/files`. Mechanism decision: **`file_path`** (base64 impractical at GB scale; `file_url` rejected to avoid building SSRF defense from scratch for marginal value).

Containment:
- env gate `AUTOMOX_MCP_ALLOW_UPLOAD_POLICY_FILE` (default off)
- **required** directory allowlist `AUTOMOX_MCP_UPLOAD_ALLOWED_DIRS` — paths canonicalized; `..`/symlink escape rejected via `resolve()` + `is_relative_to` (no `startswith` prefix bug)
- size cap `AUTOMOX_MCP_UPLOAD_MAX_BYTES` (default 10 GB), **streamed** not buffered
- **stdio-only** — not registered under a remote transport, and `main()` refuses to start a remote transport while the flag is on (authoritative, since registration can't see the CLI `--transport` flag)

Installer bytes stream straight to Automox and **never pass through the model** (no token cost for file size).

## Counts / docs
Tool count **130 → 132** (84 read / **48** write). Updates count-guarded docs (README, manifest, tool-reference), meta catalog, `api-coverage.md` (both upload rows now covered), and CHANGELOG.

## Security
`/security-review` (OWASP + Python): **APPROVE WITH NOTES**, 0 FAIL. Path containment, fail-closed allowlist, and two-layer local-only enforcement reviewed; added a docstring caveat that the `main()` guarantee covers the CLI entrypoint (embedding `mcp.run()` directly is the embedder's responsibility).

## Caveat
The `upload_policy_file` contract is **spec-derived, not yet live-verified** (the CSV half was). The shape is trivially simple (`file` multipart + `o` query), so spec-≠-reality risk is low — but smoke-test with a throwaway policy + small installer before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)