### PR TITLE
ci: verify-publish — refresh uv index per retry, widen window to ~15 min

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
   verify-publish:
     needs: publish
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions: {}
     steps:
       - name: Set up uv
@@ -249,17 +249,25 @@ jobs:
           python-version: "3.13"
           enable-cache: false
 
+      # Two hard-won details (v2.0.3): (1) uv caches simple-index responses,
+      # so without --refresh-package every retry after a too-early first
+      # attempt replays the cached "no such version" miss instead of
+      # re-checking PyPI. (2) Index propagation occasionally exceeds the old
+      # 2-minute window (6x20s), failing the run and costing ~20 attended
+      # minutes to diagnose and rerun. Runner minutes are free; the loop
+      # exits on the first success, so the generous 15-minute ceiling costs
+      # nothing on a normal day.
       - name: Install published package from PyPI and boot it
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Verifying automox-mcp==${VERSION} installs from PyPI and boots..."
-          for i in $(seq 1 6); do
-            if uvx --from "automox-mcp==${VERSION}" automox-mcp --help > /dev/null 2>&1; then
+          for i in $(seq 1 30); do
+            if uvx --refresh-package automox-mcp --from "automox-mcp==${VERSION}" automox-mcp --help > /dev/null 2>&1; then
               echo "Published package installs and the entry point boots."
               exit 0
             fi
-            echo "  attempt ${i}/6: not installable yet (PyPI CDN propagation?), sleeping 20s..."
-            sleep 20
+            echo "  attempt ${i}/30: not installable yet (PyPI index propagation?), sleeping 30s..."
+            sleep 30
           done
-          echo "::error::Published automox-mcp==${VERSION} failed to install/boot from PyPI."
+          echo "::error::Published automox-mcp==${VERSION} failed to install/boot from PyPI after ~15 minutes."
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`verify-publish` no longer loses the race to PyPI index propagation (CI only).** The v2.0.3 run failed despite a healthy publish, for two compounding reasons: uv caches simple-index responses, so after a too-early first attempt every retry replayed the cached "no such version" miss instead of re-checking PyPI; and the retry window (6×20s ≈ 2 min) was shorter than occasional index-propagation lag. The install check now passes `--refresh-package automox-mcp` and retries for up to ~15 minutes (30×30s; job timeout raised 10→20 min). The loop still exits on the first success, so a normal release pays nothing — the ceiling only spends free runner minutes on slow days, instead of attended minutes diagnosing and rerunning a red release.
+
 ## [2.0.3] - 2026-06-04
 
 ### Changed


### PR DESCRIPTION
## Summary

The v2.0.3 `verify-publish` failed despite a fully healthy publish, costing ~20 attended minutes to diagnose and rerun. Two compounding causes, both fixed:

1. **uv caches simple-index responses.** After a too-early first attempt, every retry replayed the cached "no such version" miss instead of re-checking PyPI (reproduced locally: plain `uvx` failed while `--refresh-package` succeeded against the same index). The check now passes `--refresh-package automox-mcp`.
2. **The window was sized to human patience, not PyPI's tail.** 6×20s ≈ 2 min loses the race when index propagation runs long. Now 30×30s ≈ 15 min, job timeout 10→20 min. The loop exits on first success — a normal release pays nothing; the ceiling trades free runner minutes for attended ones.

CI-only change (workflow + CHANGELOG). No code or tooling touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)