### PR TITLE
chore: pre-release review polish (doc clarity + smoke helper)

### DIFF
--- a/src/automox_mcp/resources/policy_resources.py
+++ b/src/automox_mcp/resources/policy_resources.py
@@ -324,9 +324,10 @@ def register_policy_resources(server: FastMCP) -> None:
                             "str - REQUIRED - One of: 'all', 'filter', 'manual', 'advanced'"
                         ),
                         "filter_type": (
-                            "str - REQUIRED - 'all' for patch_rule all/manual/advanced; for "
-                            "'filter' use 'include' (Patch Only), 'exclude' (Patch All Except), "
-                            "or 'severity' (Patch by Severity). Auto-set when omitted"
+                            "str - Required by the Automox API; the MCP auto-sets it if you omit "
+                            "it. Value is 'all' for patch_rule all/manual/advanced; for 'filter' "
+                            "it is 'include' (Patch Only), 'exclude' (Patch All Except), or "
+                            "'severity' (Patch by Severity)"
                         ),
                         "auto_patch": "bool - REQUIRED - Automatically apply patches",
                         "auto_reboot": "bool - REQUIRED - Automatically reboot after patching",

--- a/src/automox_mcp/workflows/policy_crud.py
+++ b/src/automox_mcp/workflows/policy_crud.py
@@ -193,8 +193,10 @@ def normalize_policy_operations_input(raw_operations: Sequence[Any]) -> list[dic
             # requires configuration.filter_type on patch-policy create for
             # every patch_rule (not just 'filter') — stripping it caused a 400
             # ("filter_type field is required") for patch_rule='all' (issue
-            # #206). A caller-supplied value is preserved and normalized by the
-            # payload builder; the builder defaults it when absent.
+            # #206). A caller-supplied value flows through to the payload builder
+            # (_coerce_policy_payload_defaults), which sets the final value per
+            # patch_rule: forced to 'all' for non-filter rules; for 'filter',
+            # honored/defaulted ('include' when omitted) or 'severity'.
 
             policy["configuration"] = config
 

--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -143,6 +143,13 @@ def record(name: str, passed: bool, detail: str = "") -> None:
     _results.append((name, passed, detail))
 
 
+def _throwaway_name() -> str:
+    """Unique name for a self-cleaning write round-trip. The shared
+    'mcp-smoke-delete-me-' prefix flags the object as smoke residue if cleanup
+    ever fails, so every throwaway must go through here."""
+    return f"mcp-smoke-delete-me-{uuid.uuid4().hex[:8]}"
+
+
 def summary() -> int:
     total = len(_results)
     passed = sum(1 for _, p, _ in _results if p)
@@ -1381,7 +1388,7 @@ async def run_readonly_tools() -> None:
         # self-cleaning write: a uniquely-named throwaway search is always
         # deleted (best-effort) even if an assertion fails, so it leaves no
         # residue in the tenant.
-        ss_name = f"mcp-smoke-delete-me-{uuid.uuid4().hex[:8]}"
+        ss_name = _throwaway_name()
         ss_query = {
             "filters": [
                 {
@@ -1447,7 +1454,7 @@ async def run_readonly_tools() -> None:
         # Asserts CORRECTNESS, not just 200: (a) the create actually succeeds (the
         # API no longer rejects a non-filter patch policy), and (b) the STORED
         # configuration carries filter_type="all" (the contract the fix targets).
-        pol_name = f"mcp-smoke-delete-me-{uuid.uuid4().hex[:8]}"
+        pol_name = _throwaway_name()
         patch_all_op = {
             "action": "create",
             "policy": {
@@ -1509,7 +1516,7 @@ async def run_readonly_tools() -> None:
         # Inert + self-cleaning, same as 78c. NB: the builder sets no
         # is_patch_tuesday/patch_tuesday_offset; a 400 here would reveal the
         # live API requires them for filter-type configs.
-        sev_name = f"mcp-smoke-delete-me-{uuid.uuid4().hex[:8]}"
+        sev_name = _throwaway_name()
         all_severities = ["no_known_cves", "none", "unknown", "low", "medium", "high", "critical"]
         severity_op = {
             "action": "create",


### PR DESCRIPTION
Vetted reviewer findings; applied the valid ones (no runtime change).

- **policy_resources.py** — `filter_type` doc was contradictory ("REQUIRED" + "Auto-set when omitted"); now reads "Required by the API; the MCP auto-sets it if you omit it."
- **policy_crud.py** — corrected the normalize comment: a caller-supplied `filter_type` isn't simply "preserved" — the builder *forces* `'all'` for non-filter rules and honors/defaults it for `'filter'`; now cross-references the builder.
- **smoke_production.py** — extracted the repeated `mcp-smoke-delete-me-{uuid}` pattern into `_throwaway_name()`.

**Not applied (with reason):** importing `_ALLOWED_SEVERITIES` into the smoke severity probe — `smoke_production.py` is a black-box test (no package-internal imports); the hardcoded spec vocabulary is the correct black-box assertion, and drift is already guarded by the unit test. The Splashtop release-notes flag name was already fixed in #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)