### PR TITLE
docs: ADS family requires org-scoped API key; tag search uses TAGS scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Documented the Advanced Device Search key-scope requirement and `TAGS` search scope.** Verified live (2026-06-04): the Server Groups API v2 search endpoints (`advanced_device_search`, `device_search_typeahead`, saved-search CRUD, `list_searches_for_device`, `get_device_assignments`) return a uniform `403` for global/account-scoped API keys regardless of role, and work with org-scoped keys — while other endpoints in the same family (`get_searchable_fields`, `list_devices_for_policies`) accept either. The README previously claimed "both global and org-scoped API keys work"; it now recommends an org-scoped key and lists the affected tools. `docs/api-coverage.md` records the verified behavior. The `advanced_device_search` description also now shows that tag search uses scope `TAGS` (not `DEVICE`): `{"scope": "TAGS", "field": "tag", "operator": "IN", "values": [...]}` — confirmed live against a known tag census.
+
 ## [2.0.2] - 2026-06-03
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You need three values from the [Automox Console](https://console.automox.com):
 | **Account UUID** | Settings > Secrets & Keys (shown on the page) |
 | **Org ID** | The numeric ID in the URL when viewing your organization |
 
-> Both global and org-scoped API keys work. API Key and Account UUID are always required. Org ID is recommended but optional — some tools that don't require org context will work without it.
+> **Use an org-scoped API key.** Most tools accept either key type, but the Advanced Device Search family (`advanced_device_search`, `device_search_typeahead`, saved-search create/read/update/delete, `list_searches_for_device`, `get_device_assignments`) returns `403` with a global/account-scoped key — the upstream Server Groups API only accepts org-scoped keys for those endpoints (verified live). API Key and Account UUID are always required. Org ID is recommended but optional — some tools that don't require org context will work without it.
 
 ### 2. Create a `.env` file
 

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -92,6 +92,18 @@ The documented-surface build items from [#111](https://github.com/AutomoxCommuni
 
 ---
 
+## API key scope requirement — Advanced Device Search family
+
+The Server Groups API v2 search endpoints **only accept org-scoped API keys**; a global/account-scoped key gets a uniform `403` regardless of the caller's role (verified live 2026-06-04: global-admin account key → 403 on every org; org-scoped key → 200 with correct results on the same org). Affected tools:
+
+`advanced_device_search`, `device_search_typeahead`, `create_saved_search`, `update_saved_search`, `delete_saved_search`, `list_saved_searches`, `list_searches_for_device`, `get_device_assignments`
+
+Other `/server-groups-api/` endpoints (`get_searchable_fields` / metadata, `list_devices_for_policies`) **do** accept either key type — the restriction is endpoint-level, not family-wide. Classic v1 endpoints (`/servers`, `/policies`, …) accept either. The README setup instructions recommend an org-scoped key for this reason. A `403` on these tools is a key-scope symptom, not a permissions/role problem — re-issue the key at the org level.
+
+(Automox's public docs don't state this restriction as of 2026-06-04 — the global-keys doc's permission-inheritance language suggests the opposite.)
+
+---
+
 ## Webhooks API coverage
 
 The Webhooks API (`Automox Webhooks API` v1.0.0) is published as a **separate** OpenAPI document from the Console API bundle. It defines 9 paths; the server now wraps **all of them**:

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -50,7 +50,7 @@ Complete reference for all 133 tools, 6 workflow prompts, MCP resources, paramet
 Uses the Server Groups API v2 for structured device queries, saved searches, and UUID-based lookups. Read-only tools are always registered; write tools (create/update/delete/assign) are gated by `read_only=False`.
 
 - **`list_saved_searches`** - List saved device searches with names, queries, and metadata.
-- **`advanced_device_search`** - Execute an advanced device search using structured query language. Enables complex queries like "find all Windows devices not seen in 30 days" using field-based filtering.
+- **`advanced_device_search`** - Execute an advanced device search using structured query language. Enables complex queries like "find all Windows devices not seen in 30 days" using field-based filtering. Tag search uses scope `TAGS` (field `tag`). Requires an org-scoped API key — global/account keys get HTTP 403 (applies to the whole search family; see `docs/api-coverage.md`).
 - **`device_search_typeahead`** - Get typeahead suggestions for device search fields. Useful for discovering valid values when building queries.
 - **`get_device_metadata_fields`** - Get available fields for device queries. Returns field names and types supported by the advanced search API.
 - **`get_device_assignments`** - Get device-to-policy and device-to-group assignments.

--- a/src/automox_mcp/tools/device_search_tools.py
+++ b/src/automox_mcp/tools/device_search_tools.py
@@ -117,9 +117,12 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "`filters` list of AND/OR groups, each a list of conditions: "
             '`{"filters": [{"AND": [{"scope": "SOFTWARE", "field": '
             '"pkgDisplayName", "operator": "IN", "values": ["nginx"]}]}]}`. '
+            'Tag search uses scope TAGS (not DEVICE): `{"scope": "TAGS", '
+            '"field": "tag", "operator": "IN", "values": ["Nginx"]}`. '
             "Use `get_searchable_fields` for valid scope/field/operator combos "
             "and `device_search_typeahead` to discover values. The org is scoped "
-            "automatically. `limit` sets the page size."
+            "automatically. `limit` sets the page size. Requires an org-scoped "
+            "API key — a global/account key gets HTTP 403 on this endpoint."
         ),
         annotations={
             "readOnlyHint": True,


### PR DESCRIPTION
## Summary

Documents two live-verified facts about the Advanced Device Search family so they aren't re-derived:

1. **Key scope requirement.** The Server Groups API v2 search endpoints return a uniform `403` for global/account-scoped API keys regardless of the caller's role, and work with org-scoped keys (verified live: global-admin account key → 403 on every org it could see; org-scoped key → 200 with correct results on the same org). Other endpoints in the same family (`get_searchable_fields`, `list_devices_for_policies`) accept either key type — the restriction is endpoint-level. The README previously claimed "both global and org-scoped API keys work"; it now recommends an org-scoped key and lists the affected tools. `docs/api-coverage.md` records the full finding.
2. **Tag search scope.** Tag conditions use scope `TAGS` (not `DEVICE`): `{"scope": "TAGS", "field": "tag", "operator": "IN", "values": [...]}`. Confirmed live against a known tag census — filtered counts matched exactly. Added to the `advanced_device_search` description and tool reference.

Affected tools (403 with a global key): `advanced_device_search`, `device_search_typeahead`, `create/update/delete/list_saved_searches`, `list_searches_for_device`, `get_device_assignments`.

Docs/description-only — no behavior change. Full local gate green (1410 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)