### PR TITLE
Fix ten high-severity security, stability, and data-integrity defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.4] - 2026-06-24
+
+### Security
+
+- **Zone listings no longer leak `access_key` secrets or `created_by` user PII.** `list_zones` and `list_zones_for_user` returned each zone DTO verbatim from the envelope, surfacing every zone's `access_key` credential and the nested `created_by` blob (email, names, two-factor status, RBAC role) to the model — the single-zone `get_zone` already redacted through an allowlist, but the two list paths bypassed it. All zone read/create paths now share one `_project_zone` projector that drops `access_key` and reduces `created_by` to a non-PII id/name reference.
+- **The access-certification review App now reports 2FA-disabled accounts correctly.** The App classified the `tfa_type` field by raw JavaScript truthiness, so an account with 2FA OFF — the API sends the literal string `"disabled"`, not null — rendered green as "2FA: enabled", inverting the signal in an access-review surface where an operator could certify an unprotected account as protected. It now classifies `disabled`/`none`/empty as OFF, null/absent as an explicit unknown state, and shows green only for genuinely-enabled values.
+
+### Fixed
+
+- **The Splashtop install, initiate-connection, and bulk attended-access tools no longer crash.** Their `device_uuid`/`device_uuids` parameters are typed as `UUID`; the values were serialized as Python objects into the JSON request body and crashed httpx (`TypeError`), leaving all three tools dead on every call. They now dump in JSON mode so the UUIDs serialize as strings, matching the existing `policy_windows` pattern.
+- **Splashtop install / uninstall / force-disconnect no longer report success as failure.** These endpoints return HTTP 200 with a bare, unquoted string body (`Command executed successfully`) under an `application/json` content-type; the client treated any non-JSON 2xx body as a parse failure and raised `invalid JSON response`. The client gained a per-call `allow_text_response` opt-in — used only by these three Splashtop writes — that surfaces the text as `{"message": ...}`; the strict-JSON guard is unchanged for every other endpoint.
+- **`policy_run_results` no longer crashes on non-numeric upstream pagination metadata.** A non-coercible upstream `metadata.limit`/`total_count` raised a pydantic `ValidationError` outside the tool's error-handling boundary — crashing the call and echoing the raw upstream value instead of returning a sanitized error. The reserved pagination keys are now coerced defensively (non-coercible → null) and the source forwards are int-guarded.
+- **Markdown output no longer crashes on tools that return string lists.** `list_searches_for_device` and `device_search_typeahead` return bare arrays of strings; rendering them with `output_format="markdown"` raised `AttributeError`. The table renderer now handles scalar rows (single-column table) instead of assuming every row is a mapping.
+- **Token-budget truncation no longer misreports a truncated response as complete.** When an over-budget response was shrunk, it could still carry `has_more=false`/`last=true` and sibling count fields (e.g. `total_devices`, `events_returned`) that overstated the surviving list. Truncation now forces `has_more=true`, clears the completeness flag, and reconciles each count down to the length of the specific list it names.
+- **`list_devices_for_policies` now reports the real blast-radius device count.** It counted the `{"servers": [...]}` envelope as a single record, so `total_devices` was always 1 regardless of how many devices a policy actually targeted — a dangerously misleading pre-flight count. It now unwraps the `servers` envelope, mirroring `preview_policy_device_filters`.
+- **`policy_runs_v2` time filtering no longer drops a whole day.** `start_time`/`end_time` were compared lexicographically as strings, so a bare-date `end_time` (e.g. `2026-06-18`) excluded every run on that day, and mixed `Z`/`+00:00` forms sorted wrong. Bounds and run times are now parsed to timezone-aware datetimes, with bare-date start/end-of-day normalization for inclusive day ranges.
+- **`audit_trail_user_activity` no longer returns the whole-org event stream mislabeled as one actor.** When `actor_name` could not be resolved to an email/uuid, no filter was applied yet `applied_filters.actor_name` still echoed the requested name, so every actor's events came back labeled as that actor's activity. It now returns zero events with an honest `metadata.filter_ineffective` signal and never asserts the filter as applied when it wasn't.
+
 ## [2.2.3] - 2026-06-23
 
 ### Added

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more \u2014 all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 14 MCP resources (including interactive MCP App UIs for compliance triage, patch-approval review, policy blast-radius review, remediation-apply review, and RBAC access certification), and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.2.3"
+version = "2.2.4"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.2.3",
+  "automox-mcp>=2.2.4",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.2.3"
+version = "2.2.4"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.2.3",
+  "version": "2.2.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/automox_mcp/client.py
+++ b/src/automox_mcp/client.py
@@ -166,6 +166,7 @@ class AutomoxClient:
         json_data: Mapping[str, Any] | None = None,
         params: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
+        allow_text_response: bool = False,
     ) -> AutomoxResponse:
         return await self._request(
             "POST",
@@ -173,6 +174,7 @@ class AutomoxClient:
             params=params,
             json_data=json_data,
             headers=headers,
+            allow_text_response=allow_text_response,
         )
 
     async def put(
@@ -198,6 +200,7 @@ class AutomoxClient:
         json_data: Mapping[str, Any] | None = None,
         params: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
+        allow_text_response: bool = False,
     ) -> AutomoxResponse:
         return await self._request(
             "DELETE",
@@ -205,6 +208,7 @@ class AutomoxClient:
             params=params,
             json_data=json_data,
             headers=headers,
+            allow_text_response=allow_text_response,
         )
 
     async def patch(
@@ -231,6 +235,7 @@ class AutomoxClient:
         params: Mapping[str, Any] | Sequence[tuple[str, Any]] | None = None,
         json_data: Mapping[str, Any] | None = None,
         headers: Mapping[str, str] | None = None,
+        allow_text_response: bool = False,
     ) -> AutomoxResponse:
         merged_headers, correlation_id = self._prepare_headers(headers)
         logger.debug(
@@ -253,7 +258,12 @@ class AutomoxClient:
         except httpx.RequestError as exc:
             self._raise_network_error(exc, method, path, start, correlation_id)
         return self._process_response(
-            response, method=method, path=path, correlation_id=correlation_id, start=start
+            response,
+            method=method,
+            path=path,
+            correlation_id=correlation_id,
+            start=start,
+            allow_text_response=allow_text_response,
         )
 
     async def post_multipart(
@@ -344,6 +354,7 @@ class AutomoxClient:
         path: str,
         correlation_id: str | None,
         start: float,
+        allow_text_response: bool = False,
     ) -> AutomoxResponse:
         latency_ms = (time.monotonic() - start) * 1000.0
         retry_after = response.headers.get("Retry-After")
@@ -395,6 +406,14 @@ class AutomoxClient:
             data: AutomoxResponse = response.json()
             return data
         except json.JSONDecodeError as exc:
+            if allow_text_response:
+                # Opt-in only: some success endpoints (Splashtop install/
+                # uninstall/force-disconnect) return 2xx with a bare, unquoted
+                # string body ('Command executed successfully') under an
+                # application/json content-type. Callers that know to expect
+                # this surface the text as a message rather than failing; every
+                # other caller keeps the strict-JSON guard below.
+                return {"message": response.text}
             raise AutomoxAPIError(
                 "invalid JSON response from Automox", response.status_code
             ) from exc

--- a/src/automox_mcp/resources/access_certification_app.py
+++ b/src/automox_mcp/resources/access_certification_app.py
@@ -84,6 +84,7 @@ _HTML_TEMPLATE = """<!doctype html>
   .tfa { font-size: 11px; margin-top: 4px; }
   .tfa.off { color: var(--bad); }
   .tfa.on { color: var(--good); }
+  .tfa.unknown { color: var(--muted); }
   .actions { display: flex; flex-direction: column; gap: 6px; flex: 0 0 auto; }
   .btn {
     border: 1px solid var(--border); border-radius: 6px; padding: 4px 10px;
@@ -120,6 +121,16 @@ _HTML_TEMPLATE = """<!doctype html>
     var n = [u.firstname, u.lastname].filter(Boolean).join(" ");
     return n || u.name || u.email || "(unnamed user)";
   }
