### PR TITLE
chore(release): 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-06-09
+
 ### Added
 
 - **Create "Patch by Severity" policies via `apply_policy_changes`.** A patch policy with `configuration.patch_rule='filter'` + `filter_type='severity'` + a `severity_filter` list (e.g. `['critical']`) is now constructed correctly — previously the builder required a name-pattern `filters` and rejected any severity-only policy. `severity_filter` values are normalized (lowercased, de-duplicated) and validated against the API enum (`no_known_cves`, `none`, `unknown`, `low`, `medium`, `high`, `critical`); an unknown value is rejected with the allowed set rather than an opaque API error. Verified end-to-end against a live tenant (create→read-back→delete; the API persisted all seven severity values). Replaces the prior limitation that pointed severity policies to `clone_policy`/the console.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+### v2.2.1 — Create patch-by-severity policies (2026-06-09) [Feature]
+
+**Target patches by severity, straight from your assistant.** You can now create a "Patch by Severity" policy directly — for example, "patch only critical and high-severity updates" — choosing any combination of the platform's severity levels. Previously this policy type had to be built in the console or cloned from an existing policy; it is now a first-class create through the assistant, alongside patch-all and patch-by-name policies.
+
 ### v2.2.0 — Interactive in-host review surfaces (2026-06-08) [Feature]
 
 **Review and act on fleet posture visually, right inside your AI assistant.** This release adds five interactive surfaces that render directly in supported hosts: a compliance-triage dashboard, a patch-approval queue, a policy-change blast-radius preview, a remediation-apply review, and an RBAC access-certification review. Instead of reading a wall of text, operators see compliance state, affected devices, and pending decisions laid out visually — and for action-oriented flows they can act in-session, with every change still routed through the assistant's standard confirmation before anything is written. These are the server's first MCP App surfaces, bringing its MCP resources from 9 to 14.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 14 MCP resources (including interactive MCP App UIs for compliance triage, patch-approval review, policy blast-radius review, remediation-apply review, and RBAC access certification), and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.2.0"
+version = "2.2.1"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.2.0",
+  "automox-mcp>=2.2.1",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.2.0"
+version = "2.2.1"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Release prep for **2.2.1** — version bump only; all functional changes are already merged to `main`.

- Version → `2.2.1` across the four release-synced files (`pyproject.toml`, `server.json` incl. `packages[].version`, `mcpb/manifest.json`, `mcpb/pyproject.toml` incl. the `automox-mcp>=` floor) + `uv.lock`.
- CHANGELOG: dated the `2.2.1` heading (a fresh empty `[Unreleased]` is retained).
- `docs/release-notes.md`: added a customer-facing highlight for Patch-by-Severity policy creation.

### What 2.2.1 ships (already on `main`)

- **Fixes (#206):** the response sanitizer no longer corrupts worklet/policy code on read-back; "patch all" (and manual/advanced) patch policies can now be created; `apply_policy_changes` returns the created policy's id; the documented `schedule` helper block is accepted; the patch-policy resource docs were corrected.
- **Cleanup:** scrubbed real org/group IDs from resource examples.
- **Feature:** create Patch-by-Severity policies (`patch_rule='filter'` + `filter_type='severity'` + `severity_filter`).

No tool/resource count changes (133 tools / 85 read / 48 write, 14 resources).

### Pre-tag checklist (after this merges, on explicit go-ahead only)

- [ ] Final smoke run, `0 failures` (today's was 103/103)
- [ ] Tag push `v2.2.1` — triggers irreversible PyPI/registry/MCPB publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
