### PR TITLE
docs: remove contributions notice and route support through Automox escalation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **README support routing updated.** Removed the "no external contributions" notice, pointed the caution note's support link at the Automox help center (`https://help.automox.com/hc/en-us`), and reworded the Support section to route questions, bug reports, and feature requests through the typical Automox escalation paths (Automox Support or your account team).
+
 - **Privacy policy now points at the hosted canonical URL.** The `privacy_policies` array in `mcpb/manifest.json` and the README "full privacy policy" link now reference the published [Automox MCP Server Privacy Policy](https://www.automox.com/legal/automox-mcp-server-privacy-policy) instead of the GitHub-hosted `PRIVACY.md` blob. `PRIVACY.md` is retained as an in-repo mirror and now names the hosted page as canonical. Content is unchanged (same 2026-05-29 revision).
 
 ## [2.2.7] - 2026-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **README support routing updated.** Removed the "no external contributions" notice, pointed the caution note's support link at the Automox help center (`https://help.automox.com/hc/en-us`), and reworded the Support section to route questions, bug reports, and feature requests through the typical Automox escalation paths (Automox Support or your account team).
+- **README and CONTRIBUTING support routing updated.** Removed the README's "no external contributions" notice, pointed the caution note's and CONTRIBUTING's support links at the Automox help center (`https://help.automox.com/hc/en-us`), and reworded the Support messaging to route questions, bug reports, and feature requests through the typical Automox escalation paths (Automox Support or your account team).
 
 - **Privacy policy now points at the hosted canonical URL.** The `privacy_policies` array in `mcpb/manifest.json` and the README "full privacy policy" link now reference the published [Automox MCP Server Privacy Policy](https://www.automox.com/legal/automox-mcp-server-privacy-policy) instead of the GitHub-hosted `PRIVACY.md` blob. `PRIVACY.md` is retained as an in-repo mirror and now names the hosted page as canonical. Content is unchanged (same 2026-05-29 revision).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 **This repository does not accept external contributions.** Issues and pull requests from outside Automox will not be reviewed or merged.
 
-- **Bug reports and feature requests:** use [help.automox.com](https://help.automox.com).
+- **Questions, bug reports, and feature requests:** use your typical Automox escalation paths — contact [Automox Support](https://help.automox.com/hc/en-us) or reach out to your account team.
 - **Security vulnerabilities:** see [`SECURITY.md`](SECURITY.md) for the private disclosure path — please do not open a public issue.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ Claude: Here's your readiness summary — 3 devices need patches,
         2 approvals are pending, and your patch policies run tonight at 2 AM...
 ```
 
-> [!IMPORTANT]
-> This repository does not accept external contributions. For bug reports or feature requests, use [help.automox.com](https://help.automox.com).
-
 > [!CAUTION]
-> AI assistants can make mistakes. Data produced by the MCP server may be incorrect or incomplete. If you see this happening consistently, please let us know via [help.automox.com](https://help.automox.com).
+> AI assistants can make mistakes. Data produced by the MCP server may be incorrect or incomplete. If you see this happening consistently, please let us know via [help.automox.com](https://help.automox.com/hc/en-us).
 
 ## Quick Start
 
@@ -330,6 +327,6 @@ MIT License. See [LICENSE](LICENSE).
 
 ## Support
 
-The official Automox MCP server. For questions, bugs, or feature requests use [help.automox.com](https://help.automox.com).
+The official Automox MCP server. For questions, bug reports, or feature requests, use your typical Automox escalation paths — contact [Automox Support](https://help.automox.com/hc/en-us) or reach out to your account team.
 
 To report a security vulnerability, see [SECURITY.md](SECURITY.md) — please do not open a public issue.


### PR DESCRIPTION
## Summary
- Remove the README `[!IMPORTANT]` no-external-contributions banner
- Point the `[!CAUTION]` note's support link at the help center: https://help.automox.com/hc/en-us
- Reword the README **Support** section and `CONTRIBUTING.md` to route questions, bug reports, and feature requests through the typical Automox escalation paths (Automox Support or your account team)
- Add the corresponding `CHANGELOG.md` entry under Unreleased

🤖 Generated with [Claude Code](https://claude.com/claude-code)