### PR TITLE
feat: declare outputSchema on the three compound tools (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Structured `outputSchema` on the three compound tools** (`get_compliance_snapshot`, `get_patch_tuesday_readiness`, `get_device_full_profile`). Each now advertises a JSON Schema (derived from a Pydantic model in `schemas.py`) for its `{"data", "metadata"}` envelope, so schema-aware MCP hosts can validate results and render them richly. The runtime return value is unchanged. The output models are deliberately permissive (all-optional fields, `dict[str, Any]` for variable sub-objects, never `extra="forbid"`) because FastMCP validates returned structured content against the schema at runtime — a too-strict schema would reject the legitimately-mutated envelope (token-budget truncation, section summaries, correlation id). Tool count unchanged.
+
 ## [2.1.0] - 2026-06-06
 
 **The projection-audit release.** Every model-facing tool output went through a 12-domain audit (54 adversarially-verified findings), an independent re-audit that live-verified each fix against the production API and caught 23 further defects, and a live verification campaign that upgraded dozens of field legends from spec-assumed to live-verified provenance — 24 PRs in total. The tool set is unchanged (130 tools); the theme is **self-describing output**: raw values are preserved for fidelity, with decoded siblings and `metadata.field_notes` legends stating verified units, vocabularies, and semantics, so a model no longer has to guess what an integer status, a unit-less number, or a bare enum string means. No tool signatures were removed or narrowed; some output shapes changed (phantom keys that never carried data were dropped, misdocumented fields renamed, flat counts regrouped) — each is detailed below. Where the audit found the *upstream* spec or API at fault, the affected legend says so explicitly rather than papering over it.

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -1433,3 +1433,176 @@ class DeviceFullProfileParams(OrgIdRequiredMixin, ForbidExtraModel):
             "Pagination docs."
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Structured output models for the compound tools (issue #176)
+# ---------------------------------------------------------------------------
+#
+# These describe the ``{"data": ..., "metadata": ...}`` envelope each compound
+# tool emits and are advertised via ``output_schema=Model.model_json_schema()``
+# on the ``@server.tool`` registration.
+#
+# CRITICAL — these models are deliberately PERMISSIVE, and that is load-bearing:
+# FastMCP validates a tool's returned ``structured_content`` against the
+# declared schema AT RUNTIME (``jsonschema.validate`` in the MCP SDK low-level
+# handler); a mismatch is returned to the client as ``isError=True``. The
+# emitted envelope is also not static — ``utils.tooling.as_tool_response``
+# mutates it (token-budget list truncation, ``correlation_id`` injection,
+# ``section_summaries``/``notes``/``errors``/``counts`` metadata), and
+# ``PaginationMetadata`` (``extra="allow"``) always adds its own keys. So:
+#
+#   * every field is OPTIONAL (no field lands in the schema's ``required`` list,
+#     so subset/degraded returns validate),
+#   * variable sub-objects are ``dict[str, Any]`` (no per-key type gate),
+#   * NEVER set ``extra="forbid"`` on any model below — it would emit
+#     ``additionalProperties: false`` and turn the advertised schema into a hard
+#     gate that rejects the real, mutated payload.
+#
+# The advertised schema therefore DOCUMENTS the shape for schema-aware hosts
+# without ever gating a legitimate response. ``tests/test_compound_output_schema.py``
+# runs real workflow outputs through the schema to guarantee this.
+
+
+class _StructuredToolResult(BaseModel):
+    """Base envelope for a compound tool's structured output (issue #176)."""
+
+    model_config = ConfigDict(extra="allow")
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Pagination, errors, per-section summaries, token-budget warnings, "
+            "and correlation metadata. Shape varies per call."
+        ),
+    )
+
+
+class ComplianceOverview(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total_devices: int | None = Field(default=None, description="Managed devices considered")
+    compliant_devices: int | None = Field(default=None, description="Devices in a compliant state")
+    noncompliant_devices: int | None = Field(default=None, description="Non-compliant devices")
+    compliance_rate_percent: float | None = Field(
+        default=None, description="Compliant share of the fleet, 0-100"
+    )
+
+
+class NoncompliantReportSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    summary: dict[str, Any] | None = Field(default=None, description="Aggregate counts")
+    devices: list[dict[str, Any]] | None = Field(
+        default=None, description="Non-compliant device records (capped at detail_limit)"
+    )
+
+
+class DeviceHealthSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    status_breakdown: dict[str, Any] | None = Field(
+        default=None, description="Device count by policy/check-in status"
+    )
+    check_in_recency: dict[str, Any] | None = Field(
+        default=None, description="Device count by check-in recency bucket"
+    )
+    stale_devices: list[dict[str, Any]] | None = Field(
+        default=None, description="Devices that have not checked in recently (capped)"
+    )
+
+
+class PolicySummarySection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total_policies: int | None = Field(default=None, description="Active policies considered")
+    by_type: dict[str, int] | None = Field(default=None, description="Policy count by type")
+    by_status: dict[str, int] | None = Field(default=None, description="Policy count by status")
+
+
+class ComplianceSnapshotData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    compliance_overview: ComplianceOverview | None = None
+    noncompliant_report: NoncompliantReportSection | None = None
+    device_health: DeviceHealthSection | None = None
+    policy_summary: PolicySummarySection | None = None
+
+
+class ComplianceSnapshotResult(_StructuredToolResult):
+    """Structured output of ``get_compliance_snapshot``."""
+
+    data: ComplianceSnapshotData | None = None
+
+
+class PrepatchReportSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total_devices_needing_patches: int | None = Field(
+        default=None, description="Devices with one or more pending patches"
+    )
+    summary: dict[str, Any] | None = Field(default=None, description="Aggregate counts")
+    devices: list[dict[str, Any]] | None = Field(
+        default=None, description="Per-device prepatch records (capped at detail_limit)"
+    )
+
+
+class PatchApprovalsSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    pending_count: int | None = Field(
+        default=None, description="Approvals awaiting a manual decision (manual_approval is null)"
+    )
+    approvals: list[dict[str, Any]] | None = Field(
+        default=None, description="Approval records (capped at detail_limit)"
+    )
+
+
+class ReadinessSummary(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    devices_needing_patches: int | None = None
+    pending_approvals: int | None = None
+    active_patch_policies: int | None = None
+
+
+class PatchTuesdayReadinessData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    prepatch_report: PrepatchReportSection | None = None
+    patch_approvals: PatchApprovalsSection | None = None
+    patch_policy_schedules: list[dict[str, Any]] | None = Field(
+        default=None, description="Patch-policy schedule entries (capped at detail_limit)"
+    )
+    readiness_summary: ReadinessSummary | None = None
+
+
+class PatchTuesdayReadinessResult(_StructuredToolResult):
+    """Structured output of ``get_patch_tuesday_readiness``."""
+
+    data: PatchTuesdayReadinessData | None = None
+
+
+class InventorySection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total_categories: int | None = None
+    total_items: int | None = None
+    categories: dict[str, Any] | None = Field(
+        default=None, description="Summarized inventory categories (counts + scalar key-values)"
+    )
+    note: str | None = None
+
+
+class PackagesSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total: int | None = Field(default=None, description="Total packages on the device")
+    returned: int | None = Field(default=None, description="Packages included in this response")
+    truncated: bool | None = None
+    packages: list[dict[str, Any]] | None = None
+    note: str | None = None
+
+
+class DeviceFullProfileData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    device: dict[str, Any] | None = Field(default=None, description="Core device record")
+    policy_assignments: dict[str, Any] | None = None
+    pending_commands: list[dict[str, Any]] | None = None
+    device_facts: dict[str, Any] | None = None
+    inventory: InventorySection | None = None
+    packages: PackagesSection | None = None
+
+
+class DeviceFullProfileResult(_StructuredToolResult):
+    """Structured output of ``get_device_full_profile``."""
+
+    data: DeviceFullProfileData | None = None

--- a/src/automox_mcp/tools/compound_tools.py
+++ b/src/automox_mcp/tools/compound_tools.py
@@ -10,8 +10,11 @@ from .. import workflows
 from ..client import AutomoxClient
 from ..schemas import (
     ComplianceSnapshotParams,
+    ComplianceSnapshotResult,
     DeviceFullProfileParams,
+    DeviceFullProfileResult,
     PatchTuesdayReadinessParams,
+    PatchTuesdayReadinessResult,
 )
 from ..utils.tooling import call_tool_workflow
 
@@ -41,6 +44,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "idempotentHint": True,
             "openWorldHint": True,
         },
+        output_schema=PatchTuesdayReadinessResult.model_json_schema(),
     )
     async def get_patch_tuesday_readiness(
         group_id: int | None = None,
@@ -70,6 +74,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "idempotentHint": True,
             "openWorldHint": True,
         },
