### PR TITLE
docs(resources): replace real-looking example org/group IDs with placeholders

### DIFF
--- a/src/automox_mcp/resources/policy_resources.py
+++ b/src/automox_mcp/resources/policy_resources.py
@@ -48,7 +48,7 @@ def register_policy_resources(server: FastMCP) -> None:
                     "action": "create",
                     "policy": {
                         "name": "Auto-Patch Google Chrome",
-                        "organization_id": 106820,
+                        "organization_id": 123456,
                         "policy_type_name": "patch",
                         "configuration": {
                             "patch_rule": "filter",
@@ -58,7 +58,7 @@ def register_policy_resources(server: FastMCP) -> None:
                             "notify_user": True,
                         },
                         "schedule": {"days": ["weekdays"], "time": "02:00"},
-                        "server_groups": [366711],
+                        "server_groups": [12345],
                         "notes": "Automatically patches Google Chrome on weekdays at 2 AM",
                     },
                 },
@@ -132,7 +132,7 @@ def register_policy_resources(server: FastMCP) -> None:
                     "action": "create",
                     "policy": {
                         "name": "Auto-Patch Firefox",
-                        "organization_id": 106820,
+                        "organization_id": 123456,
                         "policy_type_name": "patch",
                         "configuration": {
                             "filter_name": "Firefox",
@@ -141,7 +141,7 @@ def register_policy_resources(server: FastMCP) -> None:
                             "notify_user": True,
                         },
                         "schedule": {"days": ["weekdays"], "time": "02:00"},
-                        "server_groups": [366711],
+                        "server_groups": [12345],
                         "notes": "Automatically patches Firefox on weekdays at 2 AM",
                     },
                 },
@@ -342,7 +342,7 @@ def register_policy_resources(server: FastMCP) -> None:
                                 "days": ["weekdays"],
                                 "time": "02:00",
                             },
-                            "server_groups": [366711],
+                            "server_groups": [12345],
                         },
                         "critical_patches": {
                             "name": "Critical Patches - Weekly",


### PR DESCRIPTION
## Summary

The patch-policy build-templates and configuration examples in `policy_resources.py` hard-coded `organization_id: 106820` and `server_groups: [366711]` — tenant-derived values that shouldn't ship as published examples. Replaced with the file's existing placeholder convention (`123456` / `12345`).

Example-data only — **no behavior change**, no test references these IDs.

### Caveat

These values are **pre-existing** in `main` history, so this only changes the documented examples going forward; the prior values remain in git history (accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
