### PR TITLE
chore: document intentional empty-except blocks (clears py/empty-except)

### DIFF
--- a/src/automox_mcp/client.py
+++ b/src/automox_mcp/client.py
@@ -406,6 +406,8 @@ class AutomoxClient:
             if isinstance(data, Mapping):
                 return data
         except json.JSONDecodeError:
+            # Non-JSON error body (e.g. an HTML gateway page) — intentionally
+            # fall through to returning the raw truncated text below.
             pass
         # Truncate raw text to avoid leaking verbose upstream error pages.
         raw = response.text[:500] if response.text else ""

--- a/src/automox_mcp/workflows/audit.py
+++ b/src/automox_mcp/workflows/audit.py
@@ -406,6 +406,8 @@ def _coerce_datetime(value: Any, depth: int = 0) -> datetime | None:
         try:
             int_value = int(text)
         except ValueError:
+            # Not an integer timestamp — intentionally fall through to the
+            # ISO-8601 parsing attempt below.
             pass
         else:
             return _coerce_datetime(int_value, depth + 1)

--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -64,6 +64,7 @@ try:
             load_dotenv(env_path)
             break
 except ImportError:
+    # python-dotenv is optional; env vars can be supplied directly in the shell.
     pass
 
 # ---------------------------------------------------------------------------
@@ -316,6 +317,7 @@ async def run_http_tests() -> None:
                         uuid.UUID(cid)
                         valid_uuid = True
                     except ValueError:
+                        # Malformed correlation id — leave valid_uuid False.
                         pass
                 record(
                     "correlation_id present and valid UUID",


### PR DESCRIPTION
CodeQL's `py/empty-except` quality rule flags four `pass`-only exception handlers. I assessed each: **none are real defects** — all are intentional control-flow where the swallowed exception routes to a deliberate fallback or pre-set default:

| Location | Why the swallow is correct |
|---|---|
| `client.py` `_extract_error_payload` | non-JSON error body → fall through to returning raw truncated text |
| `audit.py` `_coerce_datetime` | `int(text)` fails → fall through to ISO-8601 parsing |
| `smoke_production.py` (import) | optional `python-dotenv` guard |
| `smoke_production.py` (uuid) | invalid correlation id → leave pre-set `valid_uuid = False` |

Rather than add fake handling, each block now carries a one-line comment explaining the intentional ignore. CodeQL suppresses `py/empty-except` when the handler body contains a comment, so this clears the findings *and* documents intent. **No behavior change** (comments only).

Gate green: ruff/mypy, pytest 1393 passed, coverage 90.72%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)