### PR TITLE
test: fix smoke markdown test for the #177 ToolResult contract

### DIFF
--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -386,27 +386,33 @@ async def run_http_tests() -> None:
             record("idempotency — cached response", False, str(exc))
 
         # -- 5. Markdown output ------------------------------------------------
+        # #177 contract: markdown mode returns a FastMCP ToolResult — the rendered
+        # table is the TEXT content (for human-facing hosts) and the full structured
+        # {data, metadata} object is preserved as structuredContent (for schema-aware
+        # hosts). Assert BOTH channels directly off the CallToolResult; do NOT parse
+        # content as JSON (it is now a markdown table, not JSON — the old contract
+        # put the table string under data, which this asserted before #177).
         log.info(f"\n{BOLD}5. Markdown output{RESET}")
         try:
             async with mcp_session() as session:
-                resp = await call_tool(
-                    session,
-                    "list_devices",
-                    {
-                        "limit": 3,
-                        "output_format": "markdown",
-                    },
+                result = await session.call_tool(
+                    "list_devices", {"limit": 3, "output_format": "markdown"}
                 )
-                fmt = resp.get("metadata", {}).get("format")
-                data_str = resp.get("data", "")
-                has_table = isinstance(data_str, str) and "|" in data_str and "---" in data_str
+                table_text = next(
+                    (b.text for b in result.content if isinstance(b, types.TextContent)), ""
+                )
+                has_table = "|" in table_text and "---" in table_text
+                sc = result.structuredContent or {}
+                has_structured = isinstance(sc.get("data"), (dict, list))
                 record(
-                    "markdown output — format=markdown with table",
-                    fmt == "markdown" and has_table,
-                    f"format={fmt}, has_table={has_table}",
+                    "markdown output — table in content + structured object preserved",
+                    not result.isError and has_table and has_structured,
+                    f"has_table={has_table}, structured_data={has_structured}",
                 )
         except Exception as exc:
-            record("markdown output — format=markdown with table", False, str(exc))
+            record(
+                "markdown output — table in content + structured object preserved", False, str(exc)
+            )
 
         # -- 6. discover_capabilities ------------------------------------------
         log.info(f"\n{BOLD}6. discover_capabilities{RESET}")


### PR DESCRIPTION
Found by actually running the smoke suite against the live tenant (per the pre-tag gate).

## What happened

First live run: **96/97**, one failure — the markdown test (test 5): `unhandled errors in a TaskGroup`. Root-caused two ways:

- **Tool layer (in-memory, live data):** `list_devices` markdown returns the table in `content` + the structured object in `structuredContent`, no error.
- **HTTP transport:** `list_devices` markdown succeeded **5/5** over `streamablehttp_client`.

So the `TaskGroup` error was a **transient transport blip** — *not* a product regression. But chasing it exposed a real stale test: **test 5 still asserted the pre-#177 markdown contract** (table string under `data`, `metadata.format == "markdown"`) and parsed the result's content block as JSON. #177 changed markdown mode to a `ToolResult` (table in `content`, structured object in `structuredContent`), so test 5 would fail on every markdown call regardless of the blip. That was a miss in the earlier "smoke readiness" pass (#196) — it added new assertions but didn't update the existing markdown test for #177's contract change.

## Fix

Test 5 now asserts the **new dual-channel contract** directly off the `CallToolResult`: a markdown table in `content` **and** the structured `{data, metadata}` object preserved in `structuredContent` (no JSON-parse of the content block).

## Verified live

Full smoke re-run: **97 tests, 97 passed, 0 failed** (`SMOKE_EXIT=0`). Markdown test reports `has_table=True, structured_data=True`. The two assertions added in #196 also behaved correctly: `mcp_app_resources` PASS (5 `ui://` Apps list with the MCP-App MIME); `list_zone_users` skip-OK (this tenant has no zones, so the live redaction path wasn't exercised — the unit test covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)