### PR TITLE
fix: translate policy status codes, add compliance rollup, rename uptime to uptime_minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`device_detail` now emits a device-level `compliance` rollup.** Counts per policy state plus the named policies in `needs_remediation`, and a note encoding the rule (verified live across ~20 devices): a device is non-compliant when at least one policy needs remediation — pending policies alone do not count against compliance. Previously the model had to derive all of this from raw per-policy entries.
+
 ### Fixed
+
+- **Per-policy status codes in `device_detail` are now translated instead of passed through raw.** `GET /servers` `policy_status[].status` is an integer enum — `0 = needs_remediation`, `1 = up_to_date`, `2 = pending` (confirmed against the Console API spec and cross-checked live against the `status.policy_statuses[].compliant` booleans: code 1 is the only value paired with `compliant: true`). The summarizer previously stringified the integers verbatim (`"1"`/`"2"`), forcing the model to guess a mapping — and in observed use it guessed one that inverted compliant and non-compliant. Worse, code 0 (needs remediation — falsy) fell through a truthiness chain to absent alternate keys and surfaced as `"unknown"`, so the one state that demands action was the one reported least clearly. The mapping is applied in the policy-entry summarizer, not in the generic status normalizer, because other Automox enums reuse these integers with different meanings.
+- **`uptime` renamed to `uptime_minutes` in `device_detail` — the public spec's unit is wrong.** The Console API spec describes `Server.uptime` as "measured in seconds", but live verification against known device boot times (2026-06-04) shows the value is **minutes**, sampled at the device's last full scan — so it can also lag the current boot session. The unit-less raw key invited bad inferences (an observed session read ~6.7k minutes ≈ 4.7 days as possibly "~9 months of uptime"). The projection now emits `uptime_minutes` as an integer, and the tool description carries the sampled-at-last-scan caveat.
 
 - **`verify-publish` no longer loses the race to PyPI index propagation (CI only).** The v2.0.3 run failed despite a healthy publish, for two compounding reasons: uv caches simple-index responses, so after a too-early first attempt every retry replayed the cached "no such version" miss instead of re-checking PyPI; and the retry window (6×20s ≈ 2 min) was shorter than occasional index-propagation lag. The install check now passes `--refresh-package automox-mcp` and retries for up to ~15 minutes (30×30s; job timeout raised 10→20 min). The loop still exits on the first success, so a normal release pays nothing — the ceiling only spends free runner minutes on slow days, instead of attended minutes diagnosing and rerunning a red release.
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -34,7 +34,7 @@ Complete reference for all 133 tools, 6 workflow prompts, MCP resources, paramet
 ## Device Management (11 tools)
 
 - **`list_devices`** - Summarize device inventory and policy status across the organization. Returns each device's `uuid` (needed by policy windows tools). Includes unmanaged devices by default and supports `policy_status`/`managed` filters so you can zero in on, for example, non-compliant managed endpoints.
-- **`device_detail`** - Return curated device context (recent policy status, assignments, queued commands, key facts). Pass `include_raw_details=true` only when you explicitly need a sanitized slice of the raw Automox payload.
+- **`device_detail`** - Return curated device context (recent policy status, assignments, queued commands, key facts). Per-policy status codes are translated (`up_to_date` / `pending` / `needs_remediation`) and a `compliance` rollup names the policies needing remediation — only those make a device non-compliant. `uptime_minutes` is sampled at the device's last full scan, so it can lag the current boot session. Pass `include_raw_details=true` only when you explicitly need a sanitized slice of the raw Automox payload.
 - **`devices_needing_attention`** - Surface Automox devices flagged for immediate action.
 - **`search_devices`** - Search Automox devices by hostname, IP, tag, status, or severity of missing patches. Supports multi-severity filtering (e.g., `["critical", "high"]`).
 - **`device_health_metrics`** - Aggregate device health metrics for the organization. Supply `limit` to sample fewer devices (default 500) and `max_stale_devices` to cap the stale-device list for token-friendly responses.