+  // Classify a 2FA field value. The Automox field carries the LITERAL STRING
+  // 'disabled' (not null) when 2FA is OFF, so bare truthiness is wrong — it
+  // would render a disabled account as protected. null/undefined/absent is an
+  // explicit unknown state; any other non-empty value is genuinely enabled.
+  function tfaState(tfa) {
+    if (tfa == null) return "unknown";
+    var v = String(tfa).trim().toLowerCase();
+    if (v === "" || v === "disabled" || v === "disable" || v === "none") return "off";
+    return "on";
+  }
   function roleNames(u) {
     var out = [];
     function add(list) {
@@ -148,6 +159,10 @@ _HTML_TEMPLATE = """<!doctype html>
     var key = userKey(u, i);
     var roles = roleNames(u);
     var tfa = u.tfa_type;
+    var tfaCls = tfaState(tfa);
+    var tfaLabel = tfaCls === "on" ? "2FA: " + esc(tfa)
+      : tfaCls === "off" ? "⚠ no 2FA"
+      : "2FA: unknown";
     var row = document.createElement("div");
     row.className = "row" + (state[key] ? " " + state[key] : "");
     var roleChips = roles.length
@@ -158,8 +173,7 @@ _HTML_TEMPLATE = """<!doctype html>
         '<div class="name">' + esc(fullName(u)) + "</div>" +
         '<div class="email">' + esc(u.email || "") + "</div>" +
         '<div class="roles">' + roleChips + "</div>" +
-        '<div class="tfa ' + (tfa ? "on" : "off") + '">' +
-          (tfa ? "2FA: " + esc(tfa) : "⚠ no 2FA") + "</div>" +
+        '<div class="tfa ' + tfaCls + '">' + tfaLabel + "</div>" +
       "</div>" +
       '<div class="actions">' +
         '<button class="btn certify' +

--- a/src/automox_mcp/tools/splashtop_tools.py
+++ b/src/automox_mcp/tools/splashtop_tools.py
@@ -215,6 +215,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                     _install_splashtop,
                     params,
                     params_model=SplashtopInstallParams,
+                    dump_mode="json",
                 )
             except BaseException:
                 await release_idempotency(request_id, "splashtop_install")
@@ -309,6 +310,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                     _initiate_connection,
                     params,
                     params_model=SplashtopInitiateConnectionParams,
+                    dump_mode="json",
                 )
             except BaseException:
                 await release_idempotency(request_id, "splashtop_initiate_connection")
@@ -423,6 +425,7 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                         "required_attended_access": required_attended_access,
                     },
                     params_model=SplashtopSetBulkAttendedAccessParams,
+                    dump_mode="json",
                 )
             except BaseException:
                 await release_idempotency(request_id, "splashtop_set_bulk_attended_access")

