### PR TITLE
fix: harden list pagination, retry idempotency, and crash paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5] - 2026-06-26
+
+### Fixed
+
+- **`list_events` no longer reports a per-page count as the organization-wide total.** The endpoint returns a bare list with no upstream total, so a normal (non-count) response now reports `events_returned` (the number of events on this page) plus a `metadata.pagination` block and a `suggested_next_call`, instead of a `total_events` that under-reported by a page on any limited query. Count mode (`count_only=true`) still returns the real `total_events` from the upstream `size`. **Note:** `total_events` is no longer present on normal `list_events` responses — read `events_returned` and `metadata.pagination`.
+- **`list_saved_searches` now returns usable saved searches.** The endpoint returns a Spring `Page` envelope that was being collapsed into a single empty record, so every saved search came back as `{}` with no id/name/query. The envelope is now unwrapped, each saved search retains its `id`/`name`/`search`, and pagination is surfaced via `metadata.pagination`.
+- **Write tools no longer block a corrected retry after a failed first attempt.** `apply_policy_changes`, `create`/`update`/`delete_policy_window`, `invite_user_to_account`, `remove_user_from_account`, `create`/`update`/`delete_server_group`, and `upload_action_set` reserved an idempotency key but did not release it when the call failed (e.g. a validation error), so a retry with the same `request_id` — even after correcting the payload — silently returned a duplicate no-op for the full key TTL. They now release the reservation on failure, so a corrected retry executes.
+- **Several read tools and one resource no longer crash on unexpected upstream shapes.** `resource://servergroups/list` no longer raises when a server group's `policies` is `null`; `describe_policy` tolerates a non-numeric `schedule_days` (degrading instead of raising); and `summarize_policy_activity`, `summarize_policy_execution_history`, `list_device_packages`, `search_devices`, and `device_health_metrics` skip non-object elements in a `/servers` (or run) list instead of raising.
+
 ## [2.2.4] - 2026-06-24
 
 ### Security

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more \u2014 all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 14 MCP resources (including interactive MCP App UIs for compliance triage, patch-approval review, policy blast-radius review, remediation-apply review, and RBAC access certification), and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.2.4"
+version = "2.2.5"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.2.4",
+  "automox-mcp>=2.2.5",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.2.4"
+version = "2.2.5"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.2.4",
+  "version": "2.2.5",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "transport": {
         "type": "stdio"
       },

--- a/src/automox_mcp/resources/servergroup_resources.py
+++ b/src/automox_mcp/resources/servergroup_resources.py
@@ -51,7 +51,7 @@ def register(server: FastMCP, *, client: AutomoxClient) -> None:
                         "name": group.get("name") or "(unnamed)",
                         "organization_id": group.get("organization_id"),
                         "server_count": group.get("server_count", 0),
-                        "policy_count": len(group.get("policies", [])),
+                        "policy_count": len(group.get("policies") or []),
                     }
                 )
 

--- a/src/automox_mcp/tools/account_tools.py
+++ b/src/automox_mcp/tools/account_tools.py
@@ -91,12 +91,16 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "account_rbac_role": account_rbac_role,
                 "zone_assignments": zone_assignments,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.invite_user_to_account,
-                params,
-                params_model=InviteUserParams,
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.invite_user_to_account,
+                    params,
+                    params_model=InviteUserParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "invite_user_to_account")
+                raise
             await store_idempotency(request_id, "invite_user_to_account", result)
             return result
 
@@ -122,12 +126,16 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "account_id": _resolve_account_id(None),
                 "user_id": user_id,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.remove_user_from_account,
-                params,
-                params_model=RemoveUserFromAccountParams,
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.remove_user_from_account,
+                    params,
+                    params_model=RemoveUserFromAccountParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "remove_user_from_account")
+                raise
             await store_idempotency(request_id, "remove_user_from_account", result)
             return result
 

--- a/src/automox_mcp/tools/group_tools.py
+++ b/src/automox_mcp/tools/group_tools.py
@@ -21,6 +21,7 @@ from ..utils.tooling import (
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
+    release_idempotency,
     store_idempotency,
 )
 
@@ -133,13 +134,17 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "notes": notes,
                 "policies": policies,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.create_server_group,
-                params,
-                params_model=CreateServerGroupParams,
-                inject_org_id=True,
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.create_server_group,
+                    params,
+                    params_model=CreateServerGroupParams,
+                    inject_org_id=True,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "create_server_group")
+                raise
             await store_idempotency(request_id, "create_server_group", result)
             return result
 
@@ -187,13 +192,17 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "notes": notes,
                 "policies": policies,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.update_server_group,
-                params,
-                params_model=UpdateServerGroupParams,
-                inject_org_id=True,
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.update_server_group,
+                    params,
+                    params_model=UpdateServerGroupParams,
+                    inject_org_id=True,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "update_server_group")
+                raise
             await store_idempotency(request_id, "update_server_group", result)
             return result
 
@@ -218,12 +227,16 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             params = {
                 "group_id": group_id,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.delete_server_group,
-                params,
-                params_model=DeleteServerGroupParams,
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.delete_server_group,
+                    params,
+                    params_model=DeleteServerGroupParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "delete_server_group")
+                raise
             await store_idempotency(request_id, "delete_server_group", result)
             return result
 

--- a/src/automox_mcp/tools/policy_tools.py
+++ b/src/automox_mcp/tools/policy_tools.py
@@ -505,12 +505,15 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             if cached is not None:
                 return cached
 
-            normalized_operations = workflows.normalize_policy_operations_input(operations)
-            params = {
-                "operations": normalized_operations,
-                "preview": preview,
-            }
             try:
+                # Normalization can raise on malformed input; keep it inside the
+                # try so the in-flight idempotency reservation is released (below)
+                # and a corrected retry with the same request_id isn't shadowed.
+                normalized_operations = workflows.normalize_policy_operations_input(operations)
+                params = {
+                    "operations": normalized_operations,
+                    "preview": preview,
+                }
                 result = await call_tool_workflow(
                     client,
                     workflows.apply_policy_changes,

--- a/src/automox_mcp/tools/policy_windows_tools.py
+++ b/src/automox_mcp/tools/policy_windows_tools.py
@@ -16,6 +16,7 @@ from ..utils.tooling import (
     call_tool_workflow,
     check_idempotency,
     maybe_format_markdown,
+    release_idempotency,
     store_idempotency,
 )
 
@@ -472,14 +473,18 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "dtstart": dtstart,
                 "status": status,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.create_policy_window,
-                params,
-                params_model=CreatePolicyWindowParams,
-                org_uuid_field="org_uuid",
-                dump_mode="json",
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.create_policy_window,
+                    params,
+                    params_model=CreatePolicyWindowParams,
+                    org_uuid_field="org_uuid",
+                    dump_mode="json",
+                )
+            except BaseException:
+                await release_idempotency(request_id, "create_policy_window")
+                raise
             await store_idempotency(request_id, "create_policy_window", result)
             return result
 