+        output_schema=ComplianceSnapshotResult.model_json_schema(),
     )
     async def get_compliance_snapshot(
         group_id: int | None = None,
@@ -101,6 +106,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "idempotentHint": True,
             "openWorldHint": True,
         },
+        output_schema=DeviceFullProfileResult.model_json_schema(),
     )
     async def get_device_full_profile(
         device_id: int,

--- a/tests/test_compound_output_schema.py
+++ b/tests/test_compound_output_schema.py
@@ -1,0 +1,312 @@
+"""Tests for the compound tools' advertised ``output_schema`` (issue #176).
+
+Two things are verified here that nothing else covers:
+
+1. **Advertisement** — each compound tool registers a non-empty ``output_schema``
+   equal to its Pydantic model's JSON schema. This must be introspected on a
+   *real* ``FastMCP`` instance, because the ``StubServer`` in ``conftest.py``
+   swallows ``**kwargs`` (including ``output_schema``).
+
+2. **Runtime non-rejection** — FastMCP validates a tool's returned
+   ``structured_content`` against the declared schema at runtime
+   (``jsonschema.validate`` in the MCP SDK; a mismatch becomes ``isError=True``).
+   So the schema must accept every real, mutated envelope the tool can emit. We
+   prove this by running the actual workflows (with the same real fixtures
+   ``test_workflows_compound`` uses), pushing the result through
+   ``as_tool_response`` (the production envelope builder — token-budget
+   truncation, ``correlation_id``, ``section_summaries``), and validating with
+   the same ``jsonschema`` the SDK uses. A too-strict model would fail here
+   instead of silently breaking the tool in production.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jsonschema
+import pytest
+from conftest import StubClient
+
+# Reuse the *real* fixtures (not invented shapes) from the workflow tests.
+from test_workflows_compound import (
+    _build_compliance_client,
+    _build_readiness_client,
+    _patch_sub_workflows,
+)
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.schemas import (
+    ComplianceSnapshotResult,
+    DeviceFullProfileResult,
+    PatchTuesdayReadinessResult,
+)
+from automox_mcp.utils.tooling import as_tool_response
+from automox_mcp.workflows.compound import (
+    get_compliance_snapshot,
+    get_device_full_profile,
+    get_patch_tuesday_readiness,
+)
+
+_TOOL_TO_MODEL = {
+    "get_compliance_snapshot": ComplianceSnapshotResult,
+    "get_patch_tuesday_readiness": PatchTuesdayReadinessResult,
+    "get_device_full_profile": DeviceFullProfileResult,
+}
+
+
+def _registered_compound_tools() -> dict[str, Any]:
+    """Register compound tools on a REAL FastMCP and return {name: Tool}.
+
+    StubServer discards ``output_schema``, so a real server is required to read
+    it back — mirrors ``tools/__init__.py`` and ``test_doc_tool_counts.py``.
+    """
+    from fastmcp import FastMCP
+
+    from automox_mcp.tools.compound_tools import register
+
+    server = FastMCP("output-schema-test")
+    register(server, read_only=False, client=cast(AutomoxClient, StubClient()))
+    lp = server.local_provider
+    return {comp.name: comp for key, comp in lp._components.items() if key.startswith("tool:")}
+
+
+def _find_additional_properties_false(schema: Any) -> bool:
+    """True if ``additionalProperties: false`` appears anywhere in the schema.
+
+    That setting would turn the advertised schema into a hard runtime gate that
+    rejects the extra metadata keys ``as_tool_response`` injects, so it must
+    never appear in a compound-tool output schema.
+    """
+    if isinstance(schema, dict):
+        if schema.get("additionalProperties") is False:
+            return True
+        return any(_find_additional_properties_false(v) for v in schema.values())
+    if isinstance(schema, list):
+        return any(_find_additional_properties_false(item) for item in schema)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 1. Advertisement: each tool exposes its model's schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", sorted(_TOOL_TO_MODEL))
+def test_compound_tool_advertises_model_output_schema(tool_name: str) -> None:
+    tools = _registered_compound_tools()
+    assert tool_name in tools, f"{tool_name} not registered"
+    schema = tools[tool_name].output_schema
+    assert schema, f"{tool_name} has no output_schema"
+    assert schema == _TOOL_TO_MODEL[tool_name].model_json_schema()
+    # Top-level envelope is documented.
+    assert schema.get("type") == "object"
+    assert "data" in schema.get("properties", {})
+    assert "metadata" in schema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# 2. Permissiveness guard: the schema must never gate a real response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", sorted(_TOOL_TO_MODEL.values(), key=lambda m: m.__name__))
+def test_output_schema_has_no_additional_properties_false(model: Any) -> None:
+    """Regression guard: nobody may tighten these models with extra='forbid'."""
+    schema = model.model_json_schema()
+    assert not _find_additional_properties_false(schema), (
+        f"{model.__name__} schema contains additionalProperties:false — this gates "
+        "the runtime payload and will break the tool. Keep these models extra='allow'."
+    )
+    # No required fields → degraded/subset returns validate.
+    assert not schema.get("required"), f"{model.__name__} declares required fields"
+
+
+@pytest.mark.parametrize("model", sorted(_TOOL_TO_MODEL.values(), key=lambda m: m.__name__))
+def test_output_schema_accepts_empty_and_maximal_envelopes(model: Any) -> None:
+    """Empty and fully-loaded (every metadata mutation) envelopes both validate."""
+    schema = model.model_json_schema()
+    # Empty — e.g. an early degraded return.
+    jsonschema.validate(instance={}, schema=schema)
+    # Maximal metadata: every key as_tool_response / token-budget can inject.
+    maximal = {
+        "data": {"some_unexpected_section": {"nested": [1, 2, 3]}},
+        "metadata": {
+            "current_page": None,
+            "total_pages": None,
+            "total_count": None,
+            "limit": None,
+            "previous": None,
+            "next": None,
+            "deprecated_endpoint": False,
+            "correlation_id": "abc-123",
+            "errors": ["device_inventory: AutomoxAPIError: 404"],
+            "detail_limit": 10,
+            "section_summaries": {"x": {"total": 30, "returned": 10, "has_more": True}},
+            "notes": ["call `foo` for the rest"],
+            "counts": {"packages_total": 50},
+            "section_status": {"device_detail": "complete"},
+            "data_complete": False,
+            "truncated": True,
+            "truncations": {"devices": {"total": 30, "returned": 15}},
+            "estimated_tokens": 9001,
+            "token_warning": "Response is ~9001 tokens (budget: 4000).",
+        },
+        "an_extra_top_level_key": True,
+    }
+    jsonschema.validate(instance=maximal, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# 3. Runtime non-rejection: real workflow output validates against the schema
+# ---------------------------------------------------------------------------
+
+
+def _validate(result: dict[str, Any], model: Any) -> None:
+    """Push a workflow result through the production envelope builder and validate
+    the emitted structured_content exactly as the MCP SDK would at runtime."""
+    envelope = as_tool_response(result)
+    jsonschema.validate(instance=envelope, schema=model.model_json_schema())
+
+
+@pytest.mark.asyncio
+async def test_compliance_snapshot_output_conforms_to_schema() -> None:
+    client = _build_compliance_client()
+    result = await get_compliance_snapshot(cast(AutomoxClient, client), org_id=555)
+    _validate(result, ComplianceSnapshotResult)
+
+
+@pytest.mark.asyncio
+async def test_compliance_snapshot_truncated_output_conforms_to_schema() -> None:
+    """The section_summaries / notes metadata path also validates."""
+    noncompliant = {
+        "nonCompliant": {
+            "total": 30,
+            "devices": [{"id": i, "name": f"nc-{i}", "groupId": 10} for i in range(30)],
+        }
+    }
+    servers = [
+        {
+            "id": 1000 + i,
+            "managed": True,
+            "status": {"policy_status": "success"},
+            "last_check_in": "2024-01-01T00:00:00Z",
+        }
+        for i in range(30)
+    ]
+    client = StubClient(
+        get_responses={
+            "/reports/needs-attention": [noncompliant],
+            "/servers": [servers],
+            "/policies": [[]],
+            "/policystats": [[]],
+        }
+    )
+    client.org_id = 555
+    result = await get_compliance_snapshot(cast(AutomoxClient, client), org_id=555, detail_limit=10)
+    assert result["metadata"]["section_summaries"]  # truncation path exercised
+    _validate(result, ComplianceSnapshotResult)
+
+
+@pytest.mark.asyncio
+async def test_compliance_snapshot_empty_org_output_conforms_to_schema() -> None:
+    client = StubClient(
+        get_responses={
+            "/reports/needs-attention": [{"nonCompliant": {"total": 0, "devices": []}}],
+            "/servers": [[]],
+            "/policies": [[]],
+            "/policystats": [[]],
+        }
+    )
+    client.org_id = 555
+    result = await get_compliance_snapshot(cast(AutomoxClient, client), org_id=555)
+    _validate(result, ComplianceSnapshotResult)
+
+
+@pytest.mark.asyncio
+async def test_patch_tuesday_readiness_output_conforms_to_schema() -> None:
+    client = _build_readiness_client()
+    result = await get_patch_tuesday_readiness(
+        cast(AutomoxClient, client),
+        org_id=555,
+        org_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    _validate(result, PatchTuesdayReadinessResult)
+
+
+@pytest.mark.asyncio
+async def test_patch_tuesday_readiness_truncated_output_conforms_to_schema() -> None:
+    devices = {
+        "prepatch": {
+            "devices": [
+                {"id": i, "name": f"h-{i}", "patches": [{"severity": "high"}]} for i in range(30)
+            ],
+            "total": 30,
+        }
+    }
+    approvals = {
+        "size": 30,
+        "results": [
+            {"id": i, "status": "awaiting", "manual_approval": None, "software": {}, "policy": {}}
+            for i in range(30)
+        ],
+    }
+    policies = [
+        {
+            "id": 1000 + i,
+            "name": f"P{i}",
+            "policy_type_name": "patch",
+            "status": "active",
+            "schedule_days": 124,
+            "schedule_time": "02:00",
+        }
+        for i in range(30)
+    ]
+    client = StubClient(
+        get_responses={
+            "/reports/prepatch": [devices],
+            "/approvals": [approvals],
+            "/policies": [policies],
+            "/policystats": [[]],
+        }
+    )
+    client.org_id = 555
+    result = await get_patch_tuesday_readiness(
+        cast(AutomoxClient, client),
+        org_id=555,
+        org_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        detail_limit=10,
+    )
+    assert result["metadata"]["section_summaries"]
+    _validate(result, PatchTuesdayReadinessResult)
+
+
+@pytest.mark.asyncio
+async def test_device_full_profile_output_conforms_to_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sub_workflows(monkeypatch)
+    result = await get_device_full_profile(
+        cast(AutomoxClient, StubClient()), org_id=555, device_id=101
+    )
+    _validate(result, DeviceFullProfileResult)
+
+
+@pytest.mark.asyncio
+async def test_device_full_profile_all_sections_fail_output_conforms_to_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fully degraded (all sub-workflows fail) still validates."""
+    from unittest.mock import AsyncMock
+
+    from automox_mcp.client import AutomoxAPIError
+
+    _patch_sub_workflows(
+        monkeypatch,
+        describe_device=AsyncMock(side_effect=AutomoxAPIError("Forbidden", status_code=403)),
+        get_device_inventory=AsyncMock(side_effect=AutomoxAPIError("Forbidden", status_code=403)),
+        list_device_packages=AsyncMock(side_effect=AutomoxAPIError("Forbidden", status_code=403)),
+    )
+    result = await get_device_full_profile(
+        cast(AutomoxClient, StubClient()), org_id=555, device_id=101
+    )
+    _validate(result, DeviceFullProfileResult)


### PR DESCRIPTION
Closes #176.

## What

Adds explicit `output_schema=<Model.model_json_schema()>` to the three compound tools — `get_compliance_snapshot`, `get_patch_tuesday_readiness`, `get_device_full_profile` — so schema-aware MCP hosts can validate results and render the `{"data","metadata"}` envelope richly. **Runtime return value is unchanged**; we only advertise the schema (`call_tool_workflow` → `as_tool_response` already emits the dict). These tools never call `maybe_format_markdown`, so there is zero schema conflict (phase 1; read tools are #177).

New output models are added to `schemas.py` (`ComplianceSnapshotResult`, `PatchTuesdayReadinessResult`, `DeviceFullProfileResult` + nested section models).

## The load-bearing design decision

FastMCP **validates a tool's returned `structured_content` against the declared schema at runtime** — `jsonschema.validate` in the MCP SDK low-level handler; a mismatch is returned to the client as `isError=True`, not advertised-only. And the emitted envelope is not static: `as_tool_response` mutates it (token-budget list truncation, `correlation_id` injection, `section_summaries`/`notes`/`counts`/`section_status` metadata), and `PaginationMetadata` (`extra="allow"`) always adds its own keys.

So the output models are **deliberately permissive**, and that is enforced:
- every field is Optional with a default (nothing lands in `required` → subset/degraded returns validate),
- variable sub-objects are `dict[str, Any]` (no per-key type gate),
- **never** `extra="forbid"` (which would emit `additionalProperties:false` and turn the advertised schema into a hard gate that rejects the real, mutated payload).

The advertised schema documents the shape without ever gating a legitimate response.

## Tests — `tests/test_compound_output_schema.py`

1. **Advertisement** — each tool exposes its model's schema, introspected on a *real* `FastMCP` via `local_provider._components` (the `StubServer` in `conftest.py` swallows `**kwargs`, so real-server introspection is required, per the issue).
2. **Permissiveness guard** — asserts no `additionalProperties:false` and no `required` fields anywhere in the generated schemas, so the models can't later be tightened into a runtime gate; empty `{}` and a maximal "every metadata mutation" envelope both validate.
3. **Runtime non-rejection** — runs the *actual* workflows (reusing the existing real fixtures from `test_workflows_compound.py`), pushes each result through `as_tool_response` (the production envelope builder), and validates with the same `jsonschema` the SDK uses — covering normal, truncated (section_summaries/notes), empty-org, and fully-degraded paths. A too-strict model fails here instead of silently breaking the tool in production.

## Gate

`ruff format --check`, `ruff check`, `mypy`, `pytest --cov-fail-under=90` (1496 passed, 91.3%), `bandit` — all green. No tool-count change (output_schema is invisible to `test_doc_tool_counts.py`), so no doc-count edits; CHANGELOG `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)