### PR TITLE
docs(privacy): point to hosted Automox MCP Server Privacy Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Privacy policy now points at the hosted canonical URL.** The `privacy_policies` array in `mcpb/manifest.json` and the README "full privacy policy" link now reference the published [Automox MCP Server Privacy Policy](https://www.automox.com/legal/automox-mcp-server-privacy-policy) instead of the GitHub-hosted `PRIVACY.md` blob. `PRIVACY.md` is retained as an in-repo mirror and now names the hosted page as canonical. Content is unchanged (same 2026-05-29 revision).
+
 ## [2.2.7] - 2026-06-27
 
 ### Fixed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,6 +2,8 @@
 
 _Last updated: 2026-05-29_
 
+The canonical, hosted version of this policy is published at <https://www.automox.com/legal/automox-mcp-server-privacy-policy>. This file mirrors it for in-repo reference.
+
 The Automox MCP server is an open-source, locally executed Model Context Protocol (MCP) server that lets a user's own AI assistant interact with the Automox API. It runs on the user's machine (typically inside a desktop AI client such as Claude Desktop, packaged as an MCPB Desktop Extension) and acts as a stateless proxy between that assistant and `console.automox.com`.
 
 This document describes how data is handled when the server is run as distributed (PyPI package, Docker image, or MCPB bundle published by Automox). Self-hosted deployments may differ; this policy applies to the upstream artifact only.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The Automox MCP server acts as a stateless proxy between your AI assistant and t
 
 **Data retention:** The server retains no persistent data between sessions. In-memory caches (idempotency keys, rate-limit counters) are cleared when the process exits. Structured logs, when enabled, are written to stderr and are the deployer's responsibility to manage and retain.
 
-See [`PRIVACY.md`](PRIVACY.md) for the full privacy policy.
+See the [Automox MCP Server Privacy Policy](https://www.automox.com/legal/automox-mcp-server-privacy-policy) for the full privacy policy (mirrored in [`PRIVACY.md`](PRIVACY.md)).
 
 ## Alternative Installation
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -29,7 +29,7 @@
     "official"
   ],
   "privacy_policies": [
-    "https://github.com/AutomoxCommunity/automox-mcp/blob/main/PRIVACY.md"
+    "https://www.automox.com/legal/automox-mcp-server-privacy-policy"
   ],
   "server": {
     "type": "uv",


### PR DESCRIPTION
## What

Repoints the privacy-policy references from the GitHub-hosted `PRIVACY.md` blob to the published canonical URL: <https://www.automox.com/legal/automox-mcp-server-privacy-policy>.

- `mcpb/manifest.json` — `privacy_policies[]` → hosted URL (the machine-readable declaration the directory consumes)
- `README.md` — "full privacy policy" link → hosted URL (mirror note retained)
- `PRIVACY.md` — adds a canonical-source line; kept as the in-repo mirror
- `CHANGELOG.md` — entry under `[Unreleased] → Changed`

## Notes

- Policy **content is unchanged** — the hosted page mirrors `PRIVACY.md` at the same 2026-05-29 revision (verified live).
- Docs/metadata only: no tools, tests, source, version, or counts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)