### PR TITLE
docs: explain org vs global API key differences in README + .env.example hint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
 # Automox API credentials
+#
+# Use an ORG-SCOPED API key (zone Settings > Secrets & Keys). A global/account
+# key works for most tools but gets HTTP 403 on the Advanced Device Search
+# family (advanced_device_search, device_search_typeahead, saved searches,
+# list_searches_for_device, get_device_assignments) — see README "key types".
 AUTOMOX_API_KEY=your_api_key_here
 AUTOMOX_ACCOUNT_UUID=your_account_uuid_here
 AUTOMOX_ORG_ID=your_org_id_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **README now explains the two API key types, not just which to pick.** Added an org-scoped vs global/account key comparison (scope, where each is created, tool coverage) to the credentials section, a "wrong key type" symptom line (403 on the search family while reads work elsewhere = key scope, not permissions), and a key-type hint in `.env.example` — so a holder of a global key can recognize it and mint the right one instead of just being told "use org-scoped."
 - **Documented the Advanced Device Search key-scope requirement and `TAGS` search scope.** Verified live (2026-06-04): the Server Groups API v2 search endpoints (`advanced_device_search`, `device_search_typeahead`, saved-search CRUD, `list_searches_for_device`, `get_device_assignments`) return a uniform `403` for global/account-scoped API keys regardless of role, and work with org-scoped keys — while other endpoints in the same family (`get_searchable_fields`, `list_devices_for_policies`) accept either. The README previously claimed "both global and org-scoped API keys work"; it now recommends an org-scoped key and lists the affected tools. `docs/api-coverage.md` records the verified behavior. The `advanced_device_search` description also now shows that tag search uses scope `TAGS` (not `DEVICE`): `{"scope": "TAGS", "field": "tag", "operator": "IN", "values": [...]}` — confirmed live against a known tag census.
 
 ## [2.0.2] - 2026-06-03

--- a/README.md
+++ b/README.md
@@ -29,11 +29,19 @@ You need three values from the [Automox Console](https://console.automox.com):
 
 | Value | Where to find it |
 |---|---|
-| **API Key** | Settings > Secrets & Keys > Add API Key ([docs](https://docs.automox.com/product/Product_Documentation/Settings/Managing_Keys.htm)) |
+| **API Key** | Use an **org-scoped** key — zone **Settings > Secrets & Keys > Add API Key** ([docs](https://docs.automox.com/product/Product_Documentation/Settings/Managing_Keys.htm)); see key types below |
 | **Account UUID** | Settings > Secrets & Keys (shown on the page) |
 | **Org ID** | The numeric ID in the URL when viewing your organization |
 
-> **Use an org-scoped API key.** Most tools accept either key type, but the Advanced Device Search family (`advanced_device_search`, `device_search_typeahead`, saved-search create/read/update/delete, `list_searches_for_device`, `get_device_assignments`) returns `403` with a global/account-scoped key — the upstream Server Groups API only accepts org-scoped keys for those endpoints (verified live). API Key and Account UUID are always required. Org ID is recommended but optional — some tools that don't require org context will work without it.
+Automox has **two API key types**, and the difference matters here:
+
+| | **Org-scoped key** (recommended) | **Global / account key** |
+|---|---|---|
+| Scope | One organization — the zone it was created in | Every org in the account; inherits the key owner's role per org |
+| Created at | Zone **Settings > Secrets & Keys** | Account **Global Access Management > Keys** (Full Administrator) |
+| Tool coverage | **All tools** | All *except* the Advanced Device Search family — `advanced_device_search`, `device_search_typeahead`, saved-search create/read/update/delete, `list_searches_for_device`, `get_device_assignments` — which return `403` (the upstream Server Groups API only accepts org-scoped keys for those endpoints; verified live) |
+
+> **Symptom of the wrong key type:** `403` on the search tools while reads work everywhere else — that's the key scope, not your permissions. API Key and Account UUID are always required. Org ID is recommended but optional — some tools that don't require org context will work without it.
 
 ### 2. Create a `.env` file
 
@@ -100,7 +108,7 @@ For the full list of tools, parameters, and MCP resources, see the **[Tool Refer
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `AUTOMOX_API_KEY` | Yes | — | Automox API key |
+| `AUTOMOX_API_KEY` | Yes | — | Automox API key (org-scoped recommended — see [key types](#1-get-your-automox-credentials)) |
 | `AUTOMOX_ACCOUNT_UUID` | Yes | — | Account UUID from Secrets & Keys |
 | `AUTOMOX_ORG_ID` | Recommended | — | Numeric organization ID (required by most tools) |
 | `AUTOMOX_MCP_READ_ONLY` | No | `false` | Disable all write operations (85 of 133 tools remain) |


### PR DESCRIPTION
## Summary

Follow-up to #143, which said *which* key type to use without explaining the two types. A reader holding a global key couldn't tell which kind they had or where to mint the right one — exactly how the ADS-403 confusion happened in the field.

## Changes

- **README credentials section:** org-scoped vs global/account comparison table — scope, where each is created (zone Settings > Secrets & Keys vs account Global Access Management), and tool coverage (global keys 403 on the ADS family).
- **Symptom line:** 403 on the search tools while reads work everywhere else = key scope, not permissions.
- **Env-var table:** `AUTOMOX_API_KEY` row links to the key-types section.
- **`.env.example`:** comment hint on the key-type requirement.

Docs-only. Full suite green (1410 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)