@@ -531,14 +536,18 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "group_uuids": group_uuids,
                 "status": status,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.update_policy_window,
-                params,
-                params_model=UpdatePolicyWindowParams,
-                org_uuid_field="org_uuid",
-                dump_mode="json",
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.update_policy_window,
+                    params,
+                    params_model=UpdatePolicyWindowParams,
+                    org_uuid_field="org_uuid",
+                    dump_mode="json",
+                )
+            except BaseException:
+                await release_idempotency(request_id, "update_policy_window")
+                raise
             await store_idempotency(request_id, "update_policy_window", result)
             return result
 
@@ -565,14 +574,18 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
                 "org_uuid": org_uuid,
                 "window_uuid": window_uuid,
             }
-            result = await call_tool_workflow(
-                client,
-                workflows.delete_policy_window,
-                params,
-                params_model=DeletePolicyWindowParams,
-                org_uuid_field="org_uuid",
-                dump_mode="json",
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    workflows.delete_policy_window,
+                    params,
+                    params_model=DeletePolicyWindowParams,
+                    org_uuid_field="org_uuid",
+                    dump_mode="json",
+                )
+            except BaseException:
+                await release_idempotency(request_id, "delete_policy_window")
+                raise
             await store_idempotency(request_id, "delete_policy_window", result)
             return result
 

--- a/src/automox_mcp/tools/vuln_sync_tools.py
+++ b/src/automox_mcp/tools/vuln_sync_tools.py
@@ -224,12 +224,16 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
             cached = await check_idempotency(request_id, "upload_action_set")
             if cached is not None:
                 return cached
-            result = await call_tool_workflow(
-                client,
-                _upload_action_set,
-                {"csv_content": csv_content, "source": source, "filename": filename},
-                params_model=UploadActionSetParams,
-            )
+            try:
+                result = await call_tool_workflow(
+                    client,
+                    _upload_action_set,
+                    {"csv_content": csv_content, "source": source, "filename": filename},
+                    params_model=UploadActionSetParams,
+                )
+            except BaseException:
+                await release_idempotency(request_id, "upload_action_set")
+                raise
             await store_idempotency(request_id, "upload_action_set", result)
             return result
 

--- a/src/automox_mcp/workflows/device_search.py
+++ b/src/automox_mcp/workflows/device_search.py
@@ -85,28 +85,61 @@ async def list_saved_searches(
     *,
     org_id: int | None = None,
 ) -> dict[str, Any]:
-    """List saved device searches."""
+    """List saved device searches.
+
+    The upstream returns a Spring ``Page`` envelope (``content`` +
+    ``totalElements``/``last``), not a ``data`` list — ``extract_list`` has no
+    special-case for it and would wrap the whole envelope as a single bogus
+    record, so every saved search rendered as ``{}`` and the model lost the
+    ``id`` it needs to get/run/delete the search. We unwrap ``content`` (mirroring
+    ``advanced_device_search``) and pass each saved-search DTO through unmodified
+    so its real fields survive — note the DTO uses ``search`` (the filter spec),
+    not ``query`` (the same envelope ``create_saved_search`` writes). Spring
+    pagination is re-emitted under ``metadata.pagination``.
+    """
     org_uuid = await _resolve_org(client, org_id)
     response = await client.get(
         f"/server-groups-api/v1/organizations/{org_uuid}/device/saved-search/list",
     )
 
-    searches = _extract_list(response)
-    summaries: list[dict[str, Any]] = []
-    for item in searches:
-        entry: dict[str, Any] = {}
-        for key in ("id", "name", "description", "query", "created_at", "updated_at"):
-            val = item.get(key)
-            if val is not None:
-                entry[key] = val
-        summaries.append(entry)
+    searches: list[Mapping[str, Any]]
+    total: Any = None
+    pagination: dict[str, Any] | None = None
+    if isinstance(response, Mapping) and "content" in response:
+        content = response.get("content")
+        searches = (
+            [item for item in content if isinstance(item, Mapping)]
+            if isinstance(content, Sequence) and not isinstance(content, (str, bytes))
+            else []
+        )
+        total = response.get("total_elements")
+        if total is None:
+            total = response.get("totalElements")
+        is_last = response.get("last")
+        pagination = (
+            build_pagination_metadata(
+                page=response.get("number"),
+                page_size=response.get("size"),
+                total_elements=total,
+                total_pages=response.get("total_pages") or response.get("totalPages"),
+                has_more=(not is_last) if is_last is not None else None,
+                extra={"first": response.get("first"), "last": is_last},
+            )
+            or None
+        )
+    else:
+        searches = _extract_list(response)
+
+    metadata: dict[str, Any] = {"deprecated_endpoint": False}
+    if pagination:
+        metadata["pagination"] = pagination
 
     return {
         "data": {
-            "total_searches": len(summaries),
-            "saved_searches": summaries,
+            "total_searches": total if total is not None else len(searches),
+            "saved_searches": list(searches),
         },
-        "metadata": {"deprecated_endpoint": False},
+        "metadata": metadata,
     }
 
 

--- a/src/automox_mcp/workflows/devices.py
+++ b/src/automox_mcp/workflows/devices.py
@@ -217,6 +217,17 @@ _MAX_STALE_DEVICE_LIMIT = 200
 _STALE_CHECK_IN_THRESHOLD_DAYS = 30
 
 
+def _mapping_rows(page: Sequence[Any]) -> list[Mapping[str, Any]]:
+    """Keep only Mapping elements from a ``/servers`` page.
+
+    The API can return a page whose elements are not all objects; iterating and
+    calling ``.get(...)`` on a scalar would raise ``AttributeError`` and fail the
+    whole tool. Mirrors the guard ``list_devices_needing_attention`` already
+    applies to its report list.
+    """
+    return [item for item in page if isinstance(item, Mapping)]
+
+
 def _add_followup(metadata: dict[str, Any], tool: str, note: str) -> None:
     """Append a suggested follow-up entry without introducing duplicates."""
     followups = metadata.setdefault("suggested_followups", [])
