### PR TITLE
release: 2.0.2 — device_filters contract fixes + preview hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.2] - 2026-06-03
 
 ### Security
 
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`preview_policy_device_filters` description and smoke coverage now reflect the verified contract.** The tool description and `docs/tool-reference.md` state that `server_groups` is required when `device_filters` is provided (pass the groups the policy targets; clauses apply within that scope). The smoke suite's preview check now asserts correctness instead of "got a response": the reported `total_devices` must match the returned device list (catches the envelope-wrapped-as-one-device regression), and a filter for a nonexistent tag must narrow the group scope to exactly 0 devices (catches a silently-ignored filter).
 - **Code-quality cleanup (CodeQL + AI code-scanning findings), no behavior change.** Removed unused module-level `logger` bindings across 18 tool modules and a dead instruction-strip allowlist superseded by the preserve-list denylist; consolidated redundant/duplicate imports (`json` hoisted in `schemas.py`, `asynccontextmanager` in `server.py`, dead local re-imports in `utils/tooling.py` and `workflows/devices.py`); parenthesized two implicitly-concatenated multi-line strings inside reference list literals to make intent explicit. Added a regression test for the `list_device_packages` auto-pagination safety cap (`_MAX_PACKAGE_PAGES`) — the `metadata.complete = False` truncation signal was previously unverified.
 
 ## [2.0.1] - 2026-06-02

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -77,7 +77,7 @@ Uses the Server Groups API v2 for structured device queries, saved searches, and
 - **`policy_detail`** - Retrieve configuration and recent history for a policy.
 - **`policy_compliance_stats`** - Retrieve per-policy compliance statistics showing compliant vs. non-compliant device counts and compliance rates.
 - **`apply_policy_changes`** - Preview or submit structured policy create/update operations. Automatically normalizes helper fields (`filter_name`, `filter_names`) and friendly schedule blocks into Automox's expected payloads, ensuring required fields (e.g., `schedule_days`, `schedule_time`) are present before submission.
-- **`preview_policy_device_filters`** - Dry-run: preview which devices a policy's device filters and/or server groups would target, before creating or updating the policy. Read-only — nothing is created or changed.
+- **`preview_policy_device_filters`** - Dry-run: preview which devices a policy's targeting would resolve to, before creating or updating the policy. Read-only — nothing is created or changed. `server_groups` is required when `device_filters` is provided (the upstream preview cannot evaluate a filter-only target): pass the groups the policy will be assigned to, and the `device_filters` clauses (`{field, op, value}`) are applied within that scope.
 - **`list_devices_for_policies`** - List the devices currently targeted by one or more policies (by policy UUID) — blast-radius assessment before executing or changing a policy. Read-only.
 - **`patch_approvals_summary`** - Summarize pending patch approvals and their severity.
 - **`decide_patch_approval`** - Approve or reject an Automox patch approval request.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.0.1"
+version = "2.0.2"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.0.1",
+  "automox-mcp>=2.0.2",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.0.1"
+version = "2.0.2"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -252,9 +252,13 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     @server.tool(
         name="preview_policy_device_filters",
         description=(
-            "Dry-run: preview which devices a policy's device filters and/or "
-            "server groups would target, before creating or updating the policy. "
-            "Read-only — nothing is created or changed."
+            "Dry-run: preview which devices a policy's targeting would resolve "
+            "to, before creating or updating the policy. Read-only — nothing is "
+            "created or changed. server_groups is REQUIRED when device_filters "
+            "is provided (the upstream preview cannot evaluate a filter-only "
+            "target): pass the groups the policy will be assigned to, and the "
+            "device_filters clauses ({field, op, value}) are applied within "
+            "that scope."
         ),
         annotations={
             "readOnlyHint": True,

--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -1228,17 +1228,44 @@ async def run_readonly_tools() -> None:
         # ---- Policy device-targeting ----
         log.info(f"\n{BOLD}Phase 4: Policy device-targeting{RESET}")
 
-        # 79. preview_policy_device_filters — must pass a VALID target. An empty
-        # body 500s upstream ("garbage in"); a real server_groups id exercises
-        # the working path (verified live). device_filters also works but each
-        # field accepts only specific operators, so a real group is simplest.
+        # 79. preview_policy_device_filters — assert CORRECTNESS, not just 200.
+        # The {results, size} envelope was once mis-parsed as ONE device
+        # (total_devices=1 for any result set), and a wrong-but-200 preview
+        # defeats the tool's purpose as a blast-radius check. Two assertions:
+        # the reported total matches the returned device list, and a filter for
+        # a nonexistent tag narrows the group scope to exactly 0 devices.
+        # (server_groups is required alongside device_filters — a filter-only
+        # body 500s upstream and is now rejected client-side.)
         if group_id:
-            resp = await _safe_call(
+            base = await _safe_call(
                 session,
                 "preview_policy_device_filters",
-                {"server_groups": [group_id], "limit": 2},
+                {"server_groups": [group_id]},
             )
-            record("preview_policy_device_filters", resp is not None, _data_keys(resp))
+            filt = await _safe_call(
+                session,
+                "preview_policy_device_filters",
+                {
+                    "server_groups": [group_id],
+                    "device_filters": [
+                        {"field": "tag", "op": "in", "value": ["smoke-no-such-tag-zzz"]}
+                    ],
+                },
+            )
+            base_data = (base or {}).get("data", {})
+            filt_data = (filt or {}).get("data", {})
+            base_total = base_data.get("total_devices")
+            filt_total = filt_data.get("total_devices")
+            ok = (
+                isinstance(base_total, int)
+                and base_total == len(base_data.get("devices") or [])
+                and filt_total == 0
+            )
+            record(
+                "preview_policy_device_filters",
+                ok,
+                f"group scope={base_total}, impossible-tag filter={filt_total} (expect 0)",
+            )
         else:
             record("preview_policy_device_filters", True, "skipped — no server group (OK)")
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Release PR for **2.0.2**. Ships the device_filters contract fixes (#138) and the preview parsing/guard fixes (#140), plus the verified-contract hardening folded into this PR.

## In this PR

- Version bump across all four manifests: `pyproject.toml`, `server.json` (incl. `packages[].version`), `mcpb/manifest.json`, `mcpb/pyproject.toml` (version **and** `automox-mcp>=` floor).
- CHANGELOG stamped `[2.0.2] - 2026-06-03`.
- `preview_policy_device_filters` description + `docs/tool-reference.md` now state `server_groups` is required when `device_filters` is provided.
- Smoke preview check hardened: asserts `total_devices` matches the device list (catches the envelope-wrapped-as-one-device regression) and that an impossible-tag filter resolves to exactly 0 (catches a silently-ignored filter).

## Release contents (already on main)

- **#138** — policy `device_filters` silent-drop: correct `{field, op, value}` shape in guidance resources, local clause validation, `device_filters_enabled` auto-set for all policy types.
- **#140** — preview tool: `{results, size}` envelope parsed correctly (was `total_devices: 1` for everything); filter-only/empty requests pre-empted with actionable guidance instead of an opaque upstream 500.
- HTML sanitizer dangerous-attribute suppression (Security), doc-count/TOC fixes, schedule-days message fix, CodeQL cleanup.

## Gate

- Full local gate green: ruff format/check, mypy, **1410 passed, coverage 90.97%**.
- Smoke suite (manual pre-tag gate) to be run against the live tenant after merge, before the tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)