### PR TITLE
release: 2.0.3 — self-diagnosing ADS 403s, TAGS scope guidance, key-type docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.3] - 2026-06-04
 
 ### Changed
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 9 MCP resources, and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.0.2"
+version = "2.0.3"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.0.2",
+  "automox-mcp>=2.0.3",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.0.2"
+version = "2.0.3"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Release PR for **2.0.3**. Ships the model-facing runtime improvements from #143–#146 — two of which installed users only get via a release:

- **`TAGS` search scope** in the `advanced_device_search` description (a model without it plausibly uses scope `DEVICE` and 400s).
- **Self-diagnosing ADS 403s** — the bare upstream 403 now carries the key-scope hint at the failure point.
- Corrected key-type documentation (org vs global comparison, symptom line, `.env.example` hint) and the ADS authorization observation matrix in `docs/api-coverage.md`.

## In this PR

- Version bump across all four manifests: `pyproject.toml`, `server.json` (incl. `packages[].version`), `mcpb/manifest.json`, `mcpb/pyproject.toml` (version **and** `automox-mcp>=` floor).
- CHANGELOG stamped `[2.0.3] - 2026-06-04`.

## Gate

- Full local gate green (1413 passed, coverage 91.00%).
- Smoke suite (manual pre-tag gate) to be run against the live tenant after merge, before the tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)