@@ -679,7 +690,7 @@ async def list_device_inventory(
         Called by parallel_paginate in strict page order; safe to mutate
         ``curated_devices`` from here.
         """
-        for item in items:
+        for item in _mapping_rows(items):
             summary_fields = _summarize_device_common_fields(item)
             is_managed = summary_fields["is_managed"]
             if managed is not None and is_managed != managed:
@@ -1215,7 +1226,7 @@ async def search_devices(
 
     def _process_search_page(_page_num: int, devices: Sequence[Any]) -> bool:
         """Apply client-side filters per-device; stop when limit reached."""
-        for device in devices:
+        for device in _mapping_rows(devices):
             if hostname_term:
                 name = str(device.get("name") or device.get("hostname") or "").lower()
                 custom_name = str(device.get("custom_name") or "").lower()
@@ -1364,7 +1375,7 @@ async def summarize_device_health(
         normalized_limit = max(0, min(int(max_stale_devices), _MAX_STALE_DEVICE_LIMIT))
         stale_limit = normalized_limit
 
-    for device in devices:
+    for device in _mapping_rows(devices):
         summary_fields = _summarize_device_common_fields(device)
         is_managed = summary_fields["is_managed"]
         totals["managed" if is_managed else "unmanaged"] += 1

--- a/src/automox_mcp/workflows/events.py
+++ b/src/automox_mcp/workflows/events.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from ..client import AutomoxClient
+from ..utils.response import build_pagination_metadata
 
 
 async def list_events(
@@ -70,7 +71,6 @@ async def list_events(
     else:
         events_list = [events] if events else []
 
-    total = api_total if api_total is not None else len(events_list)
     summary: list[dict[str, Any]] = []
     for event in events_list:
         if not isinstance(event, Mapping):
@@ -89,12 +89,56 @@ async def list_events(
         }
         summary.append(entry)
 
-    return {
-        "data": {
-            "total_events": total,
-            "events": summary,
+    data: dict[str, Any] = {}
+    metadata: dict[str, Any] = {"deprecated_endpoint": False}
+
+    if api_total is not None:
+        # Count mode (countOnly=1): upstream supplies a real org-wide total
+        # under `size`, with no event bodies. Only here can we claim a grand
+        # total; count_only suppresses the events array.
+        data["total_events"] = api_total
+        data["events"] = []
+        return {"data": data, "metadata": metadata}
+
+    # Normal mode: the live /events endpoint returns a bare list with no
+    # upstream total, so we can only report how many came back on THIS page —
+    # never a grand total (presenting len(page) as `total_events`
+    # under-reported by a page on any limited query).
+    events_returned = len(summary)
+    data["events_returned"] = events_returned
+    data["events"] = summary
+
+    # /events is offset-paginated with no total, so "more pages exist" is
+    # inferred from a full page (returned == limit) rather than a counter.
+    has_more = limit is not None and events_returned >= limit
+    current_page = page if page is not None else 0
+    next_page = current_page + 1 if has_more else None
+    metadata["pagination"] = build_pagination_metadata(
+        page=current_page,
+        page_size=limit,
+        has_more=has_more,
+        extra={
+            "returned_count": events_returned,
+            "next_page": next_page,
         },
-        "metadata": {
-            "deprecated_endpoint": False,
-        },
-    }
+    )
+    if has_more:
+        metadata["suggested_next_call"] = {
+            "tool": "list_events",
+            "args": {
+                k: v
+                for k, v in {
+                    "page": next_page,
+                    "limit": limit,
+                    "policy_id": policy_id,
+                    "server_id": server_id,
+                    "user_id": user_id,
+                    "event_name": event_name,
+                    "start_date": start_date,
+                    "end_date": end_date,
+                }.items()
+                if v is not None
+            },
+        }
+
+    return {"data": data, "metadata": metadata}

--- a/src/automox_mcp/workflows/policy.py
+++ b/src/automox_mcp/workflows/policy.py
@@ -58,12 +58,17 @@ async def summarize_policy_activity(
         params=run_params,
     )
 
+    # Accept only `list` here (not the broader Sequence): a bare `str` and a
+    # `bytes` response are Sequences too, and a string `data` would iterate
+    # into per-character items that have no `.get`. Restricting to list, plus
+    # the per-item Mapping guard below, makes a non-list / non-dict-element
+    # body yield zero runs instead of an AttributeError crash.
     runs: Sequence[Mapping[str, Any]] = []
     if isinstance(policy_runs, Mapping):
         run_items = policy_runs.get("data")
-        if isinstance(run_items, Sequence):
+        if isinstance(run_items, list):
             runs = run_items
-    elif isinstance(policy_runs, Sequence):
+    elif isinstance(policy_runs, list):
         runs = policy_runs
 
     # Each run item contains aggregate device counts: success, failed, pending,
@@ -74,6 +79,8 @@ async def summarize_policy_activity(
     )
 
     for item in runs:
+        if not isinstance(item, Mapping):
+            continue
         failed = item.get("failed") or 0
         success = item.get("success") or 0
         device_count = item.get("device_count") or 0
@@ -216,12 +223,14 @@ async def summarize_policy_execution_history(
 
     if isinstance(payload, Mapping):
         run_items = payload.get("data")
-        if isinstance(run_items, Sequence):
+        # Accept only `list` (not the broader Sequence): a string `data` is a
+        # Sequence that would slice into per-character items with no `.get`.
+        if isinstance(run_items, list):
             runs = run_items
         # Try to extract policy name from first run item
-        if runs:
+        if runs and isinstance(runs[0], Mapping):
             policy_name = runs[0].get("policy_name")
-    elif isinstance(payload, Sequence):
+    elif isinstance(payload, list):
         runs = payload  # type: ignore[assignment]
 
     runs = list(_take(runs, limit))
@@ -230,6 +239,8 @@ async def summarize_policy_execution_history(
     timeline = []
 
     for item in runs:
+        if not isinstance(item, Mapping):
+            continue
         exec_token = item.get("execution_token") or item.get("exec_token")
         run_time = item.get("run_time")
         failed = item.get("failed") or 0
@@ -670,10 +681,14 @@ async def describe_policy(
                 logger.debug("Failed to fetch policy history: %s", exc)
                 recent_activity = None
 
-    # Decode schedule_days bitmask for better readability and add to top level
+    # Decode schedule_days bitmask for better readability and add to top level.
+    # schedule_days is a bitmask but the upstream type is known-uncertain (a
+    # non-int like the string "62" would raise TypeError in the bitmask AND
+    # below); gate on int (excluding bool) exactly as summarize_policies does
+    # and skip decoding gracefully when it is not an int.
     schedule_interpretation = None
     schedule_days = policy_data.get("schedule_days")
-    if schedule_days is not None:
+    if isinstance(schedule_days, int) and not isinstance(schedule_days, bool):
         schedule_interpretation = _decode_schedule_days_bitmask(schedule_days)
 
     data = {

--- a/tests/test_fix_devices_mapping_guard.py
+++ b/tests/test_fix_devices_mapping_guard.py
@@ -1,0 +1,74 @@
+"""Regression tests for the ``/servers`` page Mapping guard.
+
+Three ``/servers`` consumers in ``workflows.devices`` iterate page elements
+calling ``item.get(...)``. A page containing a non-Mapping element (a bare list
+with a scalar row) used to raise ``AttributeError`` and fail the whole tool.
+Each consumer must now skip the scalar and still process the valid Mapping rows.
+
+The sibling ``list_devices_needing_attention`` already filters its list to
+Mappings; these tests pin the same behaviour for the three former outliers.
+"""
+
+from typing import Any
+
+import pytest
+from conftest import StubClient
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.devices import (
+    list_device_inventory,
+    search_devices,
+    summarize_device_health,
+)
+
+# A page that mixes one scalar (non-Mapping) row with two real device dicts.
+# `managed: True` so the default include_unmanaged=False filtering keeps them.
+_MIXED_SERVERS_PAGE: list[Any] = [
+    "not-a-device",  # scalar element that would break a bare item.get(...)
+    {"id": 1, "name": "host-1", "managed": True, "compliant": True},
+    {"id": 2, "name": "host-2", "managed": True, "compliant": False},
+]
+
+
+def _stub_servers(page: list[Any]) -> StubClient:
+    """StubClient whose `/servers` page is returned once (subsequent pages empty)."""
+    return StubClient(get_responses={"/servers": [page, []]})
+
+
+@pytest.mark.asyncio
+async def test_list_device_inventory_skips_non_mapping_rows() -> None:
+    client = _stub_servers(_MIXED_SERVERS_PAGE)
+
+    result = await list_device_inventory(cast_client(client))
+
+    devices = result["data"]["devices"]
+    assert result["data"]["total_devices_returned"] == 2
+    assert {d["device_id"] for d in devices} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_search_devices_skips_non_mapping_rows() -> None:
+    client = _stub_servers(_MIXED_SERVERS_PAGE)
+
+    result = await search_devices(cast_client(client))
+
+    devices = result["data"]["devices"]
+    assert result["data"]["matches"] == 2
+    assert {d["device_id"] for d in devices} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_summarize_device_health_skips_non_mapping_rows() -> None:
+    client = _stub_servers(_MIXED_SERVERS_PAGE)
+
+    result = await summarize_device_health(cast_client(client))
+
+    data = result["data"]
+    # Two valid managed devices counted (the scalar row contributes nothing).
+    assert data["total_devices"] == 2
+    assert data["compliance_breakdown"] == {"compliant": 1, "non_compliant": 1}
+
+
+def cast_client(client: StubClient) -> AutomoxClient:
+    """Satisfy the AutomoxClient-typed parameter without a real client."""
+    return client  # type: ignore[return-value]

--- a/tests/test_fix_events_count.py
+++ b/tests/test_fix_events_count.py
@@ -1,0 +1,121 @@
+"""Regression tests for list_events count mislabeling.
+
+The live ``/events`` endpoint returns a bare JSON list with no upstream total,
+so ``len(page)`` is a per-page count, NOT an org-wide grand total. Presenting
+it as ``total_events`` under-reported by a page on any limited query. The fix
+renames the per-page count to ``events_returned`` (reserving ``total_events``
+for count mode, where upstream actually supplies a real total under ``size``)
+and adds a canonical ``metadata.pagination`` block plus ``suggested_next_call``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from conftest import StubClient
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.events import list_events
+
+
+def _event(event_id: int) -> dict[str, Any]:
+    return {
+        "id": event_id,
+        "name": "patch.success",
+        "server_id": 10,
+        "server_name": "web-01",
+        "policy_id": 5,
+        "policy_name": "Weekly Patches",
+        "policy_type_name": "patch",
+        "user_id": 99,
+        "data": None,
+        "create_time": "2026-03-01T00:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bare_list_reports_events_returned_not_total():
+    """A bare-list /events response names the count `events_returned`.
+
+    There is no upstream total, so no `total_events` may claim a grand total.
+    """
+    page = [_event(1), _event(2), _event(3)]
+    client = StubClient(get_responses={"/events": [page]})
+
+    result = await list_events(cast(AutomoxClient, client), org_id=42)
+
+    data = result["data"]
+    assert data["events_returned"] == 3
+    assert "total_events" not in data
+    assert len(data["events"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_full_page_emits_pagination_and_suggested_next_call():
+    """A full page (returned == limit) signals more pages.
+
+    Pagination state lands under `metadata.pagination` and the next-page
+    invocation under `metadata.suggested_next_call`.
+    """
+    page = [_event(i) for i in range(5)]
+    client = StubClient(get_responses={"/events": [page]})
+
+    result = await list_events(
+        cast(AutomoxClient, client),
+        org_id=42,
+        page=0,
+        limit=5,
+        event_name="patch.success",
+    )
+
+    metadata = result["metadata"]
+    pagination = metadata["pagination"]
+    assert pagination["page"] == 0
+    assert pagination["page_size"] == 5
+    assert pagination["has_more"] is True
+    assert pagination["returned_count"] == 5
+    assert pagination["next_page"] == 1
+
+    suggested = metadata["suggested_next_call"]
+    assert suggested["tool"] == "list_events"
+    assert suggested["args"]["page"] == 1
+    assert suggested["args"]["limit"] == 5
+    # Active filters are carried forward so the next page stays scoped.
+    assert suggested["args"]["event_name"] == "patch.success"
+
+
+@pytest.mark.asyncio
+async def test_partial_page_has_no_more_and_no_suggestion():
+    """A short page (returned < limit) is the last page: no next call."""
+    page = [_event(1), _event(2)]
+    client = StubClient(get_responses={"/events": [page]})
+
+    result = await list_events(cast(AutomoxClient, client), org_id=42, page=0, limit=25)
+
+    metadata = result["metadata"]
+    assert metadata["pagination"]["has_more"] is False
+    assert "suggested_next_call" not in metadata
+    assert result["data"]["events_returned"] == 2
+
+
+@pytest.mark.asyncio
+async def test_count_only_reports_real_total_and_suppresses_events():
+    """Count mode supplies a real total under `size`; events array suppressed.
+
+    Fixture is the live count-mode shape: total under `size`, empty `results`.
+    """
+    count_payload = {"size": 1382, "results": []}
+    client = StubClient(get_responses={"/events": [count_payload]})
+
+    result = await list_events(
+        cast(AutomoxClient, client),
+        org_id=42,
+        count_only=True,
+    )
+
+    data = result["data"]
+    # Only count mode may claim a grand total.
+    assert data["total_events"] == 1382
+    assert data["events"] == []
+    assert "events_returned" not in data

--- a/tests/test_fix_idempotency_release.py
+++ b/tests/test_fix_idempotency_release.py
@@ -1,0 +1,213 @@
+"""Regression tests: write tools must release their idempotency reservation on
+failure so a corrected retry (same ``request_id``) actually executes.
+
+Bug pattern: a write tool reserves the sentinel
+via ``check_idempotency`` then calls the workflow with no try/except that
+releases the reservation on failure. Any failure leaves the slot reserved for
+the full TTL, so the next retry with the same ``request_id`` is shadowed by the
+in-flight "duplicate" no-op instead of running.
+
+These tests exercise the REAL idempotency cache (conftest resets it per test).
+Only the underlying workflow is stubbed — fail on the first call, succeed on the
+retry — and we assert the retry routes through to the workflow (executes) and
+returns the real result, not the ``{"duplicate": True}`` marker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from conftest import FakeClient, StubServer
+from fastmcp.exceptions import ToolError
+
+from automox_mcp.tools import (
+    account_tools,
+    group_tools,
+    policy_windows_tools,
+    vuln_sync_tools,
+)
+
+_ACCT_UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_ORG_UUID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _success() -> dict[str, Any]:
+    return {"data": {"ok": True}, "metadata": {"deprecated_endpoint": False}}
+
+
+# Each case wires up the fail-then-succeed workflow on the right target and
+# returns the registered tool callable. Valid inputs mirror the existing
+# dispatch tests / pydantic param models so only the forced failure (not a
+# validation error) drives the first call.
+
+
+def _wire_via_workflows_attr(
+    module: Any, wf_name: str
+) -> Callable[[pytest.MonkeyPatch, list[bool]], None]:
+    """Tools that reference the workflow as ``module.workflows.<name>``."""
+
+    def wire(monkeypatch: pytest.MonkeyPatch, calls: list[bool]) -> None:
+        async def fail_then_succeed(client, **_):
+            calls.append(True)
+            if len(calls) == 1:
+                raise RuntimeError("upstream blew up")
+            return _success()
+
+        monkeypatch.setattr(module.workflows, wf_name, fail_then_succeed)
+
+    return wire
+
+
+def _wire_via_module_alias(
+    module: Any, alias: str
+) -> Callable[[pytest.MonkeyPatch, list[bool]], None]:
+    """Tools that reference the workflow via a module-level alias (vuln_sync)."""
+
+    def wire(monkeypatch: pytest.MonkeyPatch, calls: list[bool]) -> None:
+        async def fail_then_succeed(client, **_):
+            calls.append(True)
+            if len(calls) == 1:
+                raise RuntimeError("upstream blew up")
+            return _success()
+
+        monkeypatch.setattr(module, alias, fail_then_succeed)
+
+    return wire
+
+
+# (tool_name, module, wiring, kwargs) — one row per fixed write tool.
+_CASES = [
+    # policy_windows
+    (
+        "create_policy_window",
+        policy_windows_tools,
+        _wire_via_workflows_attr(policy_windows_tools, "create_policy_window"),
+        {
+            "org_uuid": _ORG_UUID,
+            "window_type": "exclude",
+            "window_name": "win",
+            "window_description": "desc",
+            "rrule": "FREQ=DAILY;UNTIL=20271231T020000Z",
+            "duration_minutes": 30,
+            "use_local_tz": False,
+            "recurrence": "once",
+            "group_uuids": [_ORG_UUID],
+            "dtstart": "2027-01-01T02:00:00Z",
+            "status": "active",
+        },
+    ),
+    (
+        "update_policy_window",
+        policy_windows_tools,
+        _wire_via_workflows_attr(policy_windows_tools, "update_policy_window"),
+        {
+            "org_uuid": _ORG_UUID,
+            "window_uuid": _ORG_UUID,
+            "dtstart": "2027-01-01T02:00:00Z",
+        },
+    ),
+    (
+        "delete_policy_window",
+        policy_windows_tools,
+        _wire_via_workflows_attr(policy_windows_tools, "delete_policy_window"),
+        {"org_uuid": _ORG_UUID, "window_uuid": _ORG_UUID},
+    ),
+    # group
+    (
+        "create_server_group",
+        group_tools,
+        _wire_via_workflows_attr(group_tools, "create_server_group"),
+        {"name": "Prod", "refresh_interval": 360, "parent_server_group_id": 0},
+    ),
+    # account
+    (
+        "invite_user_to_account",
+        account_tools,
+        _wire_via_workflows_attr(account_tools, "invite_user_to_account"),
+        {"email": "test@example.com", "account_rbac_role": "global-admin"},
+    ),
+    (
+        "remove_user_from_account",
+        account_tools,
+        _wire_via_workflows_attr(account_tools, "remove_user_from_account"),
+        {"user_id": _ACCT_UUID},
+    ),
+    # vuln_sync (workflow referenced via module-level alias)
+    (
+        "upload_action_set",
+        vuln_sync_tools,
+        _wire_via_module_alias(vuln_sync_tools, "_upload_action_set"),
+        {"csv_content": "a,b\n1,2\n", "source": "generic", "filename": "x.csv"},
+    ),
+]
+
+_CASE_IDS = [c[0] for c in _CASES]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name,module,wire,kwargs", _CASES, ids=_CASE_IDS)
+async def test_failed_write_releases_sentinel_so_retry_executes(
+    tool_name: str,
+    module: Any,
+    wire: Callable[[pytest.MonkeyPatch, list[bool]], None],
+    kwargs: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First call fails; the SAME request_id retried with valid input must run
+    the workflow again (execute) instead of returning the duplicate no-op.
+    """
+    monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", _ACCT_UUID)
+    calls: list[bool] = []
+    wire(monkeypatch, calls)
+
+    server = StubServer()
+    module.register(server, read_only=False, client=FakeClient(org_id=42))
+    tool = server.tools[tool_name]
+
+    # First call fails — the reservation must be released on the way out.
+    # call_tool_workflow may surface the raw error or wrap it as ToolError.
+    with pytest.raises((RuntimeError, ToolError)):
+        await tool(request_id="retry-me", **kwargs)
+
+    # Retry with the SAME request_id: must execute (not the duplicate marker).
+    result = await tool(request_id="retry-me", **kwargs)
+
+    # The retry executed: real result returned, NOT the duplicate no-op.
+    assert result["data"] == {"ok": True}
+    assert "duplicate" not in result.get("data", {})
+    assert calls == [True, True]  # workflow ran on BOTH attempts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name,module,wire,kwargs", _CASES, ids=_CASE_IDS)
+async def test_unreleased_sentinel_would_shadow_retry_without_fix(
+    tool_name: str,
+    module: Any,
+    wire: Callable[[pytest.MonkeyPatch, list[bool]], None],
+    kwargs: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity-check the cache mechanics the fix relies on: a reservation left in
+    place (no release) shadows a same-request_id retry with the duplicate
+    marker. This is the failure the release fixes prevent.
+    """
+    from automox_mcp.utils.tooling import check_idempotency
+
+    # Reserve the slot as the tool's first (failing) call would, but DON'T
+    # release it — the pre-fix behaviour.
+    first = await check_idempotency("shadow-me", tool_name)
+    assert first is None  # fresh reservation
+
+    monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", _ACCT_UUID)
+    calls: list[bool] = []
+    wire(monkeypatch, calls)
+
+    server = StubServer()
+    module.register(server, read_only=False, client=FakeClient(org_id=42))
+
+    # Retry with the same request_id sees the in-flight sentinel → no execution.
+    result = await server.tools[tool_name](request_id="shadow-me", **kwargs)
+    assert result["data"]["duplicate"] is True
+    assert calls == []  # workflow never ran — exactly the bug being fixed

--- a/tests/test_fix_policy_crash_guards.py
+++ b/tests/test_fix_policy_crash_guards.py
@@ -1,0 +1,169 @@
+"""Crash-guard regression tests for policy workflows.
+
+Covers two known-uncertain upstream-type defects:
+
+* ``describe_policy`` decoded ``schedule_days`` guarded only by
+  ``is not None``. A non-int value (e.g. the string ``"62"``) reached
+  ``_decode_schedule_days_bitmask`` and raised ``TypeError`` on ``bitmask &
+  0xFE``. The sibling ``summarize_policies`` already gates on
+  ``isinstance(..., int)``; ``describe_policy`` must degrade the same way.
+* ``summarize_policy_activity`` iterated the runs list without an
+  ``isinstance(item, Mapping)`` guard and accepted any ``Sequence`` under
+  ``data``. A ``data`` that is a string (or a list of scalars) made the loop
+  call ``item.get(...)`` and raise ``AttributeError``.
+
+Fixtures mirror the existing ``test_workflows_policy`` ``StubClient`` style.
+"""
+
+import copy
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.policy import (
+    describe_policy,
+    summarize_policy_activity,
+)
+
+
+class StubClient:
+    """Minimal Automox client stub: feed canned GET responses per path."""
+
+    def __init__(self, *, get_responses: dict[str, list[Any]] | None = None) -> None:
+        self._get_responses = {key: list(value) for key, value in (get_responses or {}).items()}
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    async def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        self.calls.append(("GET", path, params))
+        responses = self._get_responses.get(path)
+        if not responses:
+            raise AssertionError(f"Unexpected GET request: {path}")
+        return copy.deepcopy(responses.pop(0))
+
+
+_ORG_UUID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+# ---------------------------------------------------------------------------
+# describe_policy degrades when schedule_days is a non-int
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_describe_policy_non_int_schedule_days_degrades() -> None:
+    """A string ``schedule_days`` must not crash the tool; it is skipped, not
+    decoded (no schedule_interpretation), and the policy still returns."""
+    policy = {
+        "id": 10,
+        "name": "Patch Everything",
+        "policy_type_name": "patch",
+        # Upstream-uncertain type: a string where an int bitmask is expected.
+        "schedule_days": "62",
+        "schedule_time": "02:00",
+    }
+    stub = StubClient(get_responses={"/policies/10": [policy]})
+
+    result = await describe_policy(
+        cast(AutomoxClient, stub),
+        org_id=42,
+        policy_id=10,
+        include_recent_runs=0,
+    )
+
+    assert result["data"]["policy"]["id"] == 10
+    # Decode was skipped — no interpretation / _important block confabulated.
+    assert "schedule_interpretation" not in result["data"]
+    assert "_important" not in result["data"]
+
+
+@pytest.mark.asyncio
+async def test_describe_policy_int_schedule_days_still_decodes() -> None:
+    """Regression sibling: a real int bitmask still decodes (the guard does
+    not over-reach and suppress valid values)."""
+    policy = {
+        "id": 11,
+        "name": "Weekday Patching",
+        "policy_type_name": "patch",
+        "schedule_days": 62,  # Mon-Fri
+        "schedule_time": "02:00",
+    }
+    stub = StubClient(get_responses={"/policies/11": [policy]})
+
+    result = await describe_policy(
+        cast(AutomoxClient, stub),
+        org_id=42,
+        policy_id=11,
+        include_recent_runs=0,
+    )
+
+    assert (
+        result["data"]["schedule_interpretation"]["interpretation"]
+        == "Weekdays (Monday through Friday)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# summarize_policy_activity tolerates non-list / non-dict runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summarize_policy_activity_data_is_string() -> None:
+    """A 200 body whose ``data`` is a string must yield zero runs, not an
+    AttributeError from iterating per-character and calling ``.get``."""
+    stub = StubClient(
+        get_responses={
+            "/policy-history/policy-run-count": [{"policy_runs": 0}],
+            "/policy-history/policy-runs": [{"data": "not-a-list"}],
+        }
+    )
+
+    result = await summarize_policy_activity(cast(AutomoxClient, stub), org_uuid=_ORG_UUID)
+
+    assert result["data"]["total_runs_considered"] == 0
+    assert result["data"]["status_breakdown"] == {}
+    assert result["data"]["top_failing_policies"] == []
+
+
+@pytest.mark.asyncio
+async def test_summarize_policy_activity_data_is_list_of_scalars() -> None:
+    """A ``data`` list of non-dict elements is skipped item-by-item via the
+    Mapping guard — a sane empty summary, no crash."""
+    stub = StubClient(
+        get_responses={
+            "/policy-history/policy-run-count": [{"policy_runs": 0}],
+            "/policy-history/policy-runs": [{"data": ["alpha", 1, None]}],
+        }
+    )
+
+    result = await summarize_policy_activity(cast(AutomoxClient, stub), org_uuid=_ORG_UUID)
+
+    # All three list elements considered, but none counted (non-Mapping skipped).
+    assert result["data"]["total_runs_considered"] == 3
+    assert result["data"]["status_breakdown"] == {}
+    assert result["data"]["top_failing_policies"] == []
+
+
+@pytest.mark.asyncio
+async def test_summarize_policy_activity_bare_string_response() -> None:
+    """A bare non-list response (string) yields zero runs (the list-only
+    acceptance rejects it)."""
+    stub = StubClient(
+        get_responses={
+            "/policy-history/policy-run-count": [{"policy_runs": 0}],
+            "/policy-history/policy-runs": ["unexpected-bare-string"],
+        }
+    )
+
+    result = await summarize_policy_activity(cast(AutomoxClient, stub), org_uuid=_ORG_UUID)
+
+    assert result["data"]["total_runs_considered"] == 0
+    assert result["data"]["status_breakdown"] == {}

--- a/tests/test_fix_policy_idempotency.py
+++ b/tests/test_fix_policy_idempotency.py
@@ -1,0 +1,88 @@
+"""Regression test for the apply_policy_changes idempotency-sentinel leak.
+
+`apply_policy_changes` reserves an in-flight idempotency sentinel via
+``check_idempotency`` before doing any work. ``normalize_policy_operations_input``
+raises ``ToolError`` on common malformed input (missing ``action``). Before the
+fix that normalize call ran *outside* the try/except that calls
+``release_idempotency``, so a malformed first call left the reservation in place
+for the full TTL — a corrected retry reusing the same ``request_id`` was then
+shadowed by the duplicate no-op instead of executing.
+
+These tests drive the real registered tool (deps stubbed) and assert that after a
+normalize failure, a corrected retry with the SAME ``request_id`` EXECUTES rather
+than returning the ``{"duplicate": True}`` marker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from conftest import StubClient
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.tools.policy_tools import register as register_policy
+
+# A malformed op: missing the required ``action`` field → normalize raises.
+_MALFORMED_OPS: list[dict[str, Any]] = [{"policy": {"name": "X"}}]
+
+# A well-formed create op; ``preview=True`` exercises the workflow without
+# requiring a canned POST response from the stub.
+_VALID_OPS: list[dict[str, Any]] = [
+    {
+        "action": "create",
+        "policy": {
+            "name": "New Policy",
+            "policy_type_name": "patch",
+            "configuration": {"patch_rule": "all"},
+            "schedule": {"days": ["monday"], "time": "02:00"},
+            "server_groups": [],
+        },
+    }
+]
+
+
+def _apply_tool() -> Any:
+    """Register the policy tools on a real FastMCP server and return the bound
+    ``apply_policy_changes`` callable."""
+    srv = FastMCP("policy-idempotency-test")
+    register_policy(srv, read_only=False, client=cast(AutomoxClient, StubClient()))
+    tools: dict[str, Any] = {
+        c.name: c for key, c in srv.local_provider._components.items() if key.startswith("tool:")
+    }
+    return tools["apply_policy_changes"].fn
+
+
+@pytest.mark.asyncio
+async def test_normalize_failure_releases_sentinel_so_retry_executes() -> None:
+    """Malformed first call raises; a corrected retry with the same request_id
+    must EXECUTE, not return the duplicate no-op."""
+    apply = _apply_tool()
+    request_id = "req-normalize-leak"
+
+    # First call: malformed input → normalize raises, reservation must be released.
+    with pytest.raises(ToolError):
+        await apply(operations=_MALFORMED_OPS, preview=True, request_id=request_id)
+
+    # Retry with the SAME request_id but a valid payload.
+    result = await apply(operations=_VALID_OPS, preview=True, request_id=request_id)
+
+    # The tool executed (returned a real preview), not the duplicate marker.
+    assert result["data"].get("duplicate") is not True
+    assert result["data"]["preview"] is True
+
+
+@pytest.mark.asyncio
+async def test_duplicate_marker_still_returned_for_genuine_in_flight() -> None:
+    """The release fix must not defeat idempotency: a stored result for the same
+    request_id is replayed rather than re-executed."""
+    apply = _apply_tool()
+    request_id = "req-genuine-dup"
+
+    first = await apply(operations=_VALID_OPS, preview=True, request_id=request_id)
+    second = await apply(operations=_VALID_OPS, preview=True, request_id=request_id)
+
+    # Second call replays the first stored response (idempotent), not a fresh run.
+    assert second == first

--- a/tests/test_fix_saved_searches_page.py
+++ b/tests/test_fix_saved_searches_page.py
@@ -1,0 +1,99 @@
+"""Regression test for list_saved_searches collapsing a Spring Page.
+
+The `/device/saved-search/list` endpoint returns a Spring `Page` envelope
+(`content` + `totalElements`/`last`), not a `data` list. The old wrapper ran
+`extract_list` on it, which has no Spring-Page case and fell through to wrapping
+the whole envelope as one record; the projection then picked snake_case keys
+(`query`/`created_at`) that don't exist on the envelope, so every saved search
+rendered as `{}` and the model lost the `id` needed to get/run/delete it.
+
+The DTO field for the filter spec is `search` (the same envelope
+`create_saved_search` writes), not `query`. These fixtures use sanitized
+real-shape payloads, per the repo testing convention.
+"""
+
+from typing import Any, cast
+
+import pytest
+from conftest import StubClient
+
+from automox_mcp.client import AutomoxClient
+from automox_mcp.workflows.device_search import list_saved_searches
+
+_ORG_UUID = "11111111-2222-3333-4444-555555555555"
+_LIST_PATH = f"/server-groups-api/v1/organizations/{_ORG_UUID}/device/saved-search/list"
+
+# Spring Page envelope with the real saved-search DTO field names: `search`
+# (the filter spec, mirroring create_saved_search's `search` envelope) and
+# camelCase timestamps.
+_SPRING_PAGE = {
+    "content": [
+        {
+            "id": "ss-001",
+            "name": "Stale Devices",
+            "description": "Not seen in 30 days",
+            "search": {"filters": [{"AND": [{"field": "lastSeen"}]}]},
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+        },
+        {
+            "id": "ss-002",
+            "name": "Windows Servers",
+            "search": {"filters": [{"AND": [{"field": "os_family"}]}]},
+            "createdAt": "2026-01-03T00:00:00Z",
+        },
+    ],
+    "totalElements": 2,
+    "totalPages": 1,
+    "number": 0,
+    "size": 25,
+    "first": True,
+    "last": True,
+}
+
+
+def _make_client(**kwargs: Any) -> StubClient:
+    client = StubClient(**kwargs)
+    client.org_uuid = _ORG_UUID
+    return client
+
+
+@pytest.mark.asyncio
+async def test_list_saved_searches_unwraps_spring_page() -> None:
+    client = _make_client(get_responses={_LIST_PATH: [_SPRING_PAGE]})
+    result = await list_saved_searches(cast(AutomoxClient, client))
+
+    content = cast(list[Any], _SPRING_PAGE["content"])
+    saved = result["data"]["saved_searches"]
+
+    # One record per content item — NOT one collapsed envelope record.
+    assert len(saved) == len(content)
+    # Count reflects totalElements, not the page slice length (here they match,
+    # but the field comes from the envelope, not len()).
+    assert result["data"]["total_searches"] == _SPRING_PAGE["totalElements"]
+
+    # Each item retains its real fields — id/name/search survive, no `{}`.
+    first = saved[0]
+    assert first != {}
+    assert first["id"] == "ss-001"
+    assert first["name"] == "Stale Devices"
+    assert first["search"] == {"filters": [{"AND": [{"field": "lastSeen"}]}]}
+    assert saved[1]["id"] == "ss-002"
+
+    # Spring envelope fields don't leak into individual records.
+    assert "content" not in first
+    assert "totalElements" not in first
+
+    # Spring pagination surfaced under metadata.pagination.
+    assert result["metadata"]["pagination"]["total_elements"] == 2
+    assert result["metadata"]["pagination"]["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_saved_searches_empty_spring_page() -> None:
+    empty_page = {"content": [], "totalElements": 0, "first": True, "last": True}
+    client = _make_client(get_responses={_LIST_PATH: [empty_page]})
+    result = await list_saved_searches(cast(AutomoxClient, client))
+
+    assert result["data"]["total_searches"] == 0
+    assert result["data"]["saved_searches"] == []

--- a/tests/test_fix_servergroup_null.py
+++ b/tests/test_fix_servergroup_null.py
@@ -1,0 +1,62 @@
+"""Regression test for null-`policies` defect in the servergroups list resource.
+
+When a server group's ``policies`` key is explicitly ``null`` (not absent), the
+``.get("policies", [])`` default does not apply — ``.get`` returns ``None`` and
+``len(None)`` raised a ``TypeError`` that crashed the entire resource read,
+breaking server_group_id -> name resolution for the whole session.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from automox_mcp.resources import servergroup_resources
+
+
+class StubResourceServer:
+    """Minimal FastMCP lookalike that captures registered resource functions."""
+
+    def __init__(self) -> None:
+        self.resources: dict[str, Any] = {}
+
+    def resource(self, uri: str, **kwargs):
+        def decorator(func):
+            self.resources[uri] = func
+            return func
+
+        return decorator
+
+
+class FakeClient:
+    def __init__(self, *, org_id: int | None = 42) -> None:
+        self.org_id = org_id
+        self._response: Any = []
+
+    async def get(self, path: str, *, params=None, headers=None) -> Any:
+        return self._response
+
+
+class TestServerGroupNullPolicies:
+    @pytest.mark.asyncio
+    async def test_null_policies_yields_zero_policy_count(self) -> None:
+        client = FakeClient(org_id=42)
+        client._response = [
+            {
+                "id": 7,
+                "name": "Null Policies",
+                "organization_id": 42,
+                "server_count": 4,
+                "policies": None,
+            }
+        ]
+
+        server = StubResourceServer()
+        servergroup_resources.register(server, client=client)
+
+        handler = server.resources["resource://servergroups/list"]
+        result = await handler()
+
+        assert result["total_count"] == 1
+        assert result["server_groups"][0]["policy_count"] == 0

--- a/tests/test_workflows_events.py
+++ b/tests/test_workflows_events.py
@@ -42,7 +42,8 @@ async def test_list_events_basic():
     client = StubClient(get_responses={"/events": [events_payload]})
     result = await list_events(cast(AutomoxClient, client), org_id=42)
 
-    assert result["data"]["total_events"] == 2
+    assert result["data"]["events_returned"] == 2
+    assert "total_events" not in result["data"]
     assert len(result["data"]["events"]) == 2
     first = result["data"]["events"][0]
     assert first["id"] == 1
@@ -57,7 +58,7 @@ async def test_list_events_empty_response():
     client = StubClient(get_responses={"/events": [[]]})
     result = await list_events(cast(AutomoxClient, client), org_id=42)
 
-    assert result["data"]["total_events"] == 0
+    assert result["data"]["events_returned"] == 0
     assert result["data"]["events"] == []
 
 
@@ -97,7 +98,7 @@ async def test_list_events_filters_passed_through():
         end_date="2026-03-31",
     )
 
-    assert result["data"]["total_events"] == 1
+    assert result["data"]["events_returned"] == 1
     assert result["data"]["events"][0]["id"] == 7
 
 
@@ -150,7 +151,7 @@ async def test_list_events_unexpected_dict_shape():
     """
     client = StubClient(get_responses={"/events": [{"unexpected": "value"}]})
     result = await list_events(cast(AutomoxClient, client), org_id=1)
-    assert result["data"]["total_events"] == 0
+    assert result["data"]["events_returned"] == 0
     assert result["data"]["events"] == []
 
 
@@ -159,8 +160,9 @@ async def test_list_events_non_list_non_dict_response():
     """Unexpected scalar response is wrapped into a single-element list."""
     client = StubClient(get_responses={"/events": ["unexpected"]})
     result = await list_events(cast(AutomoxClient, client), org_id=1)
-    # "unexpected" is not a Mapping, so it gets skipped in the loop
-    assert result["data"]["total_events"] == 1
+    # "unexpected" is not a Mapping, so it is skipped; events_returned counts
+    # only the events actually returned (0), not the raw page length.
+    assert result["data"]["events_returned"] == 0
     assert result["data"]["events"] == []
 
 
@@ -185,7 +187,7 @@ async def test_list_events_skips_non_mapping_items():
     ]
     client = StubClient(get_responses={"/events": [events]})
     result = await list_events(cast(AutomoxClient, client), org_id=1)
-    assert result["data"]["total_events"] == 3
+    assert result["data"]["events_returned"] == 1
     assert len(result["data"]["events"]) == 1
 
 
@@ -194,7 +196,7 @@ async def test_list_events_none_response():
     """None response returns empty events."""
     client = StubClient(get_responses={"/events": [None]})
     result = await list_events(cast(AutomoxClient, client), org_id=1)
-    assert result["data"]["total_events"] == 0
+    assert result["data"]["events_returned"] == 0
     assert result["data"]["events"] == []
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.2.4"
+version = "2.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Second batch of fixes following the earlier high-severity pass. Each change is surgical, follows existing patterns, and is covered by unit tests.

## Fixed

- **`list_events` no longer mislabels a per-page count as the organization-wide total.** The endpoint returns a bare list with no upstream total, so a normal response now reports `events_returned` (the count on this page) plus a `metadata.pagination` block and a `suggested_next_call`, rather than a `total_events` that under-reported by a page on any limited query. Count mode (`count_only=true`) still returns the real `total_events`. **Note:** `total_events` is no longer present on normal `list_events` responses — read `events_returned` and `metadata.pagination`.
- **`list_saved_searches` returns usable saved searches.** A Spring `Page` envelope was being collapsed into a single empty record, so every saved search came back as `{}` with no id/name/filter. The envelope is now unwrapped and each saved search retains its `id`/`name`/`search`, with pagination surfaced.
- **Write tools no longer block a corrected retry after a failed first attempt.** `apply_policy_changes`, `create`/`update`/`delete_policy_window`, `invite_user_to_account`, `remove_user_from_account`, `create`/`update`/`delete_server_group`, and `upload_action_set` reserved an idempotency key but did not release it on failure, so a retry with the same `request_id` — even after correcting the payload — silently returned a duplicate no-op for the key's TTL. They now release the reservation on failure.
- **Several read tools and one resource degrade gracefully on unexpected upstream shapes.** `resource://servergroups/list` no longer raises on a `null` policy list; `describe_policy` tolerates a non-numeric schedule field; and `summarize_policy_activity`, `summarize_policy_execution_history`, `list_device_packages`, `search_devices`, and `device_health_metrics` skip non-object list elements instead of raising.

## Testing

- Full unit and integration suite passes (new input→output tests added per fix, including negative-proof tests that demonstrate each bug).
- `ruff` (format + lint), `mypy`, and the coverage gate are clean.
- Version metadata and the changelog are updated for the next patch release.
