### PR TITLE
chore: resolve CodeQL + AI code-scanning findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **HTML sanitizer now suppresses the text content of elements carrying a dangerous attribute.** `_HTMLTextExtractor` detected `on*` event handlers and `javascript:`/`data:` URLs in `href`/`src`/`action` but took no action — it dropped the tag (as it does for any tag) while still emitting the element's inner text. The dangerous *value* never reached output (attributes are never emitted), so impact was limited to defence-in-depth, but the detection was effectively dead. The extractor now tracks suppression with a `(tag, skipping)` stack that correctly releases on the matching end tag, skips void elements (`<img>`, `<br>`, …) that have no end tag, tolerates unclosed inner tags, and relies on `HTMLParser` CDATA mode for `<script>`/`<style>`. (The obvious one-line `_skip_depth += 1` fix was rejected — it leaks skip state on non-`script`/`style` tags and self-closing tags, silently swallowing all trailing text.)
+
+### Fixed
+
+- **`docs/tool-reference.md` Table of Contents counts and anchors corrected.** The TOC listed Device Management as 9 tools (header says 11) and Vulnerability Sync as 7 (header says 9); the stale counts also broke the in-page anchor links. The section headers — validated against the registered tool set by `test_doc_tool_counts.py` — were already correct.
+- **`create_policy`/`update_policy` schedule-days error message no longer advertises an unsupported range.** The "Unrecognized day name" message offered numeric indexes "0-6 or 1-7", but `_normalize_schedule_days_input` accepts 0–6 only (1–7 was intentionally removed for its ambiguous Monday/Sunday mapping). Dropped the "or 1-7" clause.
+
+### Changed
+
+- **Code-quality cleanup (CodeQL + AI code-scanning findings), no behavior change.** Removed unused module-level `logger` bindings across 18 tool modules and a dead instruction-strip allowlist superseded by the preserve-list denylist; consolidated redundant/duplicate imports (`json` hoisted in `schemas.py`, `asynccontextmanager` in `server.py`, dead local re-imports in `utils/tooling.py` and `workflows/devices.py`); parenthesized two implicitly-concatenated multi-line strings inside reference list literals to make intent explicit. Added a regression test for the `list_device_packages` auto-pagination safety cap (`_MAX_PACKAGE_PAGES`) — the `metadata.complete = False` truncation signal was previously unverified.
+
 ## [2.0.1] - 2026-06-02
 
 ### Fixed

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -6,7 +6,7 @@ Complete reference for all 133 tools, 6 workflow prompts, MCP resources, paramet
 
 ## Table of Contents
 
