### PR TITLE
fix: harden auth config and transport rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.6] - 2026-06-26
+
+### Security
+
+- **The per-IP authentication rate limiter no longer blocks clients over a transport-layer rejection.** An invalid-`Origin` / DNS-rebinding `403` was being counted as an authentication failure, so a misconfigured client (or a shared-IP reverse proxy) was IP-blocked for 5 minutes after 10 such requests, and an unauthenticated caller could trip the limiter cheaply. The DNS-rebinding/Origin check now sits outside the rate limiter, so transport-security rejections are no longer counted — while genuine authentication failures still are.
+- **Floored the transitive `joserfc` dependency to `>=1.6.7`** to pick up the fix for a JWS payload-size-limit bypass (CVE-2026-48990), where an oversized RFC 7797 `b64=false` payload could deserialize past the configured size limit.
+
+### Fixed
+
+- **The `AUTOMOX_MCP_OAUTH_ALGORITHM` setting is now case-insensitive.** A lowercase/mixed-case value (e.g. `rs256`) cleared the wrapper's validation but then crashed the server at startup inside the JWT verifier; the value is normalized so the server starts.
+- **Setting both `AUTOMOX_MCP_OAUTH_JWKS_URI` and `AUTOMOX_MCP_OAUTH_PUBLIC_KEY` now fails fast with a clear error** naming the conflict, instead of crashing at startup with an opaque library error.
+- **`EdDSA` is no longer advertised as a supported OAuth algorithm** — it was enumerated but always rejected (and unsupported downstream); configuring it now returns a clear "not a recognized algorithm" error.
+- **The auto-derived `Origin` allowlist now matches a same-host client over HTTPS.** Under TLS, a same-host browser client's `https://{host}` Origin (default port) previously failed validation unless `AUTOMOX_MCP_ALLOWED_ORIGINS` was set manually.
+
 ## [2.2.5] - 2026-06-26
 
 ### Fixed

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more \u2014 all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 14 MCP resources (including interactive MCP App UIs for compliance triage, patch-approval review, policy blast-radius review, remediation-apply review, and RBAC access certification), and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.2.5"
+version = "2.2.6"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.2.5",
+  "automox-mcp>=2.2.6",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.2.5"
+version = "2.2.6"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [
@@ -22,6 +22,7 @@ dependencies = [
   "cryptography>=48.0.1",  # GHSA-537c-gmf6-5ccf: bundled-OpenSSL fix in wheels
   "fastmcp>=3.4.2",
   "httpx>=0.28",
+  "joserfc>=1.6.7",  # CVE-2026-48990: JWS payload-size-limit bypass; transitive via fastmcp
   "pydantic>=2.12",
   "python-dotenv>=1.1"
 ]

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.2.5",
+  "version": "2.2.6",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/automox_mcp/auth.py
+++ b/src/automox_mcp/auth.py
@@ -233,6 +233,14 @@ def _create_jwt_auth() -> Any | None:
 
     public_key = _env_str("AUTOMOX_MCP_OAUTH_PUBLIC_KEY")
 
+    # JWTVerifier accepts exactly one of jwks_uri / public_key; reject the
+    # ambiguous both-set case here with a friendly message instead of letting
+    # the library raise an opaque ValueError at construction.
+    if jwks_uri and public_key:
+        raise RuntimeError(
+            "Set exactly one of AUTOMOX_MCP_OAUTH_JWKS_URI or AUTOMOX_MCP_OAUTH_PUBLIC_KEY."
+        )
+
     # If public_key looks like a file path, read it
     if public_key and not public_key.startswith("-----"):
         key_path = Path(public_key).expanduser()
@@ -308,8 +316,13 @@ def _create_jwt_auth() -> Any | None:
             "will be accepted, enabling cross-service token reuse. "
             "Set AUTOMOX_MCP_OAUTH_AUDIENCE to your server's resource identifier."
         )
