### PR TITLE
chore(release): 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Automox MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.2] - 2026-06-10
 
 ### Added
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+### v2.2.2 — Trustworthy capability discovery (2026-06-10) [Improvement]
+
+**Your assistant now knows exactly which tools it can use in your session.** The capability-discovery tool reports live availability instead of a static catalog: tools withheld by an opt-in safety flag, read-only mode, or module filtering are marked unavailable, and each safety-gated tool names the exact setting that enables it — so the assistant routes around tools it can't call and can tell you precisely how to enable a capability you want. Discovery responses also carry self-checking totals, letting clients verify they've seen the complete inventory rather than silently missing a domain.
+
 ### v2.2.1 — Create patch-by-severity policies (2026-06-09) [Feature]
 
 **Target patches by severity, straight from your assistant.** You can now create a "Patch by Severity" policy directly — for example, "patch only critical and high-severity updates" — choosing any combination of the platform's severity levels. Previously this policy type had to be built in the console or cloned from an existing policy; it is now a first-class create through the assistant, alongside patch-all and patch-by-name policies.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more — all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 14 MCP resources (including interactive MCP App UIs for compliance triage, patch-approval review, policy blast-radius review, remediation-apply review, and RBAC access certification), and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.2.1"
+version = "2.2.2"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.2.1",
+  "automox-mcp>=2.2.2",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.2.1"
+version = "2.2.2"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.2.1"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Release 2.2.2 — runtime-aware, self-checking `discover_capabilities` (#217 / #219).

- Roll `[Unreleased]` → `[2.2.2] - 2026-06-10` in `CHANGELOG.md`
- Version bump across all four manifest-checked files (`pyproject.toml`, `server.json` incl. `packages[].version`, `mcpb/manifest.json`, `mcpb/pyproject.toml` version + `automox-mcp>=` floor)
- `docs/release-notes.md`: discovery-improvement highlight

Post-merge: run the production smoke suite (0 failures required), then tag `v2.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)