-- [Device Management (9 tools)](#device-management-9-tools)
+- [Device Management (11 tools)](#device-management-11-tools)
 - [Advanced Device Search (18 tools)](#advanced-device-search-18-tools)
 - [Policy Management (15 tools)](#policy-management-15-tools)
 - [Policy History v2 (7 tools)](#policy-history-v2-7-tools)
@@ -15,7 +15,7 @@ Complete reference for all 133 tools, 6 workflow prompts, MCP resources, paramet
 - [Webhook Management (9 tools)](#webhook-management-9-tools)
 - [Worklet Catalog (2 tools)](#worklet-catalog-2-tools)
 - [Data Extracts (3 tools)](#data-extracts-3-tools)
-- [Vulnerability Sync (7 tools)](#vulnerability-sync-7-tools)
+- [Vulnerability Sync (9 tools)](#vulnerability-sync-9-tools)
 - [Compound Workflows (3 tools)](#compound-workflows-3-tools)
 - [Events (1 tool)](#events-1-tool)
 - [Reports (2 tools)](#reports-2-tools)

--- a/src/automox_mcp/resources/platform_resources.py
+++ b/src/automox_mcp/resources/platform_resources.py
@@ -332,8 +332,10 @@ def register(server: FastMCP) -> None:
                     "HTTP 429 (Too Many Requests). The MCP server surfaces this as an error."
                 ),
                 "recommendations": [
-                    "Use compound tools (get_patch_tuesday_readiness, get_compliance_snapshot) "
-                    "to reduce the number of individual API calls",
+                    (
+                        "Use compound tools (get_patch_tuesday_readiness, get_compliance_snapshot) "
+                        "to reduce the number of individual API calls"
+                    ),
                     "Use pagination (limit/page parameters) to fetch manageable result sets",
                     "Avoid polling the same endpoint in tight loops",
                 ],

--- a/src/automox_mcp/resources/policy_resources.py
+++ b/src/automox_mcp/resources/policy_resources.py
@@ -202,9 +202,11 @@ def register_policy_resources(server: FastMCP) -> None:
                 "operations": ["create", "update"],
                 "notes": [
                     "Updates require the policy 'id' field",
-                    "schedule_days uses a bitmask "
-                    "(Monday=2, Tuesday=4, Wednesday=8, Thursday=16, "
-                    "Friday=32, Saturday=64, Sunday=128)",
+                    (
+                        "schedule_days uses a bitmask "
+                        "(Monday=2, Tuesday=4, Wednesday=8, Thursday=16, "
+                        "Friday=32, Saturday=64, Sunday=128)"
+                    ),
                     "You can use friendly schedule syntax with a 'schedule' block",
                     "Filter names can be specified using 'filter_name' or 'filter_names' shortcuts",
                 ],

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import date as Date
 from typing import Annotated, Any, Literal
 from uuid import UUID
@@ -936,8 +937,6 @@ class CreateDataExtractParams(OrgIdRequiredMixin, ForbidExtraModel):
 
     @model_validator(mode="after")
     def _limit_extract_data_size(self) -> CreateDataExtractParams:
-        import json
-
         raw = json.dumps(self.extract_data, default=str)
         if len(raw) > 50_000:
             raise ValueError("extract_data payload exceeds 50 KB limit")
@@ -1083,8 +1082,6 @@ class AdvancedDeviceSearchParams(ForbidExtraModel):
     @model_validator(mode="after")
     def _limit_query_size(self) -> AdvancedDeviceSearchParams:
         if self.query is not None:
-            import json
-
             raw = json.dumps(self.query, default=str)
             if len(raw) > 50_000:
                 raise ValueError("query payload exceeds 50 KB limit")
@@ -1119,8 +1116,6 @@ class CreateSavedSearchParams(ForbidExtraModel):
 
     @model_validator(mode="after")
     def _limit_query_size(self) -> CreateSavedSearchParams:
-        import json
-
         raw = json.dumps(self.query, default=str)
         if len(raw) > 50_000:
             raise ValueError("query payload exceeds 50 KB limit")
@@ -1138,8 +1133,6 @@ class UpdateSavedSearchParams(ForbidExtraModel):
         if self.name is None and self.query is None and self.description is None:
             raise ValueError("at least one of name/query/description must be provided")
         if self.query is not None:
-            import json
-
             raw = json.dumps(self.query, default=str)
             if len(raw) > 50_000:
                 raise ValueError("query payload exceeds 50 KB limit")

--- a/src/automox_mcp/server.py
+++ b/src/automox_mcp/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 from importlib import import_module
 from types import ModuleType
 from typing import Any, cast
@@ -38,7 +39,6 @@ def _patch_stdio_transport() -> None:  # pragma: no cover - patches MCP internal
         return
 
     import sys
-    from contextlib import asynccontextmanager
     from io import TextIOWrapper
 
     import anyio
@@ -168,8 +168,6 @@ def create_server() -> FastMCP:
     from .utils.logging import configure_logging
 
     configure_logging()
-
-    from contextlib import asynccontextmanager
 
     client = AutomoxClient()
 

--- a/src/automox_mcp/tools/account_tools.py
+++ b/src/automox_mcp/tools/account_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from typing import Any, Literal
 
@@ -44,8 +43,6 @@ from ..utils.tooling import (
     release_idempotency,
     store_idempotency,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/audit_tools.py
+++ b/src/automox_mcp/tools/audit_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -14,8 +13,6 @@ from ..utils.tooling import (
     call_tool_workflow,
     maybe_format_markdown,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/audit_v2_tools.py
+++ b/src/automox_mcp/tools/audit_v2_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -14,8 +13,6 @@ from ..utils.tooling import (
     maybe_format_markdown,
 )
 from ..workflows.audit_v2 import audit_events_ocsf as _audit_events_ocsf
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/compound_tools.py
+++ b/src/automox_mcp/tools/compound_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -15,8 +14,6 @@ from ..schemas import (
     PatchTuesdayReadinessParams,
 )
 from ..utils.tooling import call_tool_workflow
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/data_extract_tools.py
+++ b/src/automox_mcp/tools/data_extract_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -29,8 +28,6 @@ from ..workflows.data_extracts import (
 from ..workflows.data_extracts import (
     list_data_extracts as _list_data_extracts,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/device_search_tools.py
+++ b/src/automox_mcp/tools/device_search_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -84,8 +83,6 @@ from ..workflows.device_search import (
 from ..workflows.device_search import (
     update_saved_search as _update_saved_search,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/device_tools.py
+++ b/src/automox_mcp/tools/device_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, Literal
 
 from fastmcp import FastMCP
@@ -29,8 +28,6 @@ from ..utils.tooling import (
     release_idempotency,
     store_idempotency,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/event_tools.py
+++ b/src/automox_mcp/tools/event_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -14,8 +13,6 @@ from ..utils.tooling import (
     call_tool_workflow,
     maybe_format_markdown,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/group_tools.py
+++ b/src/automox_mcp/tools/group_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -22,8 +21,6 @@ from ..utils.tooling import (
     maybe_format_markdown,
     store_idempotency,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/package_tools.py
+++ b/src/automox_mcp/tools/package_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -17,8 +16,6 @@ from ..utils.tooling import (
     call_tool_workflow,
     maybe_format_markdown,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/policy_history_tools.py
+++ b/src/automox_mcp/tools/policy_history_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -42,8 +41,6 @@ from ..workflows.policy_history import (
 from ..workflows.policy_history import (
     policy_runs_by_policy as _policy_runs_by_policy,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -36,8 +35,6 @@ from ..utils.tooling import (
     store_idempotency,
 )
 from ..utils.upload import get_upload_allowed_dirs
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/policy_windows_tools.py
+++ b/src/automox_mcp/tools/policy_windows_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, Literal
 from uuid import UUID
 
@@ -162,9 +161,6 @@ class UpdatePolicyWindowParams(ForbidExtraModel):
 class DeletePolicyWindowParams(ForbidExtraModel):
     org_uuid: UUID
     window_uuid: UUID
-
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/report_tools.py
+++ b/src/automox_mcp/tools/report_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -17,8 +16,6 @@ from ..utils.tooling import (
     call_tool_workflow,
     maybe_format_markdown,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/splashtop_tools.py
+++ b/src/automox_mcp/tools/splashtop_tools.py
@@ -20,7 +20,6 @@ require a human in the loop.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -76,8 +75,6 @@ from ..workflows.splashtop import (
 from ..workflows.splashtop import (
     uninstall_splashtop as _uninstall_splashtop,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -54,8 +53,6 @@ from ..workflows.vuln_sync import (
 from ..workflows.vuln_sync import (
     upload_action_set as _upload_action_set,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/webhook_tools.py
+++ b/src/automox_mcp/tools/webhook_tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
-import logging
 import socket
 from typing import Any
 from urllib.parse import urlparse
@@ -211,9 +210,6 @@ class TestWebhookParams(ForbidExtraModel):
 class RotateWebhookSecretParams(ForbidExtraModel):
     org_uuid: UUID
     webhook_id: UUID
-
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/tools/worklet_tools.py
+++ b/src/automox_mcp/tools/worklet_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import FastMCP
@@ -18,8 +17,6 @@ from ..utils.tooling import (
 )
 from ..workflows.worklets import get_worklet_detail as _get_worklet_detail
 from ..workflows.worklets import search_worklet_catalog as _search_worklet_catalog
-
-logger = logging.getLogger(__name__)
 
 
 def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient) -> None:

--- a/src/automox_mcp/utils/sanitize.py
+++ b/src/automox_mcp/utils/sanitize.py
@@ -85,33 +85,89 @@ _INSTRUCTION_PREFIX_PROBE = re.compile(
 
 
 class _HTMLTextExtractor(HTMLParser):
-    """Extract safe text from HTML, dropping tags and dangerous content."""
+    """Extract safe text from HTML, dropping tags and dangerous content.
+
+    Text inside a dangerous *element* is suppressed. An element is dangerous if
+    its tag is in ``_DANGEROUS_TAGS`` (``script``/``style``) **or** it carries a
+    dangerous attribute (an ``on*`` event handler, or a ``javascript:``/``data:``
+    URL in ``href``/``src``/``action``). In every case the tag and its attributes
+    are dropped; only text nodes survive, so the dangerous attribute value itself
+    never reaches the output — suppressing the element's text is defence in depth.
+
+    Suppression is tracked with a stack of ``(tag, skipping)`` frames rather than a
+    bare depth counter so that:
+
+    * a dangerous attribute on an arbitrary tag (e.g. ``<a onclick=...>``) is
+      released by its matching end tag — a counter keyed on ``_DANGEROUS_TAGS``
+      alone would never decrement and would silently swallow all trailing text;
+    * **void** elements (``<img>``, ``<br>``, ...) emit a start tag with no end
+      tag, so they are never pushed (they have no text content to suppress and a
+      pushed frame would leak);
+    * unclosed inner tags are tolerated — an end tag pops down to its matching
+      frame.
+
+    ``<script>``/``<style>`` are parsed by ``HTMLParser`` in CDATA mode, so their
+    raw body (including any ``</a>``-looking text) arrives as a single data event
+    and cannot desynchronise the stack.
+    """
+
+    # Elements with no end tag in the HTML spec — never pushed onto the stack.
+    _VOID_ELEMENTS = frozenset(
+        {
+            "area",
+            "base",
+            "br",
+            "col",
+            "embed",
+            "hr",
+            "img",
+            "input",
+            "link",
+            "meta",
+            "param",
+            "source",
+            "track",
+            "wbr",
+        }
+    )
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
         self._pieces: list[str] = []
-        self._skip_depth: int = 0
+        # Stack of (tag_name, skipping) for currently-open non-void elements.
+        self._stack: list[tuple[str, bool]] = []
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def _skipping(self) -> bool:
+        return bool(self._stack and self._stack[-1][1])
+
+    def _is_dangerous(self, tag: str, attrs: list[tuple[str, str | None]]) -> bool:
         if tag.lower() in _DANGEROUS_TAGS:
-            self._skip_depth += 1
-            return
+            return True
         for attr_name, attr_value in attrs:
             if _EVENT_HANDLER_RE.match(attr_name):
-                return
+                return True
             if (
                 attr_value
                 and attr_name.lower() in ("href", "src", "action")
                 and _DANGEROUS_PROTOCOL_RE.match(attr_value)
             ):
-                return
+                return True
+        return False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        skipping = self._skipping() or self._is_dangerous(tag, attrs)
+        if tag.lower() not in self._VOID_ELEMENTS:
+            self._stack.append((tag.lower(), skipping))
 
     def handle_endtag(self, tag: str) -> None:
-        if tag.lower() in _DANGEROUS_TAGS and self._skip_depth > 0:
-            self._skip_depth -= 1
+        t = tag.lower()
+        for i in range(len(self._stack) - 1, -1, -1):
+            if self._stack[i][0] == t:
+                del self._stack[i:]
+                return
 
     def handle_data(self, data: str) -> None:
-        if self._skip_depth == 0:
+        if not self._skipping():
             self._pieces.append(data)
 
     def get_text(self) -> str:
@@ -156,33 +212,6 @@ _INSTRUCTION_PREFIX_RE = re.compile(
 # ---------------------------------------------------------------------------
 # Field classification
 # ---------------------------------------------------------------------------
-
-# Fields where instruction-prefix stripping is safe to apply.
-# These are free-text fields where users write descriptions/notes.
-_INSTRUCTION_STRIP_FIELDS: frozenset[str] = frozenset(
-    {
-        "notes",
-        "description",
-        "details",
-        "data",
-        "message",
-        "result_reason",
-        "stdout",
-        "stderr",
-        "comments",
-        "reason",
-        "summary",
-        "output",
-        "body",
-        "content",
-        "text",
-        "value",
-        "result",
-        "response",
-        "log",
-        "error",
-    }
-)
 
 # Fields where instruction-prefix stripping should NOT apply because
 # users commonly use words like "IMPORTANT" or "SYSTEM" in names/tags.

--- a/src/automox_mcp/utils/tooling.py
+++ b/src/automox_mcp/utils/tooling.py
@@ -436,8 +436,6 @@ def format_error(exc: AutomoxAPIError) -> str:
     # injections like `IMPORTANT: ...`. Sanitizing first puts each value at its
     # own logical line start where the anchor can fire.
     if is_sanitization_enabled() and safe_payload:
-        from .sanitize import sanitize_dict
-
         safe_payload = sanitize_dict(safe_payload)
     try:
         payload_block = json.dumps(safe_payload, indent=2, sort_keys=True) if safe_payload else None

--- a/src/automox_mcp/workflows/devices.py
+++ b/src/automox_mcp/workflows/devices.py
@@ -921,8 +921,6 @@ async def search_devices(
         # Handle JSON-encoded arrays like '["critical", "high"]'
         stripped = severity.strip()
         if stripped.startswith("["):
-            import json
-
             try:
                 parsed = json.loads(stripped)
                 if isinstance(parsed, list):

--- a/src/automox_mcp/workflows/policy_crud.py
+++ b/src/automox_mcp/workflows/policy_crud.py
@@ -294,7 +294,7 @@ def _expand_day_alias(value: str) -> list[str]:
             return [day_name]
     raise ValueError(
         f"Unrecognized day name '{value}'. Use values like 'monday', 'wed', "
-        "'weekdays', or provide numeric day indexes (0-6 or 1-7)."
+        "'weekdays', or provide numeric day indexes (0-6)."
     )
 
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -6,6 +6,7 @@ import os
 from unittest.mock import patch
 
 from automox_mcp.utils.sanitize import (
+    _strip_html,
     is_sanitization_enabled,
     sanitize_dict,
     sanitize_for_llm,
@@ -367,3 +368,47 @@ class TestFastPath:
         text = "ＩＭＰＯＲＴＡＮＴ:　test"
         result = sanitize_for_llm(text, field_name="notes")
         assert "IMPORTANT:" not in result
+
+
+# ---------------------------------------------------------------------------
+# _strip_html — HTML tag / dangerous-element removal
+# ---------------------------------------------------------------------------
+
+
+class TestStripHTML:
+    def test_drops_tags_keeps_benign_text(self):
+        assert _strip_html('<a href="https://example.com">Link text</a>') == "Link text"
+
+    def test_suppresses_script_content(self):
+        assert _strip_html("<script>alert(1)</script>safe") == "safe"
+
+    def test_suppresses_style_content(self):
+        assert _strip_html("<style>.x{color:red}</style>kept") == "kept"
+
+    def test_cdata_inner_close_tag_does_not_desync(self):
+        # <script> is parsed in CDATA mode: the inner </a> is body text, not a
+        # real end tag, so it must not pop the script frame and leak "tail".
+        assert _strip_html("<script>a</a>b</script>tail") == "tail"
+
+    def test_suppresses_text_of_event_handler_element(self):
+        assert _strip_html('<a onclick="steal()">Click me</a>') == ""
+
+    def test_suppresses_text_of_javascript_url_element(self):
+        # The element's text is dropped AND trailing text after the close tag is
+        # preserved — i.e. skip state is released, not leaked, by the end tag.
+        assert _strip_html('<a href="javascript:alert(1)">Click</a> Trailing.') == " Trailing."
+
+    def test_dangerous_void_element_does_not_leak(self):
+        # <img> is a void element (no end tag); a naive depth counter would stay
+        # elevated and swallow the caption. The stack must not push void tags.
+        assert _strip_html('<img src="javascript:bad()"> Visible caption.') == " Visible caption."
+        assert _strip_html('<img src="javascript:bad()"/> Caption2.') == " Caption2."
+
+    def test_nested_dangerous_element_scopes_suppression(self):
+        assert _strip_html('<div><a onclick="x">bad</a>good</div>') == "good"
+
+    def test_unclosed_inner_tag_tolerated(self):
+        assert _strip_html("<div><span>unclosed</div>after") == "unclosedafter"
+
+    def test_data_uri_src_suppressed(self):
+        assert _strip_html('<a href="data:text/html,evil">x</a>tail') == "tail"

--- a/tests/test_tool_titles.py
+++ b/tests/test_tool_titles.py
@@ -11,8 +11,7 @@ import pytest
 from conftest import FakeClient
 from fastmcp import FastMCP
 
-import automox_mcp.tools as tools_mod
-from automox_mcp.tools import _humanize_tool_name, register_tools
+from automox_mcp.tools import _apply_tool_titles, _humanize_tool_name, register_tools
 
 
 @pytest.mark.parametrize(
@@ -75,4 +74,4 @@ def test_apply_titles_noop_on_stub_without_local_provider() -> None:
         pass
 
     # Should return silently rather than AttributeError.
-    tools_mod._apply_tool_titles(Bare())
+    _apply_tool_titles(Bare())

--- a/tests/test_workflows_packages.py
+++ b/tests/test_workflows_packages.py
@@ -7,6 +7,7 @@ from conftest import StubClient
 
 from automox_mcp.client import AutomoxAPIError, AutomoxClient
 from automox_mcp.workflows.packages import (
+    _MAX_PACKAGE_PAGES,
     list_device_packages,
     search_org_packages,
 )
@@ -143,6 +144,30 @@ async def test_list_packages_auto_paginates_until_short_page() -> None:
     names = [p["name"] for p in result["data"]["packages"]]
     assert "nginx" in names  # the package on the second page is not lost
     assert result["metadata"]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_packages_auto_paginate_hits_safety_cap() -> None:
+    """A host with more pages than the cap stops at _MAX_PACKAGE_PAGES and flags incomplete.
+
+    With page_size 2 and every page full, pagination never sees a short page,
+    so it walks exactly _MAX_PACKAGE_PAGES pages and reports complete=False —
+    the signal that the result is truncated, not exhaustive.
+    """
+    # One full page (size 2) per cap slot — never a short page to end early.
+    full_pages = [
+        [{"id": 2 * n, "name": f"pkg{2 * n}"}, {"id": 2 * n + 1, "name": f"pkg{2 * n + 1}"}]
+        for n in range(_MAX_PACKAGE_PAGES)
+    ]
+    client = StubClient(get_responses={"/servers/101/packages": full_pages})
+    result = await list_device_packages(
+        cast(AutomoxClient, client), org_id=555, device_id=101, limit=2
+    )
+
+    assert result["data"]["total_packages"] == _MAX_PACKAGE_PAGES * 2
+    assert result["metadata"]["complete"] is False
+    # The cap bounds the loop: exactly _MAX_PACKAGE_PAGES fetches, no over-run.
+    assert len(client.calls) == _MAX_PACKAGE_PAGES
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves the open **code-quality** scanning findings — five CodeQL quality rules and six AI findings. No tool-set changes (counts unchanged, doc-count guard green); no public-API behavior change **except** a security hardening in the HTML sanitizer.

## CodeQL quality rules

| Rule | Action |
|---|---|
| `py/unused-global-variable` | Removed 18 unused `logger` bindings + the dead `_INSTRUCTION_STRIP_FIELDS` allowlist (superseded by the `_PRESERVE_PREFIX_FIELDS` denylist). |
| `py/import-and-import-from` | Consolidated the one top-level dual import (`test_tool_titles`). The other 6 are intentional function-local monkeypatch/reload imports — left as-is (recommend dismiss). |
| `py/implicit-string-concatenation-in-list` | Parenthesized 2 wrapped multi-line strings in reference list literals. |
| `py/repeated-import` | Hoisted `json` (`schemas.py`) and `asynccontextmanager` (`server.py`); removed dead local re-imports in `utils/tooling.py`, `workflows/devices.py`. Test-file repeats left as-is (per-test locality). |
| `py/catch-base-exception` | **No change.** All 39 are correct cancellation-safe idempotency-release handlers that re-raise (`asyncio.CancelledError` is a `BaseException`; narrowing to `Exception` would leak idempotency keys). Recommend dismiss. |

## AI findings

- **Sanitizer hardening (Security):** `_HTMLTextExtractor` detected dangerous attributes (`on*`, `javascript:`/`data:` URLs) but took no action. Reworked to suppress the element's text via a `(tag, skipping)` stack handling void elements, self-closing tags, unclosed inner tags, and `<script>`/`<style>` CDATA. The naive `_skip_depth += 1` fix was proven to leak (swallows all trailing text after any dangerous-attr element) and rejected. 10 regression tests added.
- **tool-reference TOC drift:** Device Management 9→11, Vulnerability Sync 7→9 (counts **and** broken anchors). Section headers were already correct (guarded).
- **policy_crud message:** dropped unsupported "or 1-7" from the schedule-days error (only 0–6 is accepted).
- **packages cap test:** added coverage for the `_MAX_PACKAGE_PAGES` safety cap and its `metadata.complete = False` signal (exact fetch-count asserted).
- **AuthRateLimitMiddleware thread-safety:** **no change** — ASGI middleware runs on a single event-loop thread; no cross-thread access. Recommend dismiss.

## Gate
`ruff format --check` · `ruff check` · `mypy` · `pytest` (1404 passed, coverage 91%) · `bandit` · doc-count guard — all green locally (pre-push hook enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)