### PR TITLE
feat: maybe_format_markdown → ToolResult; outputSchema on report tools (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Structured `outputSchema` on the report tools** (`prepatch_report`, `noncompliant_report`). Both now advertise a JSON Schema for their `{"data", "metadata"}` envelope, derived from permissive Pydantic models in `schemas.py` (phase 2 of the structured-output work; see the compound tools above). The schema validates in both JSON and markdown modes.
 - **Read-only MCP App: compliance triage UI** (the `io.modelcontextprotocol/ui` Apps extension). `get_compliance_snapshot` now attaches an `AppConfig` pointing at a new `ui://automox/triage.html` resource (MIME `text/html;profile=mcp-app`); Apps-capable hosts render an interactive non-compliant-triage surface (compliance posture, non-compliant devices, stale devices, policy summary) inline, fed by the tool's structured output. The UI is fully self-contained (inline JS/CSS, no CDN imports), implements the ext-apps postMessage handshake by hand, and degrades gracefully — non-Apps hosts ignore the App link and receive the structured snapshot unchanged. No new model-facing tool; MCP resource count 9 → 10. Note: resource/App counts are not CI-guarded (see `CLAUDE.md`).
 - **Structured `outputSchema` on the three compound tools** (`get_compliance_snapshot`, `get_patch_tuesday_readiness`, `get_device_full_profile`). Each now advertises a JSON Schema (derived from a Pydantic model in `schemas.py`) for its `{"data", "metadata"}` envelope, so schema-aware MCP hosts can validate results and render them richly. The runtime return value is unchanged. The output models are deliberately permissive (all-optional fields, `dict[str, Any]` for variable sub-objects, never `extra="forbid"`) because FastMCP validates returned structured content against the schema at runtime — a too-strict schema would reject the legitimately-mutated envelope (token-budget truncation, section summaries, correlation id). Tool count unchanged.
+
+### Changed
+
+- **`maybe_format_markdown` now returns a FastMCP `ToolResult` in markdown mode** instead of replacing `data` with a markdown string. The `ToolResult` carries the rendered table as text content (for human-facing hosts) *and* the full, unchanged `{data, metadata}` object as `structuredContent` (for schema-aware hosts and MCP Apps). This unblocks advertising an object `outputSchema` on read tools while still offering markdown output — previously the markdown string could not satisfy an object schema. The return type of the ~66 markdown-capable read tools was widened accordingly (`ToolResult | dict`); their JSON-mode behavior is unchanged.
 
 ## [2.1.0] - 2026-06-06
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -413,6 +413,8 @@ Thirteen list tools accept an optional `output_format` parameter:
 list_devices(output_format="markdown")
 ```
 
+In `"markdown"` mode the tool returns a FastMCP `ToolResult` that carries **both** the rendered table (as text content, for human-facing hosts) **and** the full structured `{data, metadata}` object (as `structuredContent`, for schema-aware hosts and MCP Apps). The structured object is never replaced by a markdown string, so a tool can advertise an `outputSchema` and still offer markdown.
+
 ### Capability Discovery
 
 The `discover_capabilities` meta-tool returns all available tools organized by domain. It is always available regardless of `AUTOMOX_MCP_MODULES` and is useful for discovering what the server can do without consulting documentation.

--- a/src/automox_mcp/schemas.py
+++ b/src/automox_mcp/schemas.py
@@ -1606,3 +1606,51 @@ class DeviceFullProfileResult(_StructuredToolResult):
     """Structured output of ``get_device_full_profile``."""
 
     data: DeviceFullProfileData | None = None
+
+
+# --- Report-tool output models (issue #177) ---
+# Same permissiveness rules as the compound output models above: all-optional,
+# dict[str, Any] for variable sub-objects, never extra="forbid". These tools may
+# also return markdown via ``maybe_format_markdown`` (a ToolResult whose
+# structured_content is this same envelope), so the schema must accept the
+# structured object unchanged.
+
+
+class PrepatchReportData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total_pending_patches: int | None = Field(
+        default=None,
+        description="Upstream prepatch 'total' (pending-patch count, not a device count)",
+    )
+    total_devices: int | None = Field(default=None, description="Devices with pending patches")
+    summary: dict[str, Any] | None = Field(
+        default=None, description="Per-severity device counts recomputed from highest_severity"
+    )
+    api_summary: dict[str, Any] | None = Field(
+        default=None, description="Raw upstream prepatch summary, passed through"
+    )
+    devices: list[dict[str, Any]] | None = Field(
+        default=None, description="Per-device prepatch records"
+    )
+
+
+class PrepatchReportResult(_StructuredToolResult):
+    """Structured output of the ``prepatch_report`` tool."""
+
+    data: PrepatchReportData | None = None
+
+
+class NoncompliantReportData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    total_devices: int | None = Field(default=None, description="Non-compliant devices")
+    summary: dict[str, Any] | None = Field(default=None, description="Upstream report summary")
+    devices: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Per-device records, each with a failing_policies list (id/name/type/severity)",
+    )
+
+
+class NoncompliantReportResult(_StructuredToolResult):
+    """Structured output of the ``noncompliant_report`` tool."""
+
+    data: NoncompliantReportData | None = None

--- a/src/automox_mcp/tools/account_tools.py
+++ b/src/automox_mcp/tools/account_tools.py
@@ -37,6 +37,7 @@ from ..schemas import (
     ZoneAssignment,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
@@ -142,7 +143,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def list_org_api_keys(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         org_id = client.org_id
         if org_id is None:
             raise ToolError("org_id required - set AUTOMOX_ORG_ID or pass org_id explicitly.")
@@ -174,7 +175,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_organizations,
@@ -206,7 +207,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_users,
@@ -226,7 +227,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_user(
         user_id: int,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.get_user,
@@ -242,7 +243,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_account(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.get_account,
@@ -258,7 +259,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def list_account_rbac_roles(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_account_rbac_roles,
@@ -281,7 +282,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_account_user(
         user_id: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.get_account_user,
@@ -298,7 +299,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def list_zones_for_user(
         user_id: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_zones_for_user,
@@ -316,7 +317,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_zones,
@@ -335,7 +336,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_zone(
         zone_id: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.get_zone,
@@ -354,7 +355,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_zone_users,
@@ -381,7 +382,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_user_api_keys,
@@ -402,7 +403,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         user_id: int,
         key_id: int,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.get_user_api_key,
@@ -421,7 +422,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def list_global_api_keys(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(client, workflows.list_global_api_keys, {})
         return maybe_format_markdown(result, output_format)
 

--- a/src/automox_mcp/tools/audit_tools.py
+++ b/src/automox_mcp/tools/audit_tools.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastmcp import FastMCP
 
 from .. import workflows
 from ..client import AutomoxClient
 from ..schemas import AuditTrailEventsParams
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -38,7 +37,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         include_raw_events: bool | None = False,
         org_uuid: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "date": date,
             "actor_email": actor_email,

--- a/src/automox_mcp/tools/audit_v2_tools.py
+++ b/src/automox_mcp/tools/audit_v2_tools.py
@@ -9,6 +9,7 @@ from fastmcp import FastMCP
 from ..client import AutomoxClient
 from ..schemas import AuditEventsOcsfParams
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -62,7 +63,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         cursor: str | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {
             "date": date,
             "category_name": category_name,

--- a/src/automox_mcp/tools/data_extract_tools.py
+++ b/src/automox_mcp/tools/data_extract_tools.py
@@ -13,6 +13,7 @@ from ..schemas import (
     ListDataExtractsParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
@@ -50,7 +51,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def list_data_extracts(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _list_data_extracts,
@@ -79,7 +80,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_data_extract(
         extract_id: int | str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         # Live extract ids are ints (list_data_extracts returns them as ints),
         # so a model commonly passes an int. Accept int|str and coerce to a
         # string for the URL path.

--- a/src/automox_mcp/tools/device_search_tools.py
+++ b/src/automox_mcp/tools/device_search_tools.py
@@ -23,6 +23,7 @@ from ..schemas import (
     UpdateSavedSearchParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
@@ -103,7 +104,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def list_saved_searches(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(client, _list_saved_searches, {})
         return maybe_format_markdown(result, output_format)
 
@@ -141,7 +142,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _advanced_device_search,
@@ -167,7 +168,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         field: str,
         prefix: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _device_search_typeahead,
@@ -191,7 +192,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_device_metadata_fields(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(client, _get_device_metadata_fields, {})
         return maybe_format_markdown(result, output_format)
 
@@ -207,7 +208,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_device_assignments(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(client, _get_device_assignments, {})
         return maybe_format_markdown(result, output_format)
 
@@ -230,7 +231,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_device_by_uuid(
         device_uuid: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_device_by_uuid,
@@ -259,7 +260,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_saved_search(
         saved_search_id: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_saved_search,
@@ -286,7 +287,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_saved_search_results,
@@ -315,7 +316,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_cached_search_results,
@@ -340,7 +341,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_search_scopes(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(client, _get_search_scopes, {})
         return maybe_format_markdown(result, output_format)
 
@@ -360,7 +361,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_searchable_fields(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(client, _get_searchable_fields, {})
         return maybe_format_markdown(result, output_format)
 
@@ -382,7 +383,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         device_uuid: str,
         search_type: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _list_searches_for_device,
@@ -412,7 +413,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         size: int | None = None,
         fields: list[str] | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _run_saved_search,

--- a/src/automox_mcp/tools/device_tools.py
+++ b/src/automox_mcp/tools/device_tools.py
@@ -21,6 +21,7 @@ from ..schemas import (
     UpdateDeviceParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     is_device_deletion_allowed,
@@ -55,7 +56,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         policy_status: str | None = None,
         managed: bool | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "group_id": group_id,
             "limit": limit,
@@ -121,7 +122,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         group_id: int | None = None,
         limit: int | None = 20,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "group_id": group_id,
             "limit": limit,
@@ -165,7 +166,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         group_id: int | None = None,
         limit: int | None = 50,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "hostname_contains": hostname_contains,
             "ip_address": ip_address,

--- a/src/automox_mcp/tools/event_tools.py
+++ b/src/automox_mcp/tools/event_tools.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastmcp import FastMCP
 
 from .. import workflows
 from ..client import AutomoxClient
 from ..schemas import GetEventsParams
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -45,7 +44,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         start_date: str | None = None,
         end_date: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "page": page,
             "limit": limit,

--- a/src/automox_mcp/tools/group_tools.py
+++ b/src/automox_mcp/tools/group_tools.py
@@ -17,6 +17,7 @@ from ..schemas import (
     UpdateServerGroupParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
@@ -45,7 +46,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "page": page,
             "limit": limit,

--- a/src/automox_mcp/tools/package_tools.py
+++ b/src/automox_mcp/tools/package_tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastmcp import FastMCP
 
 from .. import workflows
@@ -13,6 +11,7 @@ from ..schemas import (
     GetOrganizationPackagesParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -49,7 +48,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "device_id": device_id,
             "page": page,
@@ -96,7 +95,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "include_unmanaged": include_unmanaged,
             "awaiting": awaiting,

--- a/src/automox_mcp/tools/policy_history_tools.py
+++ b/src/automox_mcp/tools/policy_history_tools.py
@@ -17,6 +17,7 @@ from ..schemas import (
     PolicyRunsV2Params,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -79,7 +80,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {
             "start_time": start_time,
             "end_time": end_time,
@@ -112,7 +113,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def policy_run_count(
         days: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {"days": days}
         result = await call_tool_workflow(
             client, _policy_run_count, kwargs, params_model=PolicyRunCountParams
@@ -134,7 +135,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def policy_runs_by_policy(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {}
         result = await call_tool_workflow(
             client, _policy_runs_by_policy, kwargs, params_model=PolicyRunsByPolicyParams
@@ -158,7 +159,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         policy_uuid: str,
         recent_runs_limit: int | None = 25,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {
             "policy_uuid": policy_uuid,
             "recent_runs_limit": recent_runs_limit,
@@ -188,7 +189,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         sort: str | None = None,
         summary_only: bool = False,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {
             "policy_uuid": policy_uuid,
             "report_days": report_days,
@@ -220,7 +221,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         start_time: str | None = None,
         end_time: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {
             "start_time": start_time,
             "end_time": end_time,
@@ -259,7 +260,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         kwargs: dict[str, Any] = {
             "policy_uuid": policy_uuid,
             "exec_token": exec_token,

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -26,6 +26,7 @@ from ..schemas import (
     UploadPolicyFileParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     is_stdio_transport,
@@ -183,7 +184,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         include_inactive: bool | None = False,
         include_stats: bool | None = False,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "limit": limit,
             "page": page,
@@ -271,7 +272,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         status: str | None = None,
         limit: int | None = 25,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "status": status,
             "limit": limit,
@@ -309,7 +310,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         page: int | None = None,
         limit: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.preview_policy_device_filters,
@@ -340,7 +341,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def list_devices_for_policies(
         policies: list[str],
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             workflows.list_devices_for_policies,

--- a/src/automox_mcp/tools/policy_windows_tools.py
+++ b/src/automox_mcp/tools/policy_windows_tools.py
@@ -12,6 +12,7 @@ from .. import workflows
 from ..client import AutomoxClient
 from ..schemas import ForbidExtraModel
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
@@ -237,7 +238,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         sort: str | None = None,
         direction: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "org_uuid": org_uuid,
             "group_uuids": group_uuids,

--- a/src/automox_mcp/tools/report_tools.py
+++ b/src/automox_mcp/tools/report_tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastmcp import FastMCP
 
 from .. import workflows
@@ -11,8 +9,11 @@ from ..client import AutomoxClient
 from ..schemas import (
     GetNeedsAttentionReportParams,
     GetPrepatchReportParams,
+    NoncompliantReportResult,
+    PrepatchReportResult,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -38,13 +39,14 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "idempotentHint": True,
             "openWorldHint": True,
         },
+        output_schema=PrepatchReportResult.model_json_schema(),
     )
     async def prepatch_report(
         group_id: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "group_id": group_id,
             "limit": limit,
@@ -75,13 +77,14 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             "idempotentHint": True,
             "openWorldHint": True,
         },
+        output_schema=NoncompliantReportResult.model_json_schema(),
     )
     async def noncompliant_report(
         group_id: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "group_id": group_id,
             "limit": limit,

--- a/src/automox_mcp/tools/splashtop_tools.py
+++ b/src/automox_mcp/tools/splashtop_tools.py
@@ -38,6 +38,7 @@ from ..schemas import (
     SplashtopUninstallParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     is_splashtop_bulk_allowed,
@@ -102,7 +103,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def splashtop_device_status(
         device_uuid: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_device_status,
@@ -134,7 +135,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         device_uuid: str,
         account_type: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params: dict[str, Any] = {"device_uuid": device_uuid}
         if account_type is not None:
             params["account_type"] = account_type
@@ -163,7 +164,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def splashtop_get_attended_access(
         device_uuid: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_attended_access,

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -19,6 +19,7 @@ from ..schemas import (
     UploadActionSetParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     is_remediation_allowed,
@@ -73,7 +74,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def list_remediation_action_sets(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _list_remediation_action_sets,
@@ -101,7 +102,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_action_set_detail(
         action_set_id: int,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_action_set_detail,
@@ -126,7 +127,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_action_set_issues(
         action_set_id: int,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_action_set_issues,
@@ -155,7 +156,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_action_set_solutions(
         action_set_id: int,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_action_set_solutions,
@@ -176,7 +177,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     )
     async def get_upload_formats(
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         result = await call_tool_workflow(
             client,
             _get_upload_formats,

--- a/src/automox_mcp/tools/webhook_tools.py
+++ b/src/automox_mcp/tools/webhook_tools.py
@@ -17,6 +17,7 @@ from .. import workflows
 from ..client import AutomoxClient
 from ..schemas import ForbidExtraModel
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
@@ -255,7 +256,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         limit: int | None = None,
         cursor: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "org_uuid": org_uuid,
             "limit": limit,
@@ -319,7 +320,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
         start_date: str | None = None,
         end_date: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {
             "org_uuid": org_uuid,
             "webhook_id": webhook_id,

--- a/src/automox_mcp/tools/worklet_tools.py
+++ b/src/automox_mcp/tools/worklet_tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastmcp import FastMCP
 
 from ..client import AutomoxClient
@@ -12,6 +10,7 @@ from ..schemas import (
     SearchWisParams,
 )
 from ..utils.tooling import (
+    ToolReturn,
     call_tool_workflow,
     maybe_format_markdown,
 )
@@ -41,7 +40,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def search_worklet_catalog(
         query: str | None = None,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {"query": query}
         result = await call_tool_workflow(
             client,
@@ -67,7 +66,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     async def get_worklet_detail(
         item_id: str,
         output_format: str | None = "json",
-    ) -> dict[str, Any]:
+    ) -> ToolReturn:
         params = {"item_id": item_id}
         result = await call_tool_workflow(
             client,

--- a/src/automox_mcp/utils/tooling.py
+++ b/src/automox_mcp/utils/tooling.py
@@ -9,8 +9,9 @@ import os
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 
+from fastmcp.tools import ToolResult
 from pydantic import BaseModel
 
 from ..client import AutomoxAPIError
@@ -19,6 +20,13 @@ from ..schemas import PaginationMetadata, ToolResponse
 from .sanitize import is_sanitization_enabled, sanitize_dict, sanitize_for_llm
 
 logger = logging.getLogger(__name__)
+
+#: Return type of read tools that may render markdown. Either a plain
+#: ``{data, metadata}`` envelope (FastMCP wraps it as ``structuredContent``), or a
+#: :class:`~fastmcp.tools.ToolResult` carrying both the markdown text (``content``,
+#: for human-facing hosts) and the structured object (``structured_content``, for
+#: schema-aware hosts / MCP Apps). See :func:`maybe_format_markdown` (issue #177).
+ToolReturn: TypeAlias = ToolResult | dict[str, Any]
 
 _VALID_MODULES: frozenset[str] = frozenset(
     {
@@ -595,10 +603,20 @@ def format_as_markdown_table(data: list[dict[str, Any]], *, max_col_width: int =
     return "\n".join([header, separator, *rows])
 
 
-def maybe_format_markdown(result: dict[str, Any], output_format: str | None) -> dict[str, Any]:
-    """If *output_format* is ``"markdown"``, convert the first list in *data* to a table.
+def maybe_format_markdown(result: dict[str, Any], output_format: str | None) -> ToolReturn:
+    """Render the first list in *data* as a markdown table when *output_format* is ``"markdown"``.
 
-    Returns the original *result* unchanged when the format is not markdown.
+    In markdown mode, returns a FastMCP :class:`~fastmcp.tools.ToolResult` whose
+    ``content`` is the rendered table (what human-facing hosts display) and whose
+    ``structured_content`` is the **full original** ``{data, metadata}`` envelope
+    (what schema-aware hosts / MCP Apps consume, and what FastMCP validates against
+    the tool's ``output_schema``). This is what lets a read tool advertise an object
+    ``output_schema`` *and* still offer markdown — the structured object is never
+    replaced by a string (issue #177). Previously this returned
+    ``{"data": "<markdown string>", ...}``, which could not satisfy an object schema.
+
+    Returns the original *result* dict unchanged when the format is not markdown, or
+    when there is no non-empty list in *data* to tabulate.
     """
     if output_format != "markdown":
         return result
@@ -606,8 +624,9 @@ def maybe_format_markdown(result: dict[str, Any], output_format: str | None) -> 
     if isinstance(data, Mapping):
         for _key, value in data.items():
             if isinstance(value, list) and value:
-                return {"data": format_as_markdown_table(value), "metadata": {"format": "markdown"}}
-    # Cannot convert to markdown table — return original result unchanged
+                table = format_as_markdown_table(value)
+                return ToolResult(content=table, structured_content=result)
+    # Nothing to tabulate — return the structured envelope unchanged.
     return result
 
 
@@ -709,6 +728,8 @@ __all__ = [
     "RateLimitError",
     "RateLimiter",
     "SENSITIVE_KEYWORDS",
+    "ToolResult",
+    "ToolReturn",
     "as_tool_response",
     "call_tool_workflow",
     "check_idempotency",

--- a/tests/test_report_output_schema.py
+++ b/tests/test_report_output_schema.py
@@ -1,0 +1,159 @@
+"""Tests for the report tools' advertised ``output_schema`` (issue #177, phase 2).
+
+Mirrors ``test_compound_output_schema.py`` for the two report tools, and adds the
+phase-2 twist: these tools can return **markdown** via ``maybe_format_markdown``.
+The refactored helper returns a ``ToolResult`` whose ``structured_content`` is the
+unchanged envelope, so the same advertised object schema validates in *both* JSON
+and markdown modes. We prove that with the same ``jsonschema`` the MCP SDK uses,
+running real workflow output (reusing the captured fixtures from
+``test_workflows_reports``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jsonschema
+import pytest
+from conftest import StubClient
+from fastmcp import FastMCP
+from fastmcp.tools import ToolResult
+
+# Reuse the captured/real report fixtures, not invented shapes.
+from test_workflows_reports import _LIVE_PREPATCH_RESPONSE, _make_noncompliant_response
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.schemas import NoncompliantReportResult, PrepatchReportResult
+from automox_mcp.utils.tooling import as_tool_response, maybe_format_markdown
+from automox_mcp.workflows.reports import get_noncompliant_report, get_prepatch_report
+
+_TOOL_TO_MODEL = {
+    "prepatch_report": PrepatchReportResult,
+    "noncompliant_report": NoncompliantReportResult,
+}
+
+
+def _registered_report_tools() -> dict[str, Any]:
+    from automox_mcp.tools.report_tools import register
+
+    server = FastMCP("report-schema-test")
+    register(server, read_only=False, client=cast(AutomoxClient, StubClient()))
+    lp = server.local_provider
+    return {comp.name: comp for key, comp in lp._components.items() if key.startswith("tool:")}
+
+
+def _has_additional_properties_false(schema: Any) -> bool:
+    if isinstance(schema, dict):
+        if schema.get("additionalProperties") is False:
+            return True
+        return any(_has_additional_properties_false(v) for v in schema.values())
+    if isinstance(schema, list):
+        return any(_has_additional_properties_false(item) for item in schema)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Advertisement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", sorted(_TOOL_TO_MODEL))
+def test_report_tool_advertises_model_output_schema(tool_name: str) -> None:
+    tools = _registered_report_tools()
+    assert tool_name in tools
+    schema = tools[tool_name].output_schema
+    assert schema == _TOOL_TO_MODEL[tool_name].model_json_schema()
+    assert schema.get("type") == "object"
+    assert "data" in schema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# Permissiveness guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", sorted(_TOOL_TO_MODEL.values(), key=lambda m: m.__name__))
+def test_report_schema_is_permissive(model: Any) -> None:
+    schema = model.model_json_schema()
+    assert not _has_additional_properties_false(schema), (
+        f"{model.__name__} has additionalProperties:false"
+    )
+    assert not schema.get("required"), f"{model.__name__} declares required fields"
+    jsonschema.validate(instance={}, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# Runtime non-rejection — JSON mode AND markdown mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepatch_report_output_conforms_json_and_markdown() -> None:
+    client = StubClient(get_responses={"/reports/prepatch": [_LIVE_PREPATCH_RESPONSE]})
+    result = await get_prepatch_report(cast(AutomoxClient, client), org_id=42, limit=500)
+    schema = PrepatchReportResult.model_json_schema()
+
+    # JSON mode: the plain envelope FastMCP would wrap + validate.
+    envelope = as_tool_response(result)
+    jsonschema.validate(instance=envelope, schema=schema)
+
+    # Markdown mode: ToolResult whose structured_content is the SAME envelope,
+    # which FastMCP validates against this exact schema.
+    md = maybe_format_markdown(envelope, "markdown")
+    assert isinstance(md, ToolResult)
+    jsonschema.validate(instance=md.structured_content, schema=schema)
+
+
+@pytest.mark.asyncio
+async def test_noncompliant_report_output_conforms_json_and_markdown() -> None:
+    device = {
+        "id": 101,
+        "name": "web-01",
+        "groupId": 10,
+        "os_family": "Windows",
+        "connected": True,
+        "needsReboot": False,
+        "lastRefreshTime": "2026-06-05T00:00:00Z",
+        "policies": [
+            {
+                "id": 301,
+                "name": "Weekday Patching",
+                "type": "patch",
+                "severity": "critical",
+                "reasonForFail": "patch failed: timeout",
+                "packages": [{"id": 1}, {"id": 2}],
+            }
+        ],
+    }
+    client = StubClient(
+        get_responses={"/reports/needs-attention": [_make_noncompliant_response([device])]}
+    )
+    result = await get_noncompliant_report(cast(AutomoxClient, client), org_id=42, limit=500)
+    schema = NoncompliantReportResult.model_json_schema()
+
+    envelope = as_tool_response(result)
+    jsonschema.validate(instance=envelope, schema=schema)
+
+    md = maybe_format_markdown(envelope, "markdown")
+    assert isinstance(md, ToolResult)
+    jsonschema.validate(instance=md.structured_content, schema=schema)
+
+
+@pytest.mark.asyncio
+async def test_empty_reports_conform_to_schema() -> None:
+    """Empty device lists (degraded/empty org) still validate."""
+    pre_client = StubClient(
+        get_responses={"/reports/prepatch": [{"prepatch": {"total": 0, "devices": []}}]}
+    )
+    pre = await get_prepatch_report(cast(AutomoxClient, pre_client), org_id=42, limit=500)
+    jsonschema.validate(
+        instance=as_tool_response(pre), schema=PrepatchReportResult.model_json_schema()
+    )
+
+    nc_client = StubClient(
+        get_responses={"/reports/needs-attention": [{"nonCompliant": {"total": 0, "devices": []}}]}
+    )
+    nc = await get_noncompliant_report(cast(AutomoxClient, nc_client), org_id=42, limit=500)
+    jsonschema.validate(
+        instance=as_tool_response(nc), schema=NoncompliantReportResult.model_json_schema()
+    )

--- a/tests/test_utils_tooling.py
+++ b/tests/test_utils_tooling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from fastmcp.tools import ToolResult
 
 from automox_mcp.client import AutomoxAPIError
 from automox_mcp.utils.tooling import (
@@ -16,6 +17,7 @@ from automox_mcp.utils.tooling import (
     format_as_markdown_table,
     format_error,
     get_enabled_modules,
+    maybe_format_markdown,
 )
 
 # ---------------------------------------------------------------------------
@@ -431,3 +433,60 @@ def test_markdown_table_none_values():
     lines = table.split("\n")
     # None renders as empty string
     assert "42" in lines[2]
+
+
+# ---------------------------------------------------------------------------
+# maybe_format_markdown — both branches (issue #177)
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_format_markdown_non_markdown_returns_dict_unchanged():
+    """Non-markdown format returns the original envelope dict (FastMCP wraps it)."""
+    result = {"data": {"items": [{"a": 1}]}, "metadata": {"x": 1}}
+    out = maybe_format_markdown(result, "json")
+    assert out is result
+    assert isinstance(out, dict)
+
+
+def test_maybe_format_markdown_none_format_returns_dict_unchanged():
+    result = {"data": {"items": [{"a": 1}]}, "metadata": {}}
+    assert maybe_format_markdown(result, None) is result
+
+
+def test_maybe_format_markdown_markdown_returns_toolresult_preserving_structured():
+    """Markdown mode returns a ToolResult: markdown text as content, the FULL
+    original envelope as structured_content (so an object output_schema is
+    satisfied and schema-aware hosts/Apps still get the data)."""
+    result = {
+        "data": {"devices": [{"name": "dev-1", "os": "linux"}, {"name": "dev-2", "os": "win"}]},
+        "metadata": {"total_count": 2},
+    }
+    out = maybe_format_markdown(result, "markdown")
+    assert isinstance(out, ToolResult)
+    # structured_content is the unchanged envelope — NOT a markdown string.
+    assert out.structured_content == result
+    # content carries the rendered markdown table for human-facing hosts.
+    text = "".join(getattr(block, "text", "") for block in out.content)
+    assert "dev-1" in text and "| name |" in text.replace(" ", " ")
+    assert "name" in text and "os" in text
+
+
+def test_maybe_format_markdown_markdown_no_list_returns_dict_unchanged():
+    """Markdown mode with no tabulatable list falls back to the unchanged dict."""
+    result = {"data": {"summary": {"count": 5}}, "metadata": {}}
+    out = maybe_format_markdown(result, "markdown")
+    assert out is result
+
+
+def test_maybe_format_markdown_markdown_data_not_mapping_returns_unchanged():
+    """When data isn't a Mapping (e.g. a bare list), there's nothing to scan; unchanged."""
+    result = {"data": [{"a": 1}], "metadata": {}}
+    out = maybe_format_markdown(result, "markdown")
+    assert out is result
+
+
+def test_maybe_format_markdown_markdown_empty_list_returns_unchanged():
+    """An empty list is not tabulated (the `and value` guard); returns the dict."""
+    result = {"data": {"devices": []}, "metadata": {}}
+    out = maybe_format_markdown(result, "markdown")
+    assert out is result


### PR DESCRIPTION
Closes #177. Phase 2 of the structured-output work (builds on #176).

## What

Refactors `maybe_format_markdown` so read tools can advertise an object `outputSchema` *and* still offer markdown.

- **`maybe_format_markdown`** now returns a FastMCP `ToolResult(content=<table>, structured_content=<full {data,metadata} envelope>)` in markdown mode, instead of replacing `data` with a markdown **string**. The structured object is preserved for schema-aware hosts / MCP Apps (and is what FastMCP validates against `outputSchema`); the table renders as text for human-facing hosts. JSON mode is unchanged (returns the dict). Previously the markdown string could not satisfy an object schema — that was the blocker.
- The helper's return type widens to `ToolReturn = ToolResult | dict[str, Any]` (exported from `utils.tooling`). The **~66 markdown-capable read tools** had their return annotation widened to `ToolReturn`; **write tools** that return a plain dict were left `-> dict[str, Any]`. Verified mechanically: per file, the count of `-> ToolReturn:` equals the count of `return maybe_format_markdown(` (64 == 64 total).
- **`outputSchema` on the report tools** (`prepatch_report`, `noncompliant_report`) via permissive models (`PrepatchReportResult`, `NoncompliantReportResult`) following the #176 rules (all-optional, `dict[str, Any]` for variable sub-objects, never `extra="forbid"`).

## Scope decision (confirmed)

The near-term consumers of `outputSchema` are the **MCP Apps** (the compound tools from #176 and the #179–#182 write-flow tools) — not the generic list tools. So this PR adds bespoke schemas to the **report tools** and defers the broad read-tool rollout. The `maybe_format_markdown` refactor itself is the durable win: it makes markdown mode **lossless for all ~66 read tools** (structured consumers get the real object even before a tool advertises a schema). A follow-up can add schemas (bespoke or a shared envelope) to the remaining read tools if/when they become render/App surfaces.

## Tests

- `test_utils_tooling.py`: branch tests for both `maybe_format_markdown` paths — markdown on (asserts `ToolResult` with table content **and** unchanged `structured_content`), markdown off, no tabulatable list, non-Mapping `data`, empty list.
- `test_report_output_schema.py`: advertisement (real-FastMCP introspection), permissiveness guard (no `additionalProperties:false` / no `required`), and **runtime non-rejection of real report output in BOTH JSON and markdown modes** — validating `ToolResult.structured_content` with the same `jsonschema` the MCP SDK uses (reusing the captured `_LIVE_PREPATCH_RESPONSE` fixture).

## Bookkeeping

No tool-count change (`output_schema` on existing tools). `docs/tool-reference.md` Markdown-output section documents the new dual-channel behavior; CHANGELOG `[Unreleased]` gets an Added (report schemas) + Changed (`maybe_format_markdown`) entry.

Gate: `ruff format --check`, `ruff check`, `mypy`, `pytest --cov-fail-under=90` (1515 passed, 91.4%), `bandit` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)