### PR TITLE
chore: resolve CodeQL quality findings + review polish (tests only)

### DIFF
--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -374,7 +374,7 @@ async def run_http_tests() -> None:
                             same,
                             f"cid1={cid1}, cid2={cid2}",
                         )
-        except BaseException as exc:
+        except Exception as exc:
             record("idempotency — cached response", False, str(exc))
 
         # -- 5. Markdown output ------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,7 +96,7 @@ def test_create_server_rejects_negative_org_id(monkeypatch):
 
 
 def test_create_server_calls_dotenv_when_not_skipped(monkeypatch):
-    import automox_mcp.server as server_mod
+    from automox_mcp import server as server_mod
 
     monkeypatch.setenv("AUTOMOX_API_KEY", "env-key")
     monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", "account-uuid")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -164,7 +164,7 @@ def test_resolve_user_agent_fallback_to_env_var(monkeypatch):
     """When the package is not installed, fall back to AUTOMOX_MCP_VERSION env var."""
     import importlib.metadata
 
-    import automox_mcp.client as client_module
+    from automox_mcp import client as client_module
 
     monkeypatch.setenv("AUTOMOX_MCP_VERSION", "9.8.7")
 
@@ -181,7 +181,7 @@ def test_resolve_user_agent_fallback_default_when_no_env(monkeypatch):
     """When the package is not installed and AUTOMOX_MCP_VERSION is unset, use 0.0.0+dev."""
     import importlib.metadata
 
-    import automox_mcp.client as client_module
+    from automox_mcp import client as client_module
 
     monkeypatch.delenv("AUTOMOX_MCP_VERSION", raising=False)
 

--- a/tests/test_phase3_edge_cases.py
+++ b/tests/test_phase3_edge_cases.py
@@ -36,7 +36,6 @@ from automox_mcp.workflows.vuln_sync import (
 )
 
 _ORG_UUID = "11111111-2222-3333-4444-555555555555"
-_ACCT_UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -1017,7 +1017,7 @@ class TestRegisterToolsFiltering:
         assert "list_server_groups" in server.tools
 
     def test_module_filtering_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import automox_mcp.tools as tools_mod
+        from automox_mcp import tools as tools_mod
         from automox_mcp.tools import register_tools
 
         monkeypatch.setattr(tools_mod, "get_enabled_modules", lambda: {"events"})

--- a/tests/test_utils_tooling.py
+++ b/tests/test_utils_tooling.py
@@ -221,7 +221,7 @@ def test_format_error_falls_back_to_repr_on_type_error(monkeypatch):
     """If json.dumps raises TypeError, format_error falls back to repr()."""
     import json as json_mod
 
-    import automox_mcp.utils.tooling as tooling_mod
+    from automox_mcp.utils import tooling as tooling_mod
 
     original_dumps = json_mod.dumps
 

--- a/tests/test_workflows_devices_extended.py
+++ b/tests/test_workflows_devices_extended.py
@@ -975,14 +975,14 @@ class FullStubClient:
 
 def _fresh_describe_device():
     """Return the describe_device function from the live (possibly re-imported) module."""
-    import automox_mcp.workflows.devices as mod
+    from automox_mcp.workflows import devices as mod
 
     return mod.describe_device
 
 
 def _patch_get_device_inventory(**kwargs):
     """Return a context manager that patches get_device_inventory in the live module."""
-    import automox_mcp.workflows.devices as mod
+    from automox_mcp.workflows import devices as mod
 
     return patch.object(mod, "get_device_inventory", **kwargs)
 

--- a/tests/test_workflows_policy_windows.py
+++ b/tests/test_workflows_policy_windows.py
@@ -30,7 +30,7 @@ _WINDOW_A: dict[str, Any] = {
     "window_description": "No patching during nightly backups",
     "org_uuid": _ORG_UUID,
     # RECURRING grammar (validator-enforced): FREQ=YEARLY + BYMONTH(1-12) +
-    # BYDAY(+N weekday). recurrence is UPPERCASE on read (probe 2026-06-05).
+    # BYDAY(+N weekday). recurrence is UPPERCASE on read (live API verification 2026-06-05).
     "rrule": "FREQ=YEARLY;BYMONTH=3;BYDAY=+2TU",
     "duration_minutes": 120,
     "dtstart": "2026-01-01T02:00:00Z",
@@ -160,7 +160,7 @@ async def test_get_window_returns_detail() -> None:
     assert result["data"]["duration_minutes"] == 120
     assert result["data"]["status"] == "active"
     # recurrence is UPPERCASE on read even though create accepts lowercase
-    # (probe 2026-06-05); the projection forwards it raw.
+    # (live API verification 2026-06-05); the projection forwards it raw.
     assert result["data"]["recurrence"] == "RECURRING"
 
 

--- a/tests/test_workflows_vuln_sync.py
+++ b/tests/test_workflows_vuln_sync.py
@@ -20,8 +20,10 @@ from automox_mcp.workflows.vuln_sync import (
 
 # Fixture shape mirrors the actual /orgs/{org}/remediations/action-sets
 # response: a `source` object with `name`/`type`, plus a nested
-# `statistics` block holding per-bucket counts. The summarizer flattens
-# this into a top-level `name`, `issue_count`, `solution_count`, etc.
+# `statistics` block holding per-bucket counts. The summarizer extracts
+# the top-level `name` from `source.name` and computes `issue_count` /
+# `solution_count` by summing the nested `statistics.issues` /
+# `statistics.solutions` buckets.
 _ACTION_SETS = [
     {
         "id": 1,


### PR DESCRIPTION
## Summary

Pre-tag polish from the CodeQL quality-rule review and AI-review findings. Tests/harness only — no `src/` behavior changes.

- **`py/catch-base-exception`**: fixed the one genuine instance (smoke harness swallowed `KeyboardInterrupt`; now `except Exception`). The 39 `src/` instances are the intentional release-and-reraise idempotency pattern — `asyncio.CancelledError` is a `BaseException`, so narrowing them would leak the idempotency slot on task cancellation; they should be bulk-dismissed in the quality tab as intentional.
- **`py/import-and-import-from`**: converted five test files' function-local module imports to `from`-aliases (same module objects). One residual in `test_config.py` (`import automox_mcp as init_mod`) cannot be converted for a top-level package — dismiss.
- **`py/unused-global-variable`**: deleted dead `_ACCT_UUID`.
- Review polish: two test-comment clarifications. Two review suggestions declined with rationale (register-signature reorder — breaks repo-wide keyword-only consistency; date-constant extraction — per-claim provenance stamps must not share one constant).

## Testing

Full local gate green: ruff format/check, mypy (70 files), pytest 1480 passed at 91.24% coverage, bandit 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)