--- a/src/automox_mcp/tools/device_tools.py
+++ b/src/automox_mcp/tools/device_tools.py
@@ -74,7 +74,14 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
 
     @server.tool(
         name="device_detail",
-        description="Return detailed information and recent activity for a device.",
+        description=(
+            "Return detailed information and recent activity for a device. "
+            "Includes a compliance rollup (per-policy status counts: up_to_date / "
+            "pending / needs_remediation, plus the policies needing remediation — "
+            "only needs_remediation policies make a device non-compliant). "
+            "`uptime_minutes` is sampled at the device's last full scan, so it "
+            "can lag the current boot session."
+        ),
         annotations={
             "readOnlyHint": True,
             "destructiveHint": False,

--- a/src/automox_mcp/workflows/devices.py
+++ b/src/automox_mcp/workflows/devices.py
@@ -175,6 +175,18 @@ def _count_failed_policies(device: Mapping[str, Any]) -> int:
     return failures
 
 
+# Integer status codes on GET /servers `policy_status[]` entries. Confirmed
+# against the Console API spec (ServerWithPolicies.policy_status[].status) and
+# cross-checked live (2026-06-04) against the `status.policy_statuses[]`
+# `compliant` booleans: code 1 is the only value paired with compliant=true.
+# Mapped here rather than in normalize_status because other Automox enums
+# reuse these integers with different meanings (e.g. OCSF status_id).
+_POLICY_STATUS_CODE_LABELS = {
+    0: "needs_remediation",
+    1: "up_to_date",
+    2: "pending",
+}
+
 _POLICY_STATUS_LIMIT = 12
 _POLICY_ASSIGNMENTS_LIMIT = 10
 _SANITIZED_SEQUENCE_LIMIT = 5
@@ -225,6 +237,73 @@ def _truncate_string(value: str, *, limit: int = _SANITIZED_STRING_LIMIT) -> str
     return f"{trimmed}... ({remaining} chars truncated)"
 
 
+def _policy_entry_status(item: Mapping[str, Any]) -> str:
+    """Translate one policy_status entry's status into a readable label.
+
+    Live entries carry the integer enum (see ``_POLICY_STATUS_CODE_LABELS``);
+    note that 0 (needs_remediation) is falsy, so a truthiness chain over the
+    alternate keys would misreport it as unknown. Non-integer values fall
+    through to the generic normalizer.
+    """
+    raw = item.get("status")
+    if isinstance(raw, bool):
+        raw = None
+    if isinstance(raw, int):
+        return _POLICY_STATUS_CODE_LABELS.get(raw, str(raw))
+    if raw in (None, ""):
+        raw = item.get("policy_status") or item.get("result_status")
+    return _normalize_status(raw)
+
+
+def _build_compliance_summary(device_data: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Roll up per-policy statuses into a device-level compliance view.
+
+    Gives the model the context it cannot infer from raw codes: how many
+    policies sit in each state, which specific policies need remediation,
+    and the rule (verified live) that pending policies alone do not make a
+    device non-compliant.
+    """
+    entries = device_data.get("policy_status")
+    device_compliant = device_data.get("compliant")
+    has_entries = isinstance(entries, Sequence) and not isinstance(entries, (str, bytes, bytearray))
+    if not has_entries and not isinstance(device_compliant, bool):
+        return None
+
+    counts: Counter[str] = Counter()
+    needs_remediation: list[dict[str, Any]] = []
+    if has_entries:
+        for item in cast(Sequence[Any], entries):
+            if not isinstance(item, Mapping):
+                continue
+            label = _policy_entry_status(item)
+            counts[label] += 1
+            if label == "needs_remediation" and len(needs_remediation) < _POLICY_STATUS_LIMIT:
+                needs_remediation.append(
+                    {
+                        "policy_id": item.get("policy_id") or item.get("id"),
+                        "policy_name": item.get("policy_name") or item.get("name"),
+                    }
+                )
+
+    summary: dict[str, Any] = {}
+    if isinstance(device_compliant, bool):
+        summary["device_compliant"] = device_compliant
+    if counts:
+        summary["policy_status_counts"] = dict(counts)
+    if needs_remediation:
+        summary["needs_remediation_policies"] = needs_remediation
+        if counts["needs_remediation"] > len(needs_remediation):
+            summary["needs_remediation_truncated"] = True
+    if not summary:
+        return None
+    summary["note"] = (
+        "A device is non-compliant when at least one policy is in "
+        "needs_remediation; pending policies (awaiting evaluation or their "
+        "next window) do not count against compliance."
+    )
+    return summary
+
+
 def _summarize_policy_status(
     entries: Any, *, limit: int = _POLICY_STATUS_LIMIT
 ) -> tuple[list[dict[str, Any]], int]:
@@ -248,9 +327,7 @@ def _summarize_policy_status(
         summary_item = {
             "policy_id": item.get("policy_id") or item.get("id"),
             "policy_name": item.get("policy_name") or item.get("name"),
-            "status": _normalize_status(
-                item.get("status") or item.get("policy_status") or item.get("result_status")
-            ),
+            "status": _policy_entry_status(item),
             "execution_time": item.get("create_time") or item.get("updated_at"),
             "pending_count": item.get("pending_count"),
             "will_reboot": item.get("will_reboot"),
@@ -647,13 +724,23 @@ def _build_device_core(
 
     # Fields that must preserve falsy values like 0 or False (None-check only).
     _NONE_CHECK_FIELDS: list[tuple[str, str]] = [
-        ("uptime", "uptime"),
         ("managed", "managed"),
     ]
     for out_key, src_key in _NONE_CHECK_FIELDS:
         value = device_data.get(src_key)
         if value is not None:
             core[out_key] = value
+
+    # Automox reports `uptime` as a bare numeric string of MINUTES sampled at
+    # the device's last full scan (verified live 2026-06-04 against known boot
+    # times; the public spec's "measured in seconds" claim is wrong). Rename
+    # so the model knows the unit, and note it can lag the current session.
+    uptime_raw = device_data.get("uptime")
+    if uptime_raw is not None:
+        try:
+            core["uptime_minutes"] = int(uptime_raw)
+        except (TypeError, ValueError):
+            core["uptime_minutes"] = uptime_raw
 
     display_name = _format_device_display_name(device_data)
     if display_name:
@@ -842,6 +929,10 @@ async def describe_device(
         },
         "raw_details": raw_details,
     }
+
+    compliance_summary = _build_compliance_summary(device_data)
+    if compliance_summary:
+        data["compliance"] = compliance_summary
 
     if detail_facts:
         data["device_facts"] = detail_facts

--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -497,11 +497,29 @@ async def run_readonly_tools() -> None:
         # 9. device_detail
         if device_id:
             resp = await _safe_call(session, "device_detail", {"device_id": device_id})
-            record(
-                "device_detail",
-                resp is not None and resp.get("data") is not None,
-                f"id={device_id}",
-            )
+            ok = resp is not None and resp.get("data") is not None
+            note = f"id={device_id}"
+            if ok and resp is not None:
+                # Correctness, not just 200: per-policy statuses must be the
+                # translated vocabulary (raw "0"/"1"/"2" means the integer
+                # enum mapping regressed), and the compliance rollup must
+                # account for every policy_status entry.
+                core = resp["data"].get("core") or {}
+                statuses = {e.get("status") for e in core.get("policy_status") or []}
+                raw_codes = statuses & {"0", "1", "2"}
+                if raw_codes:
+                    ok = False
+                    note = f"raw status codes leaked: {sorted(raw_codes)}"
+                compliance = resp["data"].get("compliance") or {}
+                counts = compliance.get("policy_status_counts")
+                total = (resp.get("metadata") or {}).get("policy_status_total")
+                if ok and counts is not None and sum(counts.values()) != total:
+                    ok = False
+                    note = f"compliance counts {sum(counts.values())} != total {total}"
+                if ok and "uptime" in core:
+                    ok = False
+                    note = "unit-less `uptime` key present (expected uptime_minutes)"
+            record("device_detail", ok, note)
         else:
             record("device_detail", False, "skipped — no device_id")
 

--- a/tests/test_workflows_devices.py
+++ b/tests/test_workflows_devices.py
@@ -51,16 +51,65 @@ def device_payload() -> dict[str, Any]:
         "server_group_id": 456,
         "managed": True,
         "patch_status": "missing",
-        "status": {"policy_status": "success"},
+        "compliant": False,
+        "uptime": "8077",
+        "status": {
+            "device_status": "active",
+            "agent_status": "active",
+            "policy_status": "active",
+            "policy_statuses": [
+                {"id": 1, "compliant": True},
+                {"id": 2, "compliant": False},
+                {"id": 3, "compliant": False},
+            ],
+        },
+        # Shape captured from a live GET /servers/{id} payload (sanitized):
+        # `status` is the integer enum (0 needs_remediation / 1 up_to_date /
+        # 2 pending), `result` is "{}" when empty, `uptime` above is a bare
+        # numeric string of minutes.
         "policy_status": [
             {
+                "id": 910001,
+                "organization_id": 9000,
                 "policy_id": 1,
+                "server_id": 42,
                 "policy_name": "Monthly Patching",
-                "status": "success",
-                "create_time": "2024-05-10T12:00:00Z",
+                "policy_type_name": "patch",
+                "status": 1,
+                "result": "{}",
+                "create_time": "2024-05-10T12:00:00+0000",
+                "next_remediation": "2024-05-12T01:00:00+0000",
                 "pending_count": 0,
                 "will_reboot": False,
-            }
+            },
+            {
+                "id": 910002,
+                "organization_id": 9000,
+                "policy_id": 2,
+                "server_id": 42,
+                "policy_name": "Third Party Patching",
+                "policy_type_name": "patch",
+                "status": 0,
+                "result": "{}",
+                "create_time": "2024-05-10T12:00:00+0000",
+                "next_remediation": "2024-05-12T01:00:00+0000",
+                "pending_count": 0,
+                "will_reboot": False,
+            },
+            {
+                "id": 910003,
+                "organization_id": 9000,
+                "policy_id": 3,
+                "server_id": 42,
+                "policy_name": "Disk Encryption Check",
+                "policy_type_name": "custom",
+                "status": 2,
+                "result": "{}",
+                "create_time": "2024-05-10T12:00:00+0000",
+                "next_remediation": "2024-05-12T01:00:00+0000",
+                "pending_count": 0,
+                "will_reboot": False,
+            },
         ],
         "server_policies": [
             {
@@ -124,7 +173,28 @@ async def test_describe_device_trims_large_payload(device_payload: dict[str, Any
     assert core["server_group_id"] == 456
     assert "group" not in core
     assert core["policy_status"][0]["policy_name"] == "Monthly Patching"
+    # Integer status codes are translated, not passed through raw.
+    assert [entry["status"] for entry in core["policy_status"]] == [
+        "up_to_date",
+        "needs_remediation",
+        "pending",
+    ]
+    # `uptime` is renamed with its (verified) unit and parsed to an int.
+    assert "uptime" not in core
+    assert core["uptime_minutes"] == 8077
     assert "evaluation_code" not in result["data"]["policy_assignments"]["policies"][0]
+
+    compliance = result["data"]["compliance"]
+    assert compliance["device_compliant"] is False
+    assert compliance["policy_status_counts"] == {
+        "up_to_date": 1,
+        "needs_remediation": 1,
+        "pending": 1,
+    }
+    assert compliance["needs_remediation_policies"] == [
+        {"policy_id": 2, "policy_name": "Third Party Patching"}
+    ]
+    assert "note" in compliance
 
     raw_details = result["data"]["raw_details"]
     assert raw_details["included"] is False
@@ -138,7 +208,7 @@ async def test_describe_device_trims_large_payload(device_payload: dict[str, Any
     assert device_facts["last_user_logon"]["user"] == "admin"
 
     metadata = result["metadata"]
-    assert metadata["policy_status_total"] == 1
+    assert metadata["policy_status_total"] == 3
     assert metadata["policy_assignments_total"] == 1
     assert metadata["include_raw_details"] is False
 

--- a/tests/test_workflows_devices_extended.py
+++ b/tests/test_workflows_devices_extended.py
@@ -11,12 +11,15 @@ from conftest import StubClient
 
 from automox_mcp.client import AutomoxClient
 from automox_mcp.workflows.devices import (
+    _build_compliance_summary,
+    _build_device_core,
     _calculate_days_since_check_in,
     _count_failed_policies,
     _extract_detail_facts,
     _extract_last_check_in,
     _format_device_display_name,
     _normalize_status,
+    _policy_entry_status,
     _sanitize_raw_device_payload,
     _summarize_device_common_fields,
     _summarize_policy_assignments,
@@ -416,6 +419,131 @@ def test_summarize_policy_status_custom_limit() -> None:
     result, total = _summarize_policy_status(entries, limit=3)
     assert len(result) == 3
     assert total == 5
+
+
+# ===========================================================================
+# _policy_entry_status — integer enum mapping (live GET /servers shape)
+# ===========================================================================
+
+
+def test_policy_entry_status_maps_integer_codes() -> None:
+    # Live policy_status entries carry the integer enum; verified against the
+    # spec and the status.policy_statuses[].compliant booleans (2026-06-04).
+    assert _policy_entry_status({"status": 0}) == "needs_remediation"
+    assert _policy_entry_status({"status": 1}) == "up_to_date"
+    assert _policy_entry_status({"status": 2}) == "pending"
+
+
+def test_policy_entry_status_zero_is_not_unknown() -> None:
+    # status 0 is falsy; the old truthiness chain fell through to the absent
+    # alternate keys and misreported needs_remediation devices as "unknown".
+    result, _ = _summarize_policy_status([{"policy_id": 1, "status": 0}])
+    assert result[0]["status"] == "needs_remediation"
+
+
+def test_policy_entry_status_unmapped_int_passes_through_as_string() -> None:
+    assert _policy_entry_status({"status": 7}) == "7"
+
+
+def test_policy_entry_status_bool_is_not_treated_as_int() -> None:
+    # bool is an int subclass; True must not be read as code 1.
+    assert _policy_entry_status({"status": True}) == "unknown"
+
+
+def test_policy_entry_status_string_falls_through_to_normalizer() -> None:
+    assert _policy_entry_status({"status": "success"}) == "success"
+    assert _policy_entry_status({"policy_status": "failed"}) == "failed"
+
+
+# ===========================================================================
+# _build_compliance_summary
+# ===========================================================================
+
+
+def test_build_compliance_summary_counts_and_failing_names() -> None:
+    device = {
+        "compliant": False,
+        "policy_status": [
+            {"policy_id": 1, "policy_name": "Monthly Patching", "status": 1},
+            {"policy_id": 2, "policy_name": "Third Party Patching", "status": 0},
+            {"policy_id": 3, "policy_name": "Disk Encryption Check", "status": 2},
+        ],
+    }
+    summary = _build_compliance_summary(device)
+    assert summary is not None
+    assert summary["device_compliant"] is False
+    assert summary["policy_status_counts"] == {
+        "up_to_date": 1,
+        "needs_remediation": 1,
+        "pending": 1,
+    }
+    assert summary["needs_remediation_policies"] == [
+        {"policy_id": 2, "policy_name": "Third Party Patching"}
+    ]
+    assert "needs_remediation_truncated" not in summary
+    assert "pending policies" in summary["note"]
+
+
+def test_build_compliance_summary_none_without_signal() -> None:
+    assert _build_compliance_summary({}) is None
+    assert _build_compliance_summary({"compliant": "yes"}) is None
+
+
+def test_build_compliance_summary_device_flag_only() -> None:
+    summary = _build_compliance_summary({"compliant": True})
+    assert summary is not None
+    assert summary["device_compliant"] is True
+    assert "policy_status_counts" not in summary
+
+
+def test_build_compliance_summary_truncates_failing_list() -> None:
+    device = {
+        "policy_status": [
+            {"policy_id": i, "policy_name": f"Policy {i}", "status": 0} for i in range(15)
+        ],
+    }
+    summary = _build_compliance_summary(device)
+    assert summary is not None
+    assert summary["policy_status_counts"] == {"needs_remediation": 15}
+    assert len(summary["needs_remediation_policies"]) == 12
+    assert summary["needs_remediation_truncated"] is True
+
+
+def test_build_compliance_summary_skips_non_mapping_entries() -> None:
+    # Nothing usable in the list and no device flag → no summary at all.
+    assert _build_compliance_summary({"policy_status": ["bogus", 3, None]}) is None
+
+
+# ===========================================================================
+# _build_device_core — uptime_minutes
+# ===========================================================================
+
+
+def _build_core(device_data: dict[str, Any]) -> dict[str, Any]:
+    return _build_device_core(
+        device_data,
+        device_id=1,
+        status_value=None,
+        ip_addresses_preview=None,
+        tags_preview=None,
+        policy_status_summary=[],
+    )
+
+
+def test_build_device_core_parses_uptime_minutes() -> None:
+    # Live payloads carry uptime as a numeric string of minutes.
+    core = _build_core({"uptime": "8077"})
+    assert "uptime" not in core
+    assert core["uptime_minutes"] == 8077
+
+
+def test_build_device_core_keeps_unparseable_uptime_verbatim() -> None:
+    core = _build_core({"uptime": "n/a"})
+    assert core["uptime_minutes"] == "n/a"
+
+
+def test_build_device_core_omits_missing_uptime() -> None:
+    assert "uptime_minutes" not in _build_core({})
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Three model-facing fixes to `device_detail`, prompted by a live test run where the model had to guess (and inverted) the policy status code mapping, and guessed wrong on the uptime unit. All verified against the live tenant (2026-06-04).

### 1. Per-policy status codes translated instead of passed through raw

`GET /servers` `policy_status[].status` is an integer enum — `0 = needs_remediation`, `1 = up_to_date`, `2 = pending`. Confirmed against the Console API spec (`ServerWithPolicies.policy_status[].status`) and cross-checked live across ~20 devices against the `status.policy_statuses[].compliant` booleans: code 1 is the only value paired with `compliant: true`.

Previously the summarizer stringified the integers verbatim (`"1"`/`"2"`), and code 0 — falsy — fell through a truthiness chain to absent alternate keys and surfaced as `"unknown"`, so the one state that demands action was reported least clearly. The mapping lives in the policy-entry summarizer, not the generic `normalize_status`, because other Automox enums reuse these integers with different meanings (e.g. OCSF `status_id`: 1=Success, 2=Failure).

### 2. Device-level `compliance` rollup

`device_detail` now emits counts per policy state, the named `needs_remediation` policies, and a note encoding the verified rule: a device is non-compliant when at least one policy needs remediation — pending policies alone do not count against compliance (devices with only up_to_date+pending report `compliant: true` live).

### 3. `uptime` → `uptime_minutes`

The public spec describes `Server.uptime` as "measured in seconds" — live verification against known device boot times shows the value is **minutes**, sampled at the device's last full scan (so it can lag the current boot session). The unit-less raw key invited bad inferences; it is now an integer `uptime_minutes` with the sampled-at-last-scan caveat in the tool description. (Spec doc bug to be filed internally.)

## Testing

- Unit fixtures updated to the captured live `policy_status` entry shape (integer status enum, real key set) per the project fixture rule; new tests cover the enum mapping (incl. the falsy-zero and bool-guard branches), the compliance rollup, and the uptime parse/fallback branches.
- Smoke `device_detail` check now asserts correctness, not just "got a response": no raw `"0"/"1"/"2"` status codes, no unit-less `uptime` key, and compliance counts reconciling with `metadata.policy_status_total`.
- Full local gate green (ruff format/check, mypy, pytest 91% coverage, bandit).
- End-to-end verified live: the affected device now reports `uptime_minutes: 6754` (~4.7 days) and a compliance rollup of 14 up_to_date / 16 pending / 1 needs_remediation naming the failing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)