--- a/src/automox_mcp/utils/tooling.py
+++ b/src/automox_mcp/utils/tooling.py
@@ -531,6 +531,7 @@ def _apply_token_budget(
         meta["total_available"] = total
         meta["returned_count"] = len(response_dict["data"])
         meta["truncations"] = {"data": {"total": total, "returned": len(response_dict["data"])}}
+        _reconcile_after_truncation(meta, returned=len(response_dict["data"]))
     elif isinstance(data, dict):
         # Truncate ALL oversized lists in the mapping, not just the first.
         truncations: dict[str, dict[str, int]] = {}
@@ -550,8 +551,95 @@ def _apply_token_budget(
             # earlier consumers; new code should read `truncations` for
             # per-key counts.
             meta["total_available"] = sum(t["total"] for t in truncations.values())
+            # Reconcile sibling scalar count fields (e.g. `<x>_returned`,
+            # `total_<x>`, `total_devices`) that still equal the pre-truncation
+            # length down to the shrunk length so no count overstates what's
+            # present. Use the largest surviving list as the post-truncation
+            # reference length.
+            max_returned = max(t["returned"] for t in truncations.values())
+            _reconcile_sibling_counts(data, truncations=truncations, fallback_len=max_returned)
+            _reconcile_after_truncation(meta, returned=max_returned)
 
     return response_dict
+
+
+# Conventional sibling scalar count keys (suffix / prefix patterns) that travel
+# alongside a list in `data` and report its length. After truncation these would
+# overstate the shrunk list, so they are reconciled down. A full cursor /
+# suggested_next_call continuation is a follow-up (out of scope here).
+_COUNT_KEY_SUFFIXES = ("_returned", "_count")
+_COUNT_KEY_PREFIXES = ("total_",)
+
+
+def _count_key_base(key: str) -> str | None:
+    """Return the list name a count key references, or ``None`` if it isn't one.
+
+    ``total_devices`` -> ``devices``; ``events_returned`` -> ``events``;
+    ``groups_count`` -> ``groups``. A bare ``total``/``count`` yields ``""``.
+    """
+    for suffix in _COUNT_KEY_SUFFIXES:
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    for prefix in _COUNT_KEY_PREFIXES:
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+    return None
+
+
+def _reconcile_sibling_counts(
+    data: dict[str, Any],
+    *,
+    truncations: dict[str, dict[str, int]],
+    fallback_len: int,
+) -> None:
+    """Clamp conventional scalar count fields in *data* to their list's length.
+
+    A count key is clamped to the surviving length of the specific list it names
+    (e.g. ``total_devices`` -> ``data['devices']``); a generic count that names
+    no single list falls back to the largest surviving list. Only ints that
+    currently *overstate* their reference length are lowered; legitimately
+    smaller counts are left untouched.
+    """
+    for key, value in data.items():
+        if not isinstance(value, int) or isinstance(value, bool):
+            continue
+        base = _count_key_base(key)
+        if base is None:
+            continue
+        limit = truncations[base]["returned"] if base in truncations else fallback_len
+        if value > limit:
+            data[key] = limit
+
+
+def _reconcile_after_truncation(meta: dict[str, Any], *, returned: int) -> None:
+    """Ensure a truncated response never signals completeness.
+
+    When items were dropped, a ``metadata.pagination`` block must not assert the
+    page is complete: force ``has_more=True`` and clear any ``last=True`` (Spring
+    completeness flag) so the response cannot simultaneously claim completeness
+    and be truncated.
+    """
+    pagination = meta.get("pagination")
+    if isinstance(pagination, dict):
+        pagination["has_more"] = True
+        if pagination.get("last") is True:
+            pagination["last"] = False
+
+
+def _coerce_optional_int(value: Any) -> int | None:
+    """Coerce *value* to ``int`` when possible, else ``None``.
+
+    Booleans are rejected (``True``/``False`` are not meaningful counts) and
+    empty/garbage strings degrade to ``None`` instead of raising.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def as_tool_response(result: Mapping[str, Any]) -> dict[str, Any]:
@@ -564,6 +652,15 @@ def as_tool_response(result: Mapping[str, Any]) -> dict[str, Any]:
     if correlation_id:
         metadata_dict["correlation_id"] = correlation_id
     data = result.get("data")
+    # Defensively coerce every strictly-typed reserved pagination key. Upstream
+    # metadata can forward a non-int value (e.g. "" or a string) into any of
+    # these; PaginationMetadata types them as int|None, so a raw value would
+    # raise a ValidationError here — outside call_tool_workflow's try/except —
+    # bypassing the format_validation_error sanitizer and crashing the tool.
+    # Degrade a non-coercible value to None rather than raise.
+    for _key in ("current_page", "total_pages", "total_count", "limit"):
+        if _key in metadata_dict:
+            metadata_dict[_key] = _coerce_optional_int(metadata_dict[_key])
     metadata = PaginationMetadata(**metadata_dict)
     response = ToolResponse(data=data, metadata=metadata)
     response_dict = cast(dict[str, Any], response.model_dump())
@@ -572,19 +669,17 @@ def as_tool_response(result: Mapping[str, Any]) -> dict[str, Any]:
     return _apply_token_budget(response_dict)
 
 
-def format_as_markdown_table(data: list[dict[str, Any]], *, max_col_width: int = 40) -> str:
-    """Convert a list of flat dicts into a Markdown table string."""
+def format_as_markdown_table(data: list[Any], *, max_col_width: int = 40) -> str:
+    """Convert a list of flat dicts into a Markdown table string.
+
+    Robust to non-dict rows: a list of scalars (e.g. UUID/name strings from
+    ``list_searches_for_device`` / ``device_search_typeahead``) renders as a
+    single ``value`` column rather than raising ``AttributeError`` on
+    ``row.get`` (the crash would propagate outside ``call_tool_workflow``'s
+    try/except and take down the tool).
+    """
     if not data:
         return "_No data_"
-
-    # Collect all keys preserving insertion order
-    columns: list[str] = []
-    seen: set[str] = set()
-    for row in data:
-        for key in row:
-            if key not in seen:
-                columns.append(key)
-                seen.add(key)
 
     def _cell(value: Any) -> str:
         text = str(value) if value is not None else ""
@@ -592,12 +687,34 @@ def format_as_markdown_table(data: list[dict[str, Any]], *, max_col_width: int =
             text = text[: max_col_width - 3] + "..."
         return text.replace("|", "\\|")
 
+    # Scalar rows (no dicts) → single-column table.
+    if not any(isinstance(row, Mapping) for row in data):
+        header = "| value |"
+        separator = "| --- |"
+        rows = ["| " + _cell(row) + " |" for row in data]
+        return "\n".join([header, separator, *rows])
+
+    # Collect all keys preserving insertion order (dict rows only).
+    columns: list[str] = []
+    seen: set[str] = set()
+    for row in data:
+        if not isinstance(row, Mapping):
+            continue
+        for key in row:
+            if key not in seen:
+                columns.append(key)
+                seen.add(key)
+
     header = "| " + " | ".join(columns) + " |"
     separator = "| " + " | ".join("---" for _ in columns) + " |"
 
     rows = []
     for row in data:
-        cells = [_cell(row.get(col)) for col in columns]
+        if isinstance(row, Mapping):
+            cells = [_cell(row.get(col)) for col in columns]
+        else:
+            # Non-dict row in a mixed list: place its scalar in the first column.
+            cells = [_cell(row)] + ["" for _ in columns[1:]]
         rows.append("| " + " | ".join(cells) + " |")
 
     return "\n".join([header, separator, *rows])

--- a/src/automox_mcp/workflows/account.py
+++ b/src/automox_mcp/workflows/account.py
@@ -236,6 +236,18 @@ _ZONE_FIELDS = (
     "created_at",
     "updated_at",
 )
+# The zone DTO's `created_by` is a nested *User* blob (email, names,
+# two_factor_authentication, RBAC role). Surfacing it raw — especially across a
+# list endpoint that returns many zones at once — leaks user PII. Re-project it
+# through this allowlist so only a non-PII actor reference (id + display name)
+# survives; never email, 2FA, or RBAC role. Mirrors the nested-org redaction in
+# get_user (see _USER_ORG_FIELDS).
+_ZONE_CREATED_BY_FIELDS = (
+    "id",
+    "user_id",
+    "firstname",
+    "lastname",
+)
 # Nested org projection for get_user.orgs[]. The User DTO forwards each org
 # whole, and an org object can carry `access_key` (a per-org credential) plus
 # `saml`/`metadata` config blobs. Project an allowlist of navigation-safe
@@ -258,6 +270,18 @@ _USER_ORG_FIELDS = (
 
 def _project(item: Mapping[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
     return {key: item.get(key) for key in fields if item.get(key) is not None}
+
+
+def _project_zone(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a zone DTO through the allowlist (drops `access_key`) and
+    re-project its nested `created_by` user blob down to a non-PII actor
+    reference. Shared by every zone read/write path so the redaction guarantee
+    holds uniformly (see SECURITY note above)."""
+    zone = _project(item, _ZONE_FIELDS)
+    created_by = zone.get("created_by")
+    if isinstance(created_by, Mapping):
+        zone["created_by"] = _project(created_by, _ZONE_CREATED_BY_FIELDS)
+    return zone
 
 
 def _envelope(response: Any) -> tuple[list[Any], dict[str, Any]]:
@@ -401,6 +425,9 @@ async def list_zones_for_user(
     """List the zones a given user belongs to."""
     response = await client.get(f"/accounts/{account_id}/users/{user_id}/zones")
     zones, meta = _envelope(response)
+    # SECURITY: project each zone through the allowlist so `access_key` and the
+    # nested `created_by` user PII are never forwarded raw (mirrors get_zone).
+    zones = [_project_zone(z) for z in zones if isinstance(z, Mapping)]
     meta["deprecated_endpoint"] = False
     meta["account_id"] = str(account_id)
 
@@ -425,6 +452,9 @@ async def list_zones(
         params["limit"] = limit
     response = await client.get(f"/accounts/{account_id}/zones", params=params or None)
     zones, meta = _envelope(response)
+    # SECURITY: project each zone through the allowlist so `access_key` and the
+    # nested `created_by` user PII are never forwarded raw (mirrors get_zone).
+    zones = [_project_zone(z) for z in zones if isinstance(z, Mapping)]
     meta["deprecated_endpoint"] = False
     meta["account_id"] = str(account_id)
 
@@ -442,7 +472,7 @@ async def get_zone(
 ) -> dict[str, Any]:
     """Get a single zone by UUID (access_key redacted)."""
     response = await client.get(f"/accounts/{account_id}/zones/{zone_id}")
-    detail = _project(response, _ZONE_FIELDS) if isinstance(response, Mapping) else {}
+    detail = _project_zone(response) if isinstance(response, Mapping) else {}
 
     return {
         "data": detail,
@@ -507,7 +537,7 @@ async def create_zone(
 ) -> dict[str, Any]:
     """Create a new zone (organization) in the account. access_key is redacted."""
     response = await client.post(f"/accounts/{account_id}/zones", json_data={"name": name})
-    detail = _project(response, _ZONE_FIELDS) if isinstance(response, Mapping) else {}
+    detail = _project_zone(response) if isinstance(response, Mapping) else {}
     detail["created"] = True
 
     return {

--- a/src/automox_mcp/workflows/audit.py
+++ b/src/automox_mcp/workflows/audit.py
@@ -710,13 +710,31 @@ async def audit_trail_user_activity(
         if resolved_uuid:
             normalized_uuid_filter = resolved_uuid
 
+    # An actor_name was requested, but the lookup could not resolve it to an
+    # email or uuid (missing account_uuid, no match, zero-score match, or an
+    # upstream error). Neither client-side filter is set, so the per-event loop
+    # below would otherwise return the WHOLE org event stream while
+    # applied_filters still echoed the requested name — every actor's events
+    # mislabeled as this actor's activity. Detect that case so we can refuse to
+    # claim the filter was applied and refuse to present unrelated events as
+    # this actor's filtered activity.
+    actor_name_unresolved = bool(
+        actor_name_text and not normalized_email_filter and not normalized_uuid_filter
+    )
+
     include_raw = bool(include_raw_events)
 
     filtered_events: list[dict[str, Any]] = []
     activity_counter: Counter[str] = Counter()
     matched_actor_context: dict[str, Any] | None = None
 
-    for event in events:
+    # When the requested actor_name did not resolve, we cannot identify which
+    # events belong to that actor. Returning the unfiltered stream as their
+    # activity is the mislabeling bug; return zero events and surface the
+    # ineffective-filter signal below instead.
+    matchable_events = [] if actor_name_unresolved else events
+
+    for event in matchable_events:
         actor_info = _extract_actor(event)
         target_user = _extract_target_user(event)
 
@@ -768,7 +786,11 @@ async def audit_trail_user_activity(
     applied_filters = {
         "actor_email": normalized_email_filter,
         "actor_uuid": normalized_uuid_filter,
-        "actor_name": actor_name_text,
+        # Only claim the name filter as applied when it actually resolved to an
+        # email/uuid that the per-event loop could match on. An unresolved name
+        # is reported via metadata.filter_ineffective instead, never asserted
+        # here as applied.
+        "actor_name": None if actor_name_unresolved else actor_name_text,
         "cursor": cursor,
         "limit": limit,
         "include_raw_events": include_raw,
@@ -789,7 +811,10 @@ async def audit_trail_user_activity(
     if resolved_actor:
         data["resolved_actor"] = resolved_actor
 
-    filter_applied = bool(normalized_email_filter or normalized_uuid_filter or actor_name_text)
+    # A filter is "applied" only when an effective client-side filter exists. An
+    # unresolved actor_name is NOT an applied filter (it matches nothing), so it
+    # must not gate the no-matches-in-page pagination advice below.
+    filter_applied = bool(normalized_email_filter or normalized_uuid_filter)
 
     metadata: dict[str, Any] = {
         "org_id": org_id,
@@ -833,6 +858,25 @@ async def audit_trail_user_activity(
                 "and re-query until both `events_returned=0` AND "
                 "`next_cursor=null`. A non-null `next_cursor` with "
                 "`events_returned=0` does NOT mean the actor was inactive."
+            ),
+        }
+    # The requested actor_name could not be resolved to an email or uuid, so no
+    # client-side filter could be applied. Surface an honest, events-adjacent
+    # signal: the actor filter did NOT apply, and (because we returned zero
+    # events) the response is not a list of this actor's activity. This prevents
+    # the consumer from reading the result as "Alice did nothing" or — worse —
+    # as the whole org's stream relabeled as Alice's.
+    if actor_name_unresolved:
+        metadata["filter_ineffective"] = {
+            "filter": "actor_name",
+            "requested_actor_name": actor_name_text,
+            "reason": "actor_name_unresolved",
+            "advice": (
+                "The requested actor_name could not be resolved to a user "
+                "(email/uuid), so the actor filter was not applied and no "
+                "events are returned. `events_returned=0` here does NOT mean "
+                "the actor had no activity. Provide actor_email or actor_uuid, "
+                "or verify the name, then re-query."
             ),
         }
     if api_next_link:

--- a/src/automox_mcp/workflows/policy.py
+++ b/src/automox_mcp/workflows/policy.py
@@ -840,10 +840,14 @@ async def describe_policy_run_result(
             ),
         },
         # Legacy fields retained for backwards-compat (#52). Canonical
-        # pagination block lives under metadata.pagination.
-        "page": upstream_page,
-        "limit": upstream_limit,
-        "total_count": upstream_total,
+        # pagination block lives under metadata.pagination. Reserved keys
+        # limit/total_count are strictly typed (int|None) on PaginationMetadata,
+        # so guard the raw upstream forwards with the same isinstance check
+        # already applied below — a non-int (e.g. "") would otherwise raise an
+        # uncaught ValidationError in as_tool_response.
+        "page": upstream_page if isinstance(upstream_page, int) else None,
+        "limit": upstream_limit if isinstance(upstream_limit, int) else None,
+        "total_count": upstream_total if isinstance(upstream_total, int) else None,
         "pagination": build_pagination_metadata(
             page=upstream_page if isinstance(upstream_page, int) else None,
             page_size=upstream_limit if isinstance(upstream_limit, int) else None,

--- a/src/automox_mcp/workflows/policy_crud.py
+++ b/src/automox_mcp/workflows/policy_crud.py
@@ -1403,7 +1403,16 @@ async def list_devices_for_policies(
         "/server-groups-api/policies/servers",
         json_data={"policies": list(policies)},
     )
-    devices = _extract_list(response)
+
+    # The endpoint returns a {"servers": [...]} envelope, which extract_list does
+    # not recognize — it would wrap the whole envelope as a single bogus "device"
+    # and report total_devices=1 for any blast radius (a dangerously misleading
+    # pre-flight count). Parse it directly, mirroring preview_policy_device_filters,
+    # and fall back to extract_list for the bare-list / {"data": [...]} shapes.
+    if isinstance(response, Mapping) and "servers" in response:
+        devices = [s for s in (response.get("servers") or []) if isinstance(s, Mapping)]
+    else:
+        devices = _extract_list(response)
 
     return {
         "data": {

--- a/src/automox_mcp/workflows/policy_history.py
+++ b/src/automox_mcp/workflows/policy_history.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -124,6 +126,57 @@ _RESULT_STATUS_KEYS = {
     "blocked": "blocked",
 }
 
+# A bare calendar date (YYYY-MM-DD) with nothing after it. Such a bound must be
+# normalized to a time-of-day boundary, or a lexicographic/instant comparison
+# silently drops every run on that day (bug #17: run_time
+# "2026-06-18T16:52:44.313Z" > end_time "2026-06-18" excludes the whole day).
+_BARE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    """Parse an ISO-8601-ish timestamp into a tz-aware (UTC) datetime.
+
+    Accepts a trailing 'Z' (normalized to +00:00) and treats a naive value as
+    UTC so mixed 'Z' vs '+00:00' forms compare correctly. Returns ``None`` when
+    the value is empty or unparseable so callers can degrade gracefully instead
+    of crashing the whole tool.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _parse_end_bound(value: str | None) -> tuple[datetime | None, bool]:
+    """Parse an ``end_time`` bound, returning ``(bound, exclusive)``.
+
+    A bare-date ``end_time`` anchors to the start of the next day and is
+    compared *exclusively* (``run_dt >= bound`` excludes) so an inclusive
+    "through that day" keeps every run on that date (bug #17). An end_time with
+    a time component keeps the original inclusive semantics (``run_dt > bound``
+    excludes). An unparseable value yields ``(None, ...)`` — no bound.
+    """
+    if value and _BARE_DATE_RE.match(value.strip()):
+        day = datetime.fromisoformat(value.strip()).replace(tzinfo=UTC)
+        return day + timedelta(days=1), True
+    return _parse_dt(value), False
+
+
+def _parse_start_bound(value: str | None) -> datetime | None:
+    """Parse a ``start_time`` bound (inclusive at start-of-day for a bare date).
+
+    A bare-date ``start_time`` anchors to 00:00:00 UTC so a run at any time that
+    day is included. Timestamps with a time component pass through unchanged.
+    """
+    if value and _BARE_DATE_RE.match(value.strip()):
+        return datetime.fromisoformat(value.strip()).replace(tzinfo=UTC)
+    return _parse_dt(value)
+
 
 async def list_policy_runs_v2(
     client: AutomoxClient,
@@ -185,6 +238,12 @@ async def list_policy_runs_v2(
         policy_type_lower = policy_type.lower() if policy_type else None
         policy_name_lower = policy_name.lower() if policy_name else None
         status_key = _RESULT_STATUS_KEYS.get(result_status.lower()) if result_status else None
+        # Parse bounds once. A bare-date end_time becomes the exclusive
+        # start-of-next-day, so it's compared with `>=` to stay inclusive of
+        # that whole day (bug #17). Unparseable bounds parse to None and are
+        # treated as "no bound" rather than crashing the tool.
+        start_bound = _parse_start_bound(start_time)
+        end_bound, end_exclusive = _parse_end_bound(end_time)
 
         def _match(run: Mapping[str, Any]) -> bool:
             if policy_uuid_str and str(run.get("policy_uuid") or "") != policy_uuid_str:
@@ -197,11 +256,19 @@ async def list_policy_runs_v2(
                 policy_name_lower not in str(run.get("policy_name") or "").lower()
             ):
                 return False
-            run_time = str(run.get("run_time") or "")
-            if start_time and run_time < start_time:
-                return False
-            if end_time and run_time > end_time:
-                return False
+            run_dt = _parse_dt(str(run.get("run_time") or ""))
+            # An unparseable run_time can't be range-checked; don't drop it on a
+            # parse failure (degrade gracefully — keep filtering behavior sane).
+            if run_dt is not None:
+                if start_bound is not None and run_dt < start_bound:
+                    return False
+                # A bare-date end is exclusive at start-of-next-day (keeps the
+                # whole day); a full-timestamp end stays inclusive at the bound.
+                if end_bound is not None:
+                    if end_exclusive and run_dt >= end_bound:
+                        return False
+                    if not end_exclusive and run_dt > end_bound:
+                        return False
             if status_key is not None:
                 counter = run.get(status_key)
                 if not isinstance(counter, (int, float)) or counter <= 0:

--- a/src/automox_mcp/workflows/splashtop.py
+++ b/src/automox_mcp/workflows/splashtop.py
@@ -129,6 +129,7 @@ async def install_splashtop(
         "/remotecontrol-st/install",
         json_data=body,
         params=params or None,
+        allow_text_response=True,
     )
 
     return {
@@ -220,6 +221,7 @@ async def force_disconnect(
     response = await client.post(
         f"/remotecontrol-st/force-disconnection/{device_uuid}",
         params={"os_family": os_family},
+        allow_text_response=True,
     )
 
     return {
@@ -297,6 +299,7 @@ async def uninstall_splashtop(
     await client.delete(
         f"/remotecontrol-st/uninstall/{device_uuid}",
         params={"os_family": os_family},
+        allow_text_response=True,
     )
 
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,13 @@ class StubClient:
         return self._pop(self._get, path)
 
     async def post(
-        self, path: str, *, json_data: Any = None, params: Any = None, headers: Any = None
+        self,
+        path: str,
+        *,
+        json_data: Any = None,
+        params: Any = None,
+        headers: Any = None,
+        allow_text_response: bool = False,
     ) -> Any:
         self.calls.append(("POST", path, json_data))
         return self._pop(self._post, path)
@@ -210,7 +216,13 @@ class StubClient:
         return self._pop(self._patch, path)
 
     async def delete(
-        self, path: str, *, json_data: Any = None, params: Any = None, headers: Any = None
+        self,
+        path: str,
+        *,
+        json_data: Any = None,
+        params: Any = None,
+        headers: Any = None,
+        allow_text_response: bool = False,
     ) -> Any:
         # Record json_data when present (body-bearing DELETE), else params, so
         # existing param-only delete assertions stay unchanged.

--- a/tests/test_fix_access_cert_2fa.py
+++ b/tests/test_fix_access_cert_2fa.py
@@ -1,0 +1,51 @@
+"""Regression test for the 2FA-status inversion in the access-certification App.
+
+Bug #10 (WRONG_DATA · High): the generated review UI classified the ``tfa_type``
+field with bare JavaScript truthiness. The Automox field carries the LITERAL
+STRING ``'disabled'`` (not null) when 2FA is OFF, so a disabled account rendered
+green ("2FA: disabled") — the exact inverse of reality. The fix replaces the
+raw-truthiness logic with a ``tfaState`` classifier: ``'disabled'``/``'disable'``/
+``'none'``/``''`` (case-insensitive, trimmed) → OFF, null/absent → UNKNOWN, any
+other non-empty value → genuinely ENABLED.
+
+The UI is a generated string, so the practical input->output assertion is that
+the rendered template contains the corrected classifier and no longer keys the
+on/off class off bare truthiness.
+"""
+
+from __future__ import annotations
+
+from automox_mcp.resources.access_certification_app import (
+    _ACCESS_CERTIFICATION_HTML,
+)
+
+
+def test_classifier_present_and_handles_disabled_string() -> None:
+    """A tfaState helper exists and treats the literal 'disabled' string as OFF."""
+    html = _ACCESS_CERTIFICATION_HTML
+    assert "function tfaState(" in html
+    # The literal 'disabled' (and siblings) must be classified as OFF, not green.
+    assert '"disabled"' in html
+    assert '"none"' in html
+
+
+def test_no_bare_truthiness_for_tfa_class() -> None:
+    """The on/off class is no longer derived from bare truthiness of tfa_type."""
+    html = _ACCESS_CERTIFICATION_HTML
+    # The old inverted logic keyed the class off (tfa ? "on" : "off").
+    assert '(tfa ? "on" : "off")' not in html
+    assert '(tfa ? "2FA: " + esc(tfa) : "⚠ no 2FA")' not in html
+
+
+def test_explicit_unknown_state_for_null() -> None:
+    """null/absent tfa_type renders a neutral unknown state, not green."""
+    html = _ACCESS_CERTIFICATION_HTML
+    assert "tfa.unknown" in html
+    assert '"unknown"' in html
+
+
+def test_class_and_label_driven_by_classifier() -> None:
+    """The rendered row keys both the CSS class and label off the classifier."""
+    html = _ACCESS_CERTIFICATION_HTML
+    assert "var tfaCls = tfaState(tfa);" in html
+    assert "class=\"tfa ' + tfaCls + '\"" in html

--- a/tests/test_fix_audit_actor_filter.py
+++ b/tests/test_fix_audit_actor_filter.py
@@ -1,0 +1,225 @@
+"""Regression tests for BUG #11 — actor_name filter silently returning the whole
+org event stream when the actor lookup cannot resolve.
+
+When ``actor_name`` is provided but the lookup fails to resolve it to an email or
+uuid, the client-side filter matches nothing. The pre-fix behaviour returned the
+entire unfiltered org stream while ``applied_filters.actor_name`` still echoed the
+requested name — every actor's events mislabeled as the requested actor's. The fix
+returns zero events and surfaces ``metadata.filter_ineffective`` so the consumer can
+tell the filter did not apply.
+"""
+
+from datetime import date
+from typing import Any, cast
+
+import pytest
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.audit import audit_trail_user_activity
+
+
+class StubClient:
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], list[Any] | Any],
+        *,
+        org_id: int,
+        org_uuid: str | None = None,
+        account_uuid: str | None = None,
+    ) -> None:
+        self._responses = responses
+        self.org_id = org_id
+        self.org_uuid = org_uuid
+        self.account_uuid = account_uuid
+        self.calls: list[dict[str, Any]] = []
+
+    async def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, Any] | None = None,
+        api: str | None = None,
+    ) -> Any:
+        key = (path, api or "console")
+        self.calls.append({"path": path, "params": params, "headers": headers, "api": api})
+        if key not in self._responses:
+            raise AssertionError(f"Unexpected GET request: {key!r}")
+        response = self._responses[key]
+        if isinstance(response, list):
+            if not response:
+                raise AssertionError(f"No stubbed responses remaining for {key!r}")
+            item = response.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _two_actor_event_page() -> dict[str, Any]:
+    """An org event page containing two different actors' events."""
+    return {
+        "metadata": {"count": 2},
+        "data": [
+            {
+                "activity": "Policy Updated",
+                "message": "Policy edited",
+                "time": 1718214000000,
+                "metadata": {"uid": "cursor-1"},
+                "actor": {
+                    "user": {
+                        "user": {
+                            "email_addr": "alice@example.com",
+                            "uid": "11111111-1111-1111-1111-111111111111",
+                        }
+                    }
+                },
+            },
+            {
+                "activity": "Task Created",
+                "message": "Different actor",
+                "time": 1718215000000,
+                "metadata": {"uid": "cursor-2"},
+                "actor": {
+                    "user": {
+                        "user": {
+                            "email_addr": "bob@example.com",
+                            "uid": "22222222-2222-2222-2222-222222222222",
+                        }
+                    }
+                },
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_unresolved_actor_name_does_not_return_unfiltered_stream() -> None:
+    """Case A: actor lookup yields no match for the requested actor_name.
+
+    The response must NOT claim the events are that actor's filtered activity:
+    ``applied_filters.actor_name`` is null, ``metadata.filter_ineffective`` is
+    present, and no unrelated events are returned.
+    """
+    org_uuid = "00000000-0000-0000-0000-000000000333"
+    account_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    audit_path = f"/audit-service/v1/orgs/{org_uuid}/events"
+    users_path = f"/accounts/{account_uuid}/users"
+
+    responses = {
+        ("/orgs", "console"): [[{"id": 44, "uuid": org_uuid}]],
+        # Lookup returns no users matching the requested name.
+        (users_path, "console"): [[]],
+        (audit_path, "console"): [_two_actor_event_page()],
+    }
+
+    client = StubClient(responses, org_id=44, account_uuid=account_uuid)
+
+    result = await audit_trail_user_activity(
+        cast(AutomoxClient, client),
+        org_id=44,
+        date=date(2024, 9, 8),
+        actor_name="Nobody Matches",
+    )
+
+    metadata = result["metadata"]
+    data = result["data"]
+
+    # The actor filter is NOT claimed as applied.
+    assert metadata["applied_filters"]["actor_name"] is None
+    assert metadata["applied_filters"]["actor_email"] is None
+    assert metadata["applied_filters"]["actor_uuid"] is None
+
+    # An honest, events-adjacent ineffective signal is present with a reason.
+    ineffective = metadata["filter_ineffective"]
+    assert ineffective["filter"] == "actor_name"
+    assert ineffective["reason"] == "actor_name_unresolved"
+    assert ineffective["requested_actor_name"] == "Nobody Matches"
+
+    # The unrelated org-wide events are NOT presented as the actor's activity.
+    assert data["events"] == []
+    assert data["events_returned"] == 0
+    assert metadata["events_returned"] == 0
+    # The "no matches in a real filter, keep paginating" advice must NOT fire —
+    # no filter was actually applied.
+    assert "filter_pagination_state" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_unresolved_actor_name_missing_account_uuid() -> None:
+    """Case A variant: lookup is skipped because account_uuid is unavailable.
+
+    Same honest signal — the filter is reported ineffective, not silently
+    applied, and the org stream is not relabeled as the actor's.
+    """
+    org_uuid = "00000000-0000-0000-0000-000000000444"
+    audit_path = f"/audit-service/v1/orgs/{org_uuid}/events"
+
+    responses = {
+        ("/orgs", "console"): [[{"id": 55, "uuid": org_uuid}]],
+        (audit_path, "console"): [_two_actor_event_page()],
+    }
+
+    # account_uuid=None -> _lookup_actor_from_hints short-circuits as "skipped".
+    client = StubClient(responses, org_id=55, account_uuid=None)
+
+    result = await audit_trail_user_activity(
+        cast(AutomoxClient, client),
+        org_id=55,
+        date=date(2024, 9, 8),
+        actor_name="Alice Anderson",
+    )
+
+    metadata = result["metadata"]
+    assert metadata["applied_filters"]["actor_name"] is None
+    assert metadata["filter_ineffective"]["reason"] == "actor_name_unresolved"
+    assert result["data"]["events"] == []
+    assert result["data"]["events_returned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_resolving_actor_name_still_filters_correctly() -> None:
+    """Case B (regression): a resolving actor_name filters and is reported applied."""
+    org_uuid = "00000000-0000-0000-0000-000000000555"
+    account_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    audit_path = f"/audit-service/v1/orgs/{org_uuid}/events"
+    users_path = f"/accounts/{account_uuid}/users"
+
+    responses = {
+        ("/orgs", "console"): [[{"id": 66, "uuid": org_uuid}]],
+        (users_path, "console"): [
+            [
+                {
+                    "display_name": "Alice Anderson",
+                    "email": "alice@example.com",
+                    "uid": "11111111-1111-1111-1111-111111111111",
+                    "account_rbac_role": "admin",
+                }
+            ]
+        ],
+        (audit_path, "console"): [_two_actor_event_page()],
+    }
+
+    client = StubClient(responses, org_id=66, account_uuid=account_uuid)
+
+    result = await audit_trail_user_activity(
+        cast(AutomoxClient, client),
+        org_id=66,
+        date=date(2024, 9, 8),
+        actor_name="Alice Anderson",
+    )
+
+    metadata = result["metadata"]
+    data = result["data"]
+
+    # The resolved filter is honestly reported as applied.
+    assert metadata["applied_filters"]["actor_name"] == "Alice Anderson"
+    assert metadata["applied_filters"]["actor_email"] == "alice@example.com"
+    # No ineffective signal when the filter resolved.
+    assert "filter_ineffective" not in metadata
+
+    # Only Alice's event survives the filter; Bob's is excluded.
+    assert data["events_returned"] == 1
+    assert data["events"][0]["actor"]["email"] == "alice@example.com"

--- a/tests/test_fix_blast_radius.py
+++ b/tests/test_fix_blast_radius.py
@@ -1,0 +1,92 @@
+"""Regression tests for the list_devices_for_policies blast-radius count (bug #13).
+
+The endpoint returns a ``{"servers": [...]}`` envelope. ``extract_list`` does not
+recognize that key, so it wrapped the whole envelope as a single record and
+``total_devices`` was always 1 regardless of the real blast radius — a dangerously
+misleading pre-flight count before a policy execution/change. These tests assert the
+envelope is unwrapped to the real device list, with a fallback for the bare-list /
+``{"data": [...]}`` shapes.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.policy_crud import list_devices_for_policies
+
+
+class StubClient:
+    """Minimal Automox client stub: returns a canned post response."""
+
+    def __init__(self, *, post_responses: dict[str, list[Any]] | None = None) -> None:
+        self._post_responses = {key: list(value) for key, value in (post_responses or {}).items()}
+        self.org_id: int | None = 555
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json_data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append(("POST", path, params, json_data))
+        return self._post_responses[path].pop(0)
+
+
+_PATH = "/server-groups-api/policies/servers"
+_POLS = ["11111111-1111-1111-1111-111111111111"]
+
+
+@pytest.mark.asyncio
+async def test_servers_envelope_counts_real_devices_not_envelope() -> None:
+    """{"servers": [d1, d2, d3]} -> total_devices == 3 and devices is the real list."""
+    servers = [
+        {"id": 1, "name": "host-a"},
+        {"id": 2, "name": "host-b"},
+        {"id": 3, "name": "host-c"},
+    ]
+    client = StubClient(post_responses={_PATH: [{"servers": servers}]})
+
+    result = await list_devices_for_policies(cast(AutomoxClient, client), policies=_POLS)
+
+    assert result["data"]["total_devices"] == 3
+    # The real device dicts, not the {"servers": ...} envelope wrapped as one record.
+    assert result["data"]["devices"] == servers
+    assert [d["id"] for d in result["data"]["devices"]] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_servers_envelope_empty_blast_radius() -> None:
+    """An empty blast radius reports 0, not 1."""
+    client = StubClient(post_responses={_PATH: [{"servers": []}]})
+
+    result = await list_devices_for_policies(cast(AutomoxClient, client), policies=_POLS)
+
+    assert result["data"]["total_devices"] == 0
+    assert result["data"]["devices"] == []
+
+
+@pytest.mark.asyncio
+async def test_bare_list_fallback_still_counts() -> None:
+    """Fallback path: a bare list of device dicts is counted directly."""
+    devices = [{"id": 1}, {"id": 2}]
+    client = StubClient(post_responses={_PATH: [devices]})
+
+    result = await list_devices_for_policies(cast(AutomoxClient, client), policies=_POLS)
+
+    assert result["data"]["total_devices"] == 2
+    assert result["data"]["devices"] == devices
+
+
+@pytest.mark.asyncio
+async def test_data_envelope_fallback_still_counts() -> None:
+    """Fallback path: a {"data": [...]} envelope is unwrapped by extract_list."""
+    devices = [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+    client = StubClient(post_responses={_PATH: [{"data": devices}]})
+
+    result = await list_devices_for_policies(cast(AutomoxClient, client), policies=_POLS)
+
+    assert result["data"]["total_devices"] == 4
+    assert result["data"]["devices"] == devices

--- a/tests/test_fix_policy_runs_time_filter.py
+++ b/tests/test_fix_policy_runs_time_filter.py
@@ -1,0 +1,157 @@
+"""Bug #17: list_policy_runs_v2 time filter must compare datetimes, not strings.
+
+The upstream policy-report-api ignores time filter params, so the workflow
+filters client-side. The old code did a raw lexicographic STRING compare of
+run_time against start_time/end_time. A bare-date end_time='2026-06-18' makes
+'2026-06-18T16:52:44.313Z' > '2026-06-18' true, so every run on that day was
+silently dropped — "runs through June 18" returned none of that day's runs.
+Mixed 'Z' vs '+00:00' forms also sorted wrong. The fix parses both sides into
+tz-aware datetimes and normalizes a bare date to an inclusive day boundary.
+"""
+
+from typing import Any, cast
+
+import pytest
+from conftest import StubClient
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.policy_history import list_policy_runs_v2
+
+_ORG_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+def _make_client(**kwargs: Any) -> StubClient:
+    client = StubClient(**kwargs)
+    client.org_uuid = _ORG_UUID
+    return client
+
+
+def _run(uuid: str, run_time: str) -> dict[str, Any]:
+    # policy_name is set so the call always engages the client-side filter
+    # path even when only a time bound is exercised.
+    return {"policy_uuid": uuid, "policy_name": "Patch All", "run_time": run_time}
+
+
+# run_time as the live API emits it: full ISO-8601 with millis + trailing Z.
+_RUNS_JUNE_18 = [
+    _run("r-early", "2026-06-18T00:00:01.000Z"),
+    _run("r-mid", "2026-06-18T16:52:44.313Z"),
+    _run("r-late", "2026-06-18T23:59:59.999Z"),
+]
+
+
+@pytest.mark.asyncio
+async def test_bare_date_end_time_includes_whole_day() -> None:
+    """end_time='2026-06-18' must INCLUDE every run on 2026-06-18, not drop
+    them via a lexicographic string compare (the core bug #17)."""
+    client = _make_client(get_responses={"/policy-history/policy-runs": [_RUNS_JUNE_18]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        end_time="2026-06-18",
+    )
+    returned = sorted(r["policy_uuid"] for r in result["data"]["runs"])
+    assert returned == ["r-early", "r-late", "r-mid"]
+
+
+@pytest.mark.asyncio
+async def test_bare_date_end_time_excludes_next_day() -> None:
+    """The inclusive end-of-day boundary must not bleed into the next day."""
+    runs = [
+        _run("keep", "2026-06-18T23:59:59.999Z"),
+        _run("drop", "2026-06-19T00:00:00.000Z"),
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        end_time="2026-06-18",
+    )
+    returned = [r["policy_uuid"] for r in result["data"]["runs"]]
+    assert returned == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_bare_date_start_time_inclusive_at_start_of_day() -> None:
+    """start_time='2026-06-18' anchors to 00:00:00 UTC, so a run at the very
+    start of the day is included and the prior day is excluded."""
+    runs = [
+        _run("prev", "2026-06-17T23:59:59.999Z"),
+        _run("boundary", "2026-06-18T00:00:00.000Z"),
+        _run("later", "2026-06-18T12:00:00.000Z"),
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        start_time="2026-06-18",
+    )
+    returned = sorted(r["policy_uuid"] for r in result["data"]["runs"])
+    assert returned == ["boundary", "later"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_zone_forms_compare_correctly() -> None:
+    """A 'Z' run_time and a '+00:00' bound denote the same instant and must
+    not sort wrong the way raw string comparison would."""
+    runs = [
+        _run("before", "2026-06-18T09:59:59Z"),
+        _run("after", "2026-06-18T10:00:01Z"),
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        start_time="2026-06-18T10:00:00+00:00",
+    )
+    returned = [r["policy_uuid"] for r in result["data"]["runs"]]
+    assert returned == ["after"]
+
+
+@pytest.mark.asyncio
+async def test_full_timestamp_end_time_inclusive_at_bound() -> None:
+    """A full-timestamp end_time keeps inclusive-at-the-bound semantics."""
+    runs = [
+        _run("at-bound", "2026-06-18T10:00:00Z"),
+        _run("past-bound", "2026-06-18T10:00:00.001Z"),
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        end_time="2026-06-18T10:00:00Z",
+    )
+    returned = [r["policy_uuid"] for r in result["data"]["runs"]]
+    assert returned == ["at-bound"]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_bound_does_not_crash() -> None:
+    """An unparseable bound degrades gracefully: the tool returns rather than
+    raising, and the unparseable bound is treated as no bound."""
+    client = _make_client(get_responses={"/policy-history/policy-runs": [_RUNS_JUNE_18]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        end_time="not-a-date",
+    )
+    returned = sorted(r["policy_uuid"] for r in result["data"]["runs"])
+    assert returned == ["r-early", "r-late", "r-mid"]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_run_time_not_dropped() -> None:
+    """A run whose run_time can't be parsed isn't silently excluded by a
+    range filter (graceful degradation, not a crash)."""
+    runs = [
+        _run("good", "2026-06-18T12:00:00Z"),
+        _run("bad", "garbage-timestamp"),
+    ]
+    client = _make_client(get_responses={"/policy-history/policy-runs": [runs]})
+    result = await list_policy_runs_v2(
+        cast(AutomoxClient, client),
+        org_id=42,
+        end_time="2026-06-18",
+    )
+    returned = sorted(r["policy_uuid"] for r in result["data"]["runs"])
+    assert returned == ["bad", "good"]

--- a/tests/test_fix_splashtop.py
+++ b/tests/test_fix_splashtop.py
@@ -1,0 +1,179 @@
+"""Regression tests for the Splashtop write-tool fixes.
+
+Covers two confirmed bug classes:
+
+1. UUID-in-body serialization (BUGS #4/#5/#6): the Splashtop install,
+   initiate-connection, and bulk-set-attended-access params models type
+   their device-UUID fields as ``uuid.UUID``. Dumped in python mode the
+   workflow body carried raw ``uuid.UUID`` objects, which httpx's
+   ``json.dumps`` cannot serialize (``TypeError``) — the three write tools
+   were dead. The fix passes ``dump_mode="json"`` so the model emits string
+   UUIDs. These tests drive each tool through the real
+   ``call_tool_workflow`` path (the only path that constructs the typed
+   model and reproduces the bug) and assert the captured request body is
+   JSON-serializable with string UUID values.
+
+2. Bare-string success body (BUG #9): Splashtop install/uninstall/
+   force-disconnect return 2xx with an unquoted string body
+   ('Command executed successfully'). ``_process_response`` called
+   ``response.json()`` on it, raising and surfacing a successful write as
+   ``AutomoxAPIError``. The fix returns ``{"message": response.text}`` for
+   <400 non-JSON bodies while leaving >=400 error handling untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import httpx
+import pytest
+from conftest import StubClient, StubServer
+
+import automox_mcp.tools.splashtop_tools as splashtop_tools
+from automox_mcp.client import AutomoxAPIError, AutomoxClient
+
+_DEVICE_UUID = "550e8400-e29b-41d4-a716-446655440000"
+_DEVICE_UUID_2 = "660e8400-e29b-41d4-a716-446655440001"
+
+
+def _register_tools() -> tuple[StubServer, StubClient]:
+    """Register the Splashtop write tools against a capturing stub client."""
+    client = StubClient(
+        post_responses={
+            "/remotecontrol-st/install": ["Command executed successfully"],
+            "/remotecontrol-st/initiate-connection": [{"splashtopUrl": "splashtop-sos://abc"}],
+        },
+        put_responses={"/remotecontrol-st/attended-access/bulk": [{}]},
+    )
+    server = StubServer()
+    splashtop_tools.register(server, read_only=False, client=cast(AutomoxClient, client))
+    return server, client
+
+
+def _last_body(client: StubClient) -> Any:
+    """Return the body (json_data) of the most recent recorded write call."""
+    return client.calls[-1][2]
+
+
+# ---------------------------------------------------------------------------
+# BUGS #4/#5/#6 — UUID fields must serialize to strings in the request body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_body_serializes_uuid_as_string() -> None:
+    server, client = _register_tools()
+
+    result = await server.tools["splashtop_install"](
+        device_uuid=_DEVICE_UUID,
+        os_family="windows",
+    )
+
+    body = _last_body(client)
+    # Body must be JSON-encodable exactly as httpx would encode it — no TypeError.
+    json.dumps(body)
+    httpx.Request("POST", "http://x/", json=body)
+    assert isinstance(body["device_uuid"], str)
+    assert body["device_uuid"] == _DEVICE_UUID
+    # Tool returned a result envelope (did not raise -> isError is False).
+    assert isinstance(result, dict)
+    assert result["data"]["queued"] is True
+
+
+@pytest.mark.asyncio
+async def test_initiate_connection_body_serializes_uuid_as_string() -> None:
+    server, client = _register_tools()
+
+    result = await server.tools["splashtop_initiate_connection"](
+        device_uuid=_DEVICE_UUID,
+        os_family="windows",
+        connection_type="remote_control",
+    )
+
+    body = _last_body(client)
+    json.dumps(body)
+    httpx.Request("POST", "http://x/", json=body)
+    # The initiate-connection endpoint keys the device UUID as ax_device_uuid.
+    assert isinstance(body["ax_device_uuid"], str)
+    assert body["ax_device_uuid"] == _DEVICE_UUID
+    assert isinstance(result, dict)
+    assert result["data"]["splashtopUrl"] == "splashtop-sos://abc"
+
+
+@pytest.mark.asyncio
+async def test_set_bulk_attended_access_body_serializes_uuids_as_strings() -> None:
+    server, client = _register_tools()
+
+    result = await server.tools["splashtop_set_bulk_attended_access"](
+        device_uuids=[_DEVICE_UUID, _DEVICE_UUID_2],
+        required_attended_access=True,
+    )
+
+    body = _last_body(client)
+    json.dumps(body)
+    httpx.Request("PUT", "http://x/", json=body)
+    assert body["deviceUuids"] == [_DEVICE_UUID, _DEVICE_UUID_2]
+    assert all(isinstance(u, str) for u in body["deviceUuids"])
+    assert isinstance(result, dict)
+    assert result["data"]["updated"] is True
+
+
+# ---------------------------------------------------------------------------
+# BUG #9 — bare-string success body is a success, not a parse error
+# ---------------------------------------------------------------------------
+
+
+def _process(response: httpx.Response, *, allow_text_response: bool = False) -> Any:
+    """Run a response through the real client._process_response."""
+    client = AutomoxClient(
+        api_key="k",
+        account_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        org_id=1,
+    )
+    return client._process_response(
+        response,
+        method="POST",
+        path="/x",
+        correlation_id=None,
+        start=0.0,
+        allow_text_response=allow_text_response,
+    )
+
+
+def test_bare_string_success_body_returns_message_when_opted_in() -> None:
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/json"},
+        # Bare, unquoted string -> response.json() raises JSONDecodeError.
+        content=b"Command executed successfully",
+    )
+    result = _process(response, allow_text_response=True)
+    assert result == {"message": "Command executed successfully"}
+
+
+def test_bare_string_success_body_still_raises_without_opt_in() -> None:
+    """The global strict-JSON guard is preserved for every non-opted-in caller."""
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/json"},
+        content=b"Command executed successfully",
+    )
+    with pytest.raises(AutomoxAPIError, match="invalid JSON"):
+        _process(response)
+
+
+def test_empty_success_body_still_returns_empty_dict() -> None:
+    response = httpx.Response(204, content=b"")
+    assert _process(response, allow_text_response=True) == {}
+
+
+def test_error_status_with_bare_string_body_still_raises() -> None:
+    response = httpx.Response(
+        500,
+        headers={"Content-Type": "application/json"},
+        content=b"Internal Server Error",
+    )
+    with pytest.raises(AutomoxAPIError) as excinfo:
+        _process(response, allow_text_response=True)
+    assert excinfo.value.status_code == 500

--- a/tests/test_fix_tooling_pagination.py
+++ b/tests/test_fix_tooling_pagination.py
@@ -1,0 +1,178 @@
+"""Regression tests for three confirmed bugs in tooling/policy response handling.
+
+Covers:
+- BUG #2 — ``format_as_markdown_table`` / ``maybe_format_markdown`` must not raise
+  ``AttributeError`` on a list of scalar (string) rows.
+- BUG #3 — ``as_tool_response`` (and the ``describe_policy_run_result`` path) must
+  sanitize non-coercible upstream ``metadata.limit`` / ``total_count`` rather than
+  raising an uncaught ``ValidationError``.
+- BUG #7 — ``_apply_token_budget`` must never report a truncated response as
+  complete and must not let sibling count fields overstate the surviving list.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID
+
+import pytest
+from conftest import StubClient
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.utils.tooling import (
+    _apply_token_budget,
+    as_tool_response,
+    format_as_markdown_table,
+    maybe_format_markdown,
+)
+from automox_mcp.workflows.policy import describe_policy_run_result
+
+ORG_UUID = UUID("11111111-1111-1111-1111-111111111111")
+POLICY_UUID = UUID("22222222-2222-2222-2222-222222222222")
+EXEC_TOKEN = UUID("33333333-3333-3333-3333-333333333333")
+
+
+# ---------------------------------------------------------------------------
+# BUG #2 — markdown rendering of scalar rows
+# ---------------------------------------------------------------------------
+
+
+def test_format_as_markdown_table_with_string_rows_does_not_raise():
+    """A list of UUID/name strings renders as a single-column table."""
+    table = format_as_markdown_table(["uuid-a", "uuid-b"])
+
+    assert "uuid-a" in table
+    assert "uuid-b" in table
+    # Single-column header, not a crash.
+    assert table.splitlines()[0] == "| value |"
+
+
+def test_maybe_format_markdown_with_string_list_envelope_does_not_raise():
+    """An envelope whose first non-empty list is strings must tabulate cleanly."""
+    envelope = {"data": {"saved_searches": ["uuid-a", "uuid-b"]}, "metadata": {}}
+
+    result = maybe_format_markdown(envelope, "markdown")
+
+    # ToolResult: structured envelope preserved, markdown content rendered.
+    assert result.structured_content == envelope
+    rendered = "".join(getattr(block, "text", str(block)) for block in result.content)
+    assert "uuid-a" in rendered
+    assert "uuid-b" in rendered
+
+
+# ---------------------------------------------------------------------------
+# BUG #3 — non-coercible reserved pagination keys are sanitized, not fatal
+# ---------------------------------------------------------------------------
+
+
+def test_as_tool_response_coerces_non_int_reserved_keys():
+    """metadata.limit='' / total_count non-int degrade to None (no ValidationError)."""
+    result = as_tool_response({"data": [1, 2], "metadata": {"limit": "", "total_count": "lots"}})
+
+    assert result["metadata"]["limit"] is None
+    assert result["metadata"]["total_count"] is None
+
+
+def test_as_tool_response_preserves_coercible_string_int():
+    """A numeric string still coerces to its int value."""
+    result = as_tool_response({"data": [1], "metadata": {"limit": "25", "total_count": "100"}})
+
+    assert result["metadata"]["limit"] == 25
+    assert result["metadata"]["total_count"] == 100
+
+
+@pytest.mark.asyncio
+async def test_describe_policy_run_result_with_garbage_metadata_is_sanitized():
+    """Upstream metadata.limit='' must not crash the run-results -> tool-response path."""
+    upstream = {
+        "data": [
+            {"server_name": "host-1", "result_status": "success", "exit_code": 0},
+        ],
+        "metadata": {"current_page": 0, "limit": "", "total_count": "n/a"},
+    }
+    client = StubClient(
+        get_responses={
+            f"/policy-history/policies/{POLICY_UUID}/{EXEC_TOKEN}": [upstream],
+        }
+    )
+
+    workflow_result = await describe_policy_run_result(
+        cast(AutomoxClient, client),
+        org_uuid=ORG_UUID,
+        policy_uuid=POLICY_UUID,
+        exec_token=EXEC_TOKEN,
+    )
+
+    # The legacy top-level keys must be guarded to int-or-None upstream...
+    assert workflow_result["metadata"]["limit"] is None
+    assert workflow_result["metadata"]["total_count"] is None
+
+    # ...and as_tool_response must not raise on the full envelope.
+    response = as_tool_response(workflow_result)
+    assert response["metadata"]["limit"] is None
+    assert response["metadata"]["total_count"] is None
+
+
+# ---------------------------------------------------------------------------
+# BUG #7 — truncation must never be misreported as complete; counts honest
+# ---------------------------------------------------------------------------
+
+
+def _oversized_devices(n: int) -> list[dict[str, str]]:
+    # Each row carries enough text to blow a tiny budget.
+    return [{"name": f"device-{i}", "detail": "x" * 200} for i in range(n)]
+
+
+def test_apply_token_budget_truncation_marks_has_more_true():
+    """When items are dropped, a pagination block must not assert completeness."""
+    devices = _oversized_devices(10)
+    response = {
+        "data": {"devices": devices, "total_devices": len(devices)},
+        "metadata": {"pagination": {"has_more": False, "last": True}},
+    }
+
+    result = _apply_token_budget(response, budget=10)
+
+    assert result["metadata"]["truncated"] is True
+    pagination = result["metadata"]["pagination"]
+    assert pagination["has_more"] is True
+    assert pagination["last"] is False
+
+
+def test_apply_token_budget_reconciles_sibling_counts():
+    """No surviving total_*/_returned count may exceed the returned list length."""
+    devices = _oversized_devices(10)
+    response = {
+        "data": {
+            "devices": devices,
+            "total_devices": len(devices),
+            "devices_returned": len(devices),
+            "device_count": len(devices),
+        },
+        "metadata": {"pagination": {"has_more": False}},
+    }
+
+    result = _apply_token_budget(response, budget=10)
+    data = result["data"]
+    returned = len(data["devices"])
+
+    assert returned < 10  # truncation actually happened
+    assert data["total_devices"] <= returned
+    assert data["devices_returned"] <= returned
+    assert data["device_count"] <= returned
+    # And completeness is not claimed.
+    assert result["metadata"]["pagination"]["has_more"] is True
+
+
+def test_apply_token_budget_under_budget_is_untouched():
+    """A response within budget passes through unchanged (no false truncation)."""
+    response = {
+        "data": {"devices": [{"name": "a"}], "total_devices": 1},
+        "metadata": {"pagination": {"has_more": False}},
+    }
+
+    result = _apply_token_budget(response, budget=10_000)
+
+    assert "truncated" not in result["metadata"]
+    assert result["metadata"]["pagination"]["has_more"] is False
+    assert result["data"]["total_devices"] == 1

--- a/tests/test_fix_zone_redaction.py
+++ b/tests/test_fix_zone_redaction.py
@@ -1,0 +1,117 @@
+"""Regression tests for zone-list secret/PII redaction.
+
+list_zones and list_zones_for_user previously forwarded raw zone DTOs straight
+out of `_envelope`, leaking every zone's `access_key` secret and the nested
+`created_by` user blob (email / two_factor_authentication / RBAC role) to the
+model. Both list paths must now project each zone through the same allowlist
+get_zone uses, dropping `access_key` and reducing `created_by` to a non-PII
+actor reference (id + display name only).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+from conftest import StubClient
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.account import list_zones, list_zones_for_user
+
+_ACCT = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_USER = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+# Two zones, each carrying the `access_key` secret and a `created_by` blob that
+# embeds user PII (email, 2FA state, RBAC role). Shaped after the get_zone
+# fixture so the list paths are asserted against the same DTO expectations.
+_ZONES = [
+    {
+        "id": "z1",
+        "organization_id": 99,
+        "account_id": 1,
+        "name": "EU Zone",
+        "access_key": "SECRET-ZONE-KEY-1",
+        "created_by": {
+            "id": 7,
+            "firstname": "Ada",
+            "lastname": "Lovelace",
+            "email": "ada@example.com",
+            "two_factor_authentication": "disabled",
+            "rbac_role": "global-admin",
+        },
+    },
+    {
+        "id": "z2",
+        "organization_id": 100,
+        "account_id": 1,
+        "name": "US Zone",
+        "access_key": "SECRET-ZONE-KEY-2",
+        "created_by": {
+            "id": 8,
+            "firstname": "Grace",
+            "lastname": "Hopper",
+            "email": "grace@example.com",
+            "two_factor_authentication": "email",
+            "rbac_role": "read-only",
+        },
+    },
+]
+
+# Secrets / PII that must NEVER appear anywhere in the serialized zone output.
+_FORBIDDEN_SUBSTRINGS = (
+    "SECRET-ZONE-KEY-1",
+    "SECRET-ZONE-KEY-2",
+    "ada@example.com",
+    "grace@example.com",
+    "two_factor_authentication",
+    "rbac_role",
+    "global-admin",
+    "read-only",
+)
+
+
+def _assert_zones_redacted(zones: list[dict]) -> None:
+    """Every zone keeps legitimate fields but leaks no secret/PII."""
+    blob = json.dumps(zones)
+    assert "access_key" not in blob
+    for forbidden in _FORBIDDEN_SUBSTRINGS:
+        assert forbidden not in blob, f"leaked: {forbidden}"
+
+    for zone in zones:
+        assert "access_key" not in zone
+        # Legitimate zone fields survive the projection.
+        assert zone["id"] in {"z1", "z2"}
+        assert zone["name"] in {"EU Zone", "US Zone"}
+        assert zone["organization_id"] in {99, 100}
+
+        # created_by, if present, carries only a non-PII actor reference.
+        created_by = zone["created_by"]
+        assert created_by["id"] in {7, 8}
+        assert created_by["firstname"] in {"Ada", "Grace"}
+        assert "email" not in created_by
+        assert "two_factor_authentication" not in created_by
+        assert "rbac_role" not in created_by
+
+
+@pytest.mark.asyncio
+async def test_list_zones_redacts_access_key_and_created_by_pii():
+    envelope = {"data": _ZONES, "metadata": {}}
+    client = StubClient(get_responses={f"/accounts/{_ACCT}/zones": [envelope]})
+    result = await list_zones(cast(AutomoxClient, client), account_id=_ACCT)
+
+    zones = result["data"]["zones"]
+    assert result["data"]["total_zones"] == 2
+    _assert_zones_redacted(zones)
+
+
+@pytest.mark.asyncio
+async def test_list_zones_for_user_redacts_access_key_and_created_by_pii():
+    envelope = {"data": _ZONES, "metadata": {}}
+    client = StubClient(get_responses={f"/accounts/{_ACCT}/users/{_USER}/zones": [envelope]})
+    result = await list_zones_for_user(cast(AutomoxClient, client), account_id=_ACCT, user_id=_USER)
+
+    zones = result["data"]["zones"]
+    assert result["data"]["total_zones"] == 2
+    assert result["data"]["user_id"] == _USER
+    _assert_zones_redacted(zones)

--- a/tests/test_workflows_audit.py
+++ b/tests/test_workflows_audit.py
@@ -527,5 +527,11 @@ async def test_audit_trail_lookup_handles_request_failure() -> None:
     assert lookup["reason"] == "actor_lookup_request_failed"
     assert lookup["error"]["status_code"] == 404
     assert lookup["error"]["payload"]["errors"] == ["Not found"]
-    # Since lookup failed, we should not filter out events
-    assert result["data"]["events_returned"] == 1
+    # The actor_name could not be resolved to an email/uuid, so the filter is
+    # NOT applied. The whole-org stream must not be returned mislabeled as this
+    # actor's activity: zero events plus an honest filter_ineffective signal.
+    assert result["data"]["events_returned"] == 0
+    assert result["metadata"]["applied_filters"]["actor_name"] is None
+    ineffective = result["metadata"]["filter_ineffective"]
+    assert ineffective["filter"] == "actor_name"
+    assert ineffective["reason"] == "actor_name_unresolved"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.2.3"
+version = "2.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

This change resolves ten high-severity defects spanning security, stability, and data integrity. Each fix is surgical, follows existing patterns in the codebase, and is covered by unit tests.

## Security

- **Redact secrets and user PII from zone listings.** The zone list endpoints returned raw zone records, exposing each zone's `access_key` credential and the nested `created_by` user object (email, name, two-factor status, role). All zone read and create paths now share a single projector that drops `access_key` and reduces `created_by` to a non-identifying reference, matching the redaction already applied to the single-zone path.
- **Correct an inverted two-factor indicator in the access-certification view.** The view classified the two-factor field by truthiness, so an account with 2FA disabled (reported as the literal string `"disabled"`) rendered as enabled. It now treats `disabled`/`none`/empty as off, absent as unknown, and only genuine values as on.

## Stability

- **Make the Splashtop install, initiate-connection, and bulk attended-access tools functional.** UUID parameters were serialized as objects into the JSON request body and raised a `TypeError`; they now serialize as strings.
- **Accept the plain-text success body** that some Splashtop write endpoints return, via an opt-in flag on the affected calls. The strict-JSON guard is unchanged for every other endpoint.
- **Prevent an uncaught error when upstream pagination metadata is non-numeric.** The reserved pagination fields are now coerced defensively before validation, so a malformed upstream value degrades gracefully instead of crashing the tool.
- **Render Markdown tables for tools that return lists of plain strings** instead of raising an error.

## Data integrity

- **Report the real device count for a policy's targets** instead of always one. The response envelope was being counted as a single record.
- **Compare policy-run timestamps chronologically** rather than lexically, so a date-only upper bound no longer excludes that day's runs.
- **Stop returning the full event stream mislabeled as a single actor's activity** when an actor filter cannot be resolved. The response now returns no events and an explicit signal that the filter was not applied.
- **Keep budget-truncated responses honest:** a truncated response never reports itself as complete, and item counts always match the items actually returned.

## Testing

- Full unit and integration suite passes.
- `ruff` (format and lint), `mypy`, and the coverage gate are clean.

## Notes

- Version metadata and the changelog are updated for the next patch release.
- The two-factor indicator and the Splashtop write paths are covered by unit tests; live verification of the write paths is intended for the pre-release smoke check, as those tools perform device-side actions.