-    algorithm = _env_str("AUTOMOX_MCP_OAUTH_ALGORITHM") or "RS256"
-    # Validate algorithm compatibility with key type
+    # Normalize once at read time so the guards below AND the forwarded
+    # verifier_kwargs['algorithm'] all use the canonical uppercase form that
+    # JWTVerifier accepts (it rejects case variants like "rs256").
+    algorithm = (_env_str("AUTOMOX_MCP_OAUTH_ALGORITHM") or "RS256").upper()
+    # Validate algorithm compatibility with key type. All entries are uppercase
+    # so the canonical `algorithm` matches directly. EdDSA is intentionally
+    # absent — JWTVerifier does not support it downstream.
     _ASYMMETRIC_ALGORITHMS = {
         "RS256",
         "RS384",
@@ -320,23 +333,22 @@ def _create_jwt_auth() -> Any | None:
         "PS256",
         "PS384",
         "PS512",
-        "EdDSA",
     }
     _HMAC_ALGORITHMS = {"HS256", "HS384", "HS512"}
-    if algorithm.upper() in _HMAC_ALGORITHMS and public_key:
+    if algorithm in _HMAC_ALGORITHMS and public_key:
         raise RuntimeError(
             f"AUTOMOX_MCP_OAUTH_ALGORITHM={algorithm} is an HMAC algorithm but a public key "
             "is configured. HMAC algorithms use shared secrets, not public keys. "
             "Use an asymmetric algorithm (e.g., RS256, ES256) with public keys."
         )
-    if algorithm.upper() in _HMAC_ALGORITHMS and jwks_uri:
+    if algorithm in _HMAC_ALGORITHMS and jwks_uri:
         raise RuntimeError(
             f"AUTOMOX_MCP_OAUTH_ALGORITHM={algorithm} is an HMAC algorithm but a JWKS URI "
             "is configured. HMAC shared secrets must not be fetched from a JWKS endpoint — "
             "this combination enables key-confusion attacks. "
             "Use an asymmetric algorithm (e.g., RS256, ES256) with JWKS."
         )
-    if algorithm.upper() not in _ASYMMETRIC_ALGORITHMS | _HMAC_ALGORITHMS:
+    if algorithm not in _ASYMMETRIC_ALGORITHMS | _HMAC_ALGORITHMS:
         raise RuntimeError(
             f"AUTOMOX_MCP_OAUTH_ALGORITHM={algorithm} is not a recognized JWT algorithm. "
             f"Supported: {', '.join(sorted(_ASYMMETRIC_ALGORITHMS | _HMAC_ALGORITHMS))}"

--- a/src/automox_mcp/transport_security.py
+++ b/src/automox_mcp/transport_security.py
@@ -377,10 +377,14 @@ def build_transport_security_middleware(
     # --- Security headers (always on) ---
     middlewares.append(ASGIMiddleware(SecurityHeadersMiddleware))
 
-    # --- Auth rate limiting (always on for HTTP/SSE) ---
-    middlewares.append(ASGIMiddleware(AuthRateLimitMiddleware))
-
     # --- DNS rebinding protection ---
+    # NB: appended BEFORE the auth rate limiter so it wraps it (Starlette applies
+    # the list outermost-first). A transport-security rejection (e.g. 403 for an
+    # invalid Origin) is a config/transport error, not an auth attempt, and must
+    # not flow back through AuthRateLimitMiddleware's send-wrapper — otherwise a
+    # misconfigured client/proxy gets IP-blocked and an unauthenticated attacker
+    # can trip the limiter cheaply. Genuine auth 401/403s originate in the inner
+    # app and still pass through the limiter.
     dns_protection = _env_flag("AUTOMOX_MCP_DNS_REBINDING_PROTECTION", default=True)
     if not dns_protection:
         logger.warning(
@@ -388,6 +392,8 @@ def build_transport_security_middleware(
             "AUTOMOX_MCP_DNS_REBINDING_PROTECTION=false. "
             "This is NOT recommended for production."
         )
+        # --- Auth rate limiting (always on for HTTP/SSE) ---
+        middlewares.append(ASGIMiddleware(AuthRateLimitMiddleware))
         return middlewares
 
     # Build allowed hosts
@@ -419,12 +425,19 @@ def build_transport_security_middleware(
     allowed_origins: list[str] = []
 
     def _add_origin_variants(h: str, p: int) -> None:
-        """Add http://host:port origin, plus bracket variant for IPv6."""
-        if ":" in h and not h.startswith("["):
-            # IPv6: browsers use bracketed form in Origin headers
-            allowed_origins.append(f"http://[{h}]:{p}")
-        else:
-            allowed_origins.append(f"http://{h}:{p}")
+        """Add origin variants for ``host``: the explicit ``http://host:port`` form
+        plus the default-port ``https://host`` form (no ``:443``).
+
+        A same-host browser MCP client under TLS sends ``Origin: https://host``
+        with the default 443 port omitted, which the explicit ``http://host:port``
+        entry never matches. Emitting the scheme-aware default-port form lets the
+        auto-allowlist cover that case without a manual override. Both bracket the
+        host for IPv6, since browsers use the bracketed form in Origin headers.
+        """
+        host_token = f"[{h}]" if ":" in h and not h.startswith("[") else h
+        allowed_origins.append(f"http://{host_token}:{p}")
+        # Default-port HTTPS form (443 omitted) for same-host TLS browser clients.
+        allowed_origins.append(f"https://{host_token}")
 
     # Allow the server's own origin
     _add_origin_variants(host, port)
@@ -450,6 +463,12 @@ def build_transport_security_middleware(
             allowed_origins=allowed_origins,
         )
     )
+
+    # --- Auth rate limiting (always on for HTTP/SSE) ---
+    # Appended last so it sits INSIDE the DNS-rebinding middleware: only responses
+    # that survive transport-security validation reach its send-wrapper, so its
+    # 403s (invalid Origin) are never miscounted as auth failures.
+    middlewares.append(ASGIMiddleware(AuthRateLimitMiddleware))
 
     return middlewares
 

--- a/tests/test_fix_auth_config.py
+++ b/tests/test_fix_auth_config.py
@@ -1,0 +1,105 @@
+"""Regression tests for _create_jwt_auth config-handling fixes.
+
+Covers three v2.2.2-audit bugs in ``automox_mcp.auth._create_jwt_auth``:
+
+* case-variant OAuth algorithm (e.g. ``rs256``) must be normalized to the
+  canonical uppercase form instead of crashing boot in JWTVerifier.
+* setting BOTH ``AUTOMOX_MCP_OAUTH_JWKS_URI`` and
+  ``AUTOMOX_MCP_OAUTH_PUBLIC_KEY`` must raise the module's friendly
+  ``RuntimeError`` rather than JWTVerifier's opaque ``ValueError``.
+* ``EdDSA`` is no longer enumerated as supported; it is rejected with the
+  clear "not a recognized JWT algorithm" guard (it is unsupported downstream).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from automox_mcp.auth import _create_jwt_auth
+
+_OAUTH_ENV_VARS = [
+    "AUTOMOX_MCP_OAUTH_ISSUER",
+    "AUTOMOX_MCP_OAUTH_JWKS_URI",
+    "AUTOMOX_MCP_OAUTH_PUBLIC_KEY",
+    "AUTOMOX_MCP_OAUTH_AUDIENCE",
+    "AUTOMOX_MCP_OAUTH_ALGORITHM",
+    "AUTOMOX_MCP_OAUTH_SCOPES",
+    "AUTOMOX_MCP_OAUTH_SERVER_URL",
+    "AUTOMOX_MCP_API_KEYS",
+    "AUTOMOX_MCP_API_KEY_FILE",
+]
+
+# A structurally-marked PEM public key; JWTVerifier accepts it as a public_key
+# without parsing (mirrors the existing test_public_key_inline fixture).
+_FAKE_PUBLIC_KEY = (
+    "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...\n-----END PUBLIC KEY-----"
+)
+
+
+@pytest.fixture
+def _clean_oauth_env(monkeypatch):
+    """Strip all auth-related env so each case starts from a known state."""
+    for var in _OAUTH_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _set_base_oauth(monkeypatch, *, public_key: bool = True) -> None:
+    """Configure the minimum valid OAuth env for a public-key verifier."""
+    monkeypatch.setenv("AUTOMOX_MCP_OAUTH_ISSUER", "https://auth.example.com")
+    monkeypatch.setenv("AUTOMOX_MCP_OAUTH_AUDIENCE", "https://mcp.example.com")
+    if public_key:
+        monkeypatch.setenv("AUTOMOX_MCP_OAUTH_PUBLIC_KEY", _FAKE_PUBLIC_KEY)
+
+
+# ---------------------------------------------------------------------------
+# case-variant algorithm normalized, not crashed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw_algorithm", ["rs256", "Rs256", "RS256"])
+def test_lowercase_algorithm_is_normalized(_clean_oauth_env, raw_algorithm):
+    monkeypatch = _clean_oauth_env
+    _set_base_oauth(monkeypatch)
+    monkeypatch.setenv("AUTOMOX_MCP_OAUTH_ALGORITHM", raw_algorithm)
+
+    # Builder must succeed (no uncaught ValueError from JWTVerifier) ...
+    provider = _create_jwt_auth()
+
+    # ... and the forwarded algorithm is the canonical uppercase form.
+    assert provider is not None
+    assert provider.algorithm == "RS256"
+
+
+# ---------------------------------------------------------------------------
+# both jwks_uri and public_key set raises a friendly RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_both_jwks_and_public_key_raise_runtimeerror(_clean_oauth_env):
+    monkeypatch = _clean_oauth_env
+    _set_base_oauth(monkeypatch)  # sets public_key
+    monkeypatch.setenv(
+        "AUTOMOX_MCP_OAUTH_JWKS_URI",
+        "https://auth.example.com/.well-known/jwks.json",
+    )
+
+    with pytest.raises(RuntimeError, match="exactly one"):
+        _create_jwt_auth()
+
+
+# ---------------------------------------------------------------------------
+# EdDSA is no longer enumerated-but-rejected; it is a clear error
+# ---------------------------------------------------------------------------
+
+
+def test_eddsa_is_rejected_with_clear_error(_clean_oauth_env):
+    monkeypatch = _clean_oauth_env
+    _set_base_oauth(monkeypatch)
+    monkeypatch.setenv("AUTOMOX_MCP_OAUTH_ALGORITHM", "EdDSA")
+
+    # No longer the self-contradictory "enumerated but rejected" state: EdDSA is
+    # simply not in the supported set, surfaced via the recognized-algorithm
+    # guard's message.
+    with pytest.raises(RuntimeError, match="not a recognized JWT algorithm"):
+        _create_jwt_auth()

--- a/tests/test_fix_transport_hardening.py
+++ b/tests/test_fix_transport_hardening.py
@@ -1,0 +1,162 @@
+"""Regression tests for the auth/transport hardening fixes.
+
+Covers two bugs in ``automox_mcp.transport_security`` (audited at v2.2.2, file
+unchanged since):
+
+- transport-security rejections (invalid Origin / DNS-rebinding 403) must
+  NOT be counted as auth failures by ``AuthRateLimitMiddleware`` — otherwise a
+  misconfigured client gets IP-blocked and an attacker has a cheap DoS lever.
+  Genuine auth 401/403s must STILL count (DoS protection preserved).
+- the auto-derived origin allowlist must include an ``https://{host}``
+  (default-port) entry so a same-host HTTPS browser Origin matches.
+"""
+
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from automox_mcp.transport_security import build_transport_security_middleware
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Loopback bind: factory auto-allowlists "localhost:8000" host and origins, so a
+# request with a valid Host survives DNS-rebinding validation and reaches the
+# inner app, while a bad Origin is rejected by the DNS middleware.
+_HOST = "127.0.0.1"
+_PORT = 8000
+_VALID_HOST = "localhost:8000"
+
+
+def _build_stack_client(
+    monkeypatch,
+    *,
+    max_failures: int,
+    inner_status: int = 200,
+) -> TestClient:
+    """Assemble the real factory middleware stack in front of a configurable app.
+
+    The inner app echoes ``?status=`` so a test can simulate a genuine auth
+    failure originating *inside* the stack (past DNS validation), which is what
+    must still reach the rate limiter.
+    """
+    monkeypatch.delenv("AUTOMOX_MCP_DNS_REBINDING_PROTECTION", raising=False)
+    monkeypatch.delenv("AUTOMOX_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("AUTOMOX_MCP_ALLOWED_ORIGINS", raising=False)
+
+    middleware = build_transport_security_middleware(host=_HOST, port=_PORT)
+    # Tighten the limiter's threshold for the test without touching the order the
+    # factory produced (DNS outermost, rate limiter innermost).
+    for m in middleware:
+        if m.cls.__name__ == "AuthRateLimitMiddleware":
+            m.kwargs["max_failures"] = max_failures
+            m.kwargs["block_seconds"] = 300.0
+
+    def _status_app(request: Request) -> Response:
+        code = int(request.query_params.get("status", str(inner_status)))
+        return PlainTextResponse("response", status_code=code)
+
+    app = Starlette(routes=[Route("/", _status_app)], middleware=middleware)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# transport rejections are not counted; genuine auth failures still are
+# ---------------------------------------------------------------------------
+
+
+class TestTransportRejectionsNotRateLimited:
+    def test_invalid_origin_403s_do_not_block_client(self, monkeypatch):
+        """Repeated invalid-Origin 403s (a transport error) must not IP-block."""
+        client = _build_stack_client(monkeypatch, max_failures=3)
+
+        # Fire well past the limiter threshold; every one is a DNS-layer 403.
+        for _ in range(10):
+            resp = client.get(
+                "/",
+                headers={"host": _VALID_HOST, "origin": "http://evil.example.com"},
+            )
+            assert resp.status_code == 403
+
+        # A clean same-host request must still succeed — the client is NOT blocked
+        # (a 429 here would prove the transport 403s were miscounted as auth fails).
+        resp = client.get("/", headers={"host": _VALID_HOST})
+        assert resp.status_code == 200
+
+    def test_genuine_auth_failures_still_block_client(self, monkeypatch):
+        """403s that pass transport validation (from the app) must still count."""
+        client = _build_stack_client(monkeypatch, max_failures=3)
+
+        # These have a valid Host and no Origin, so they clear the DNS middleware
+        # and reach the inner app, which returns a genuine auth 403.
+        for _ in range(3):
+            resp = client.get("/?status=403", headers={"host": _VALID_HOST})
+            assert resp.status_code == 403
+
+        # Threshold reached — the next request is rate-limited (429).
+        resp = client.get("/?status=200", headers={"host": _VALID_HOST})
+        assert resp.status_code == 429
+        assert "Too many" in resp.text
+
+    def test_genuine_auth_401s_still_block_client(self, monkeypatch):
+        """401s from the app (real auth failures) must also count toward the limit."""
+        client = _build_stack_client(monkeypatch, max_failures=2)
+
+        for _ in range(2):
+            resp = client.get("/?status=401", headers={"host": _VALID_HOST})
+            assert resp.status_code == 401
+
+        resp = client.get("/?status=200", headers={"host": _VALID_HOST})
+        assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# auto-allowlist includes an https://{host} (default-port) origin
+# ---------------------------------------------------------------------------
+
+
+class TestHttpsDefaultPortOriginVariant:
+    @staticmethod
+    def _origins_for(host: str, port: int, monkeypatch) -> set[str]:
+        monkeypatch.delenv("AUTOMOX_MCP_DNS_REBINDING_PROTECTION", raising=False)
+        monkeypatch.delenv("AUTOMOX_MCP_ALLOWED_HOSTS", raising=False)
+        monkeypatch.delenv("AUTOMOX_MCP_ALLOWED_ORIGINS", raising=False)
+        mw = build_transport_security_middleware(host=host, port=port)
+        for m in mw:
+            if m.cls.__name__ == "DNSRebindingProtectionMiddleware":
+                return set(m.kwargs["allowed_origins"])
+        raise AssertionError("DNSRebindingProtectionMiddleware not built")
+
+    def test_https_default_port_origin_present(self, monkeypatch):
+        """A same-host HTTPS client sends ``https://host`` (443 omitted)."""
+        origins = self._origins_for("127.0.0.1", 443, monkeypatch)
+        # Default-port HTTPS form for the bound host and its loopback aliases.
+        assert "https://127.0.0.1" in origins
+        assert "https://localhost" in origins
+
+    def test_http_explicit_port_origin_still_present(self, monkeypatch):
+        """The existing http://host:port form must be preserved."""
+        origins = self._origins_for("127.0.0.1", 8000, monkeypatch)
+        assert "http://127.0.0.1:8000" in origins
+
+    def test_https_origin_matches_same_host_browser(self, monkeypatch):
+        """End-to-end: a same-host HTTPS Origin clears DNS-rebinding validation."""
+        monkeypatch.delenv("AUTOMOX_MCP_DNS_REBINDING_PROTECTION", raising=False)
+        monkeypatch.delenv("AUTOMOX_MCP_ALLOWED_HOSTS", raising=False)
+        monkeypatch.delenv("AUTOMOX_MCP_ALLOWED_ORIGINS", raising=False)
+        mw = build_transport_security_middleware(host="127.0.0.1", port=443)
+        app = Starlette(
+            routes=[Route("/", lambda r: PlainTextResponse("ok"))],
+            middleware=mw,
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/",
+            headers={"host": "localhost:443", "origin": "https://localhost"},
+        )
+        assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -122,12 +122,13 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.2.5"
+version = "2.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "pydantic" },
     { name = "python-dotenv" },
 ]
@@ -153,6 +154,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastmcp", specifier = ">=3.4.2" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "joserfc", specifier = ">=1.6.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.12" },
@@ -906,14 +908,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.4"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Hardens the authentication configuration and transport rate-limiting paths. Each change is surgical and covered by unit tests.

## Security

- **The per-IP authentication rate limiter no longer blocks clients over a transport-layer rejection.** An invalid-`Origin` / DNS-rebinding `403` was being counted as an authentication failure, so a misconfigured client (or a shared-IP reverse proxy) could be IP-blocked for 5 minutes after 10 such requests, and an unauthenticated caller could trip the limiter cheaply. The DNS-rebinding/Origin check now sits outside the rate limiter, so transport-security rejections are no longer counted — while **genuine authentication failures still are** (the abuse protection is fully preserved).

- **Floored the transitive `joserfc` dependency to `>=1.6.7`** for the fix to a JWS payload-size-limit bypass (CVE-2026-48990) — `joserfc` is pulled in via `fastmcp`'s OAuth/JWT support.

## Fixed

- **`AUTOMOX_MCP_OAUTH_ALGORITHM` is now case-insensitive.** A lowercase/mixed-case value (e.g. `rs256`) cleared the wrapper's validation but then crashed the server at startup inside the JWT verifier; the value is normalized so the server starts.
- **Setting both `AUTOMOX_MCP_OAUTH_JWKS_URI` and `AUTOMOX_MCP_OAUTH_PUBLIC_KEY` now fails fast with a clear error** naming the conflict, instead of crashing at startup with an opaque library error.
- **`EdDSA` is no longer advertised as a supported OAuth algorithm** — it was enumerated but always rejected (and unsupported downstream); configuring it now returns a clear "not a recognized algorithm" error.
- **The auto-derived `Origin` allowlist now matches a same-host client over HTTPS.** Under TLS, a same-host browser client's `https://{host}` Origin (default port) previously failed validation unless `AUTOMOX_MCP_ALLOWED_ORIGINS` was set manually.

## Testing

- New input→output unit tests per fix, asserting both directions of the rate-limiter change (transport `403` not counted; genuine `401`/`403` still counted).
- Full suite passes; `ruff` (format + lint), `mypy`, `bandit`, and the coverage gate are clean.
- Version metadata and the changelog are updated for the next patch release.
