### PR TITLE
fix(webhooks): unwrap the data envelope in create/get/update webhook tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`create_webhook`, `get_webhook`, and `update_webhook` now read fields from the response `data` envelope.** The webhooks API returns single-object responses wrapped as `{"data": {...}}`, but these three tools read the fields at the top level and returned `null` for every field — including the one-time signing secret from `create_webhook`, which is shown only on creation and cannot be retrieved afterward. They now unwrap the `data` envelope before reading fields (with a safe fallback for un-enveloped responses). The `list` and `rotate` webhook tools already handled their responses correctly and are unchanged.
 
+### Security
+
+- **Floored `click>=8.3.3`** to force the fix for PYSEC-2026-2132 (a command-injection in `click.edit()`). `click` is a transitive dependency (via `typer`/`fastmcp`); the floor pulls in the patched version.
+
 ## [2.2.7] - 2026-06-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Privacy policy now points at the hosted canonical URL.** The `privacy_policies` array in `mcpb/manifest.json` and the README "full privacy policy" link now reference the published [Automox MCP Server Privacy Policy](https://www.automox.com/legal/automox-mcp-server-privacy-policy) instead of the GitHub-hosted `PRIVACY.md` blob. `PRIVACY.md` is retained as an in-repo mirror and now names the hosted page as canonical. Content is unchanged (same 2026-05-29 revision).
 
+### Fixed
+
+- **`create_webhook`, `get_webhook`, and `update_webhook` now read fields from the response `data` envelope.** The webhooks API returns single-object responses wrapped as `{"data": {...}}`, but these three tools read the fields at the top level and returned `null` for every field — including the one-time signing secret from `create_webhook`, which is shown only on creation and cannot be retrieved afterward. They now unwrap the `data` envelope before reading fields (with a safe fallback for un-enveloped responses). The `list` and `rotate` webhook tools already handled their responses correctly and are unchanged.
+
 ## [2.2.7] - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Topic :: System :: Systems Administration"
 ]
 dependencies = [
+  "click>=8.3.3",  # PYSEC-2026-2132: click.edit() command injection; transitive via typer/fastmcp
   "cryptography>=48.0.1",  # GHSA-537c-gmf6-5ccf: bundled-OpenSSL fix in wheels
   "fastmcp>=3.4.2",
   "httpx>=0.28",

--- a/src/automox_mcp/workflows/webhooks.py
+++ b/src/automox_mcp/workflows/webhooks.py
@@ -9,8 +9,25 @@ from ..client import AutomoxClient
 from ..utils.response import build_pagination_metadata
 
 
+def _unwrap_data(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Unwrap a single-object response from its top-level ``data`` envelope.
+
+    The Automox webhooks API returns single-object responses wrapped as
+    ``{"data": {<fields>}}``. Return the inner object when the envelope is
+    present, otherwise the input unchanged. Only a ``data`` whose value is
+    itself a mapping is unwrapped, so an already-unwrapped record (e.g. a list
+    item, which has no ``data`` key) or a non-enveloped response passes through
+    untouched — the fix stays correct if the API ever stops enveloping.
+    """
+    inner = result.get("data")
+    if isinstance(inner, Mapping):
+        return inner
+    return result
+
+
 def _summarize_webhook(webhook: Mapping[str, Any]) -> dict[str, Any]:
     """Extract key fields from a webhook record."""
+    webhook = _unwrap_data(webhook)
     return {
         "id": webhook.get("id"),
         "name": webhook.get("name"),
@@ -219,14 +236,15 @@ async def create_webhook(
 
     data: dict[str, Any]
     if isinstance(result, Mapping):
+        webhook = _unwrap_data(result)
         data = {
-            "id": result.get("id"),
-            "name": result.get("name"),
-            "url": result.get("url"),
-            "enabled": result.get("enabled"),
-            "eventTypes": result.get("eventTypes"),
-            "secret": result.get("secret"),
-            "createdAt": result.get("createdAt"),
+            "id": webhook.get("id"),
+            "name": webhook.get("name"),
+            "url": webhook.get("url"),
+            "enabled": webhook.get("enabled"),
+            "eventTypes": webhook.get("eventTypes"),
+            "secret": webhook.get("secret"),
+            "createdAt": webhook.get("createdAt"),
             "_important": (
                 "SAVE THE SECRET NOW. The signing secret above is only shown once "
                 "and cannot be retrieved later. Store it securely for signature "

--- a/tests/test_workflows_webhooks.py
+++ b/tests/test_workflows_webhooks.py
@@ -145,6 +145,25 @@ async def test_get_webhook_returns_detail() -> None:
     assert result["data"]["enabled"] is True
 
 
+@pytest.mark.asyncio
+async def test_get_webhook_unwraps_data_envelope() -> None:
+    """A single-object get response wrapped in a `data` envelope surfaces fields."""
+    client = StubClient(
+        get_responses={
+            f"/organizations/{_ORG_UUID}/webhooks/wh-001": [{"data": _WEBHOOK_A}],
+        }
+    )
+    result = await get_webhook(
+        cast(AutomoxClient, client),
+        org_uuid=_ORG_UUID,
+        webhook_id="wh-001",
+    )
+
+    assert result["data"]["name"] == "Deploy Hook"
+    assert result["data"]["id"] == "wh-001"
+    assert result["data"]["enabled"] is True
+
+
 # ---------------------------------------------------------------------------
 # list_webhook_deliveries
 # ---------------------------------------------------------------------------
@@ -264,6 +283,50 @@ async def test_create_webhook_returns_secret() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_webhook_unwraps_data_envelope() -> None:
+    """A single-object create response wrapped in a top-level `data` envelope
+    still surfaces the real fields — including the one-time signing secret."""
+    enveloped = {"data": {**_WEBHOOK_A, "secret": "whsec_live_abc123"}}
+    client = StubClient(
+        post_responses={
+            f"/organizations/{_ORG_UUID}/webhooks": [enveloped],
+        }
+    )
+    result = await create_webhook(
+        cast(AutomoxClient, client),
+        org_uuid=_ORG_UUID,
+        name="Deploy Hook",
+        url="https://example.com/hook",
+        event_types=["device.compliant"],
+    )
+
+    assert result["data"]["secret"] == "whsec_live_abc123"
+    assert result["data"]["id"] == "wh-001"
+    assert result["data"]["name"] == "Deploy Hook"
+
+
+@pytest.mark.asyncio
+async def test_create_webhook_flat_response_still_works() -> None:
+    """A flat (un-enveloped) create response is unchanged — no regression."""
+    created = {**_WEBHOOK_A, "secret": "s3cr3t-key"}
+    client = StubClient(
+        post_responses={
+            f"/organizations/{_ORG_UUID}/webhooks": [created],
+        }
+    )
+    result = await create_webhook(
+        cast(AutomoxClient, client),
+        org_uuid=_ORG_UUID,
+        name="Deploy Hook",
+        url="https://example.com/hook",
+        event_types=["device.compliant"],
+    )
+
+    assert result["data"]["secret"] == "s3cr3t-key"
+    assert result["data"]["id"] == "wh-001"
+
+
+@pytest.mark.asyncio
 async def test_create_webhook_sends_correct_body() -> None:
     client = StubClient(
         post_responses={
@@ -308,6 +371,28 @@ async def test_update_webhook_partial_update() -> None:
     assert result["data"]["enabled"] is False
     body = client.calls[0][2]
     assert body == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_update_webhook_unwraps_data_envelope() -> None:
+    """A single-object update response wrapped in a `data` envelope surfaces fields."""
+    client = StubClient(
+        patch_responses={
+            f"/organizations/{_ORG_UUID}/webhooks/wh-001": [
+                {"data": {**_WEBHOOK_A, "enabled": False}},
+            ],
+        }
+    )
+    result = await update_webhook(
+        cast(AutomoxClient, client),
+        org_uuid=_ORG_UUID,
+        webhook_id="wh-001",
+        enabled=False,
+    )
+
+    assert result["data"]["updated"] is True
+    assert result["data"]["name"] == "Deploy Hook"
+    assert result["data"]["enabled"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The webhooks API ([`POST /organizations/{orgUuid}/webhooks`](https://console.automox.com/api/docs#webhooks/tag/webhooks/POST/api/organizations/{orgUuid}/webhooks)) wraps single-object responses in a top-level `data` object: `{"data": {...}}`. `create_webhook`, `get_webhook`, and `update_webhook` read the fields at the top level, so every field came back `null` — including the one-time signing secret from `create_webhook`, which the API returns only on creation and cannot be retrieved afterward. A user who created a webhook through the MCP server never received their signing secret.

## Fix

Add a small `_unwrap_data` helper and apply it where the single-object responses are read:

- `_summarize_webhook` now unwraps, fixing `get_webhook` and `update_webhook` at their shared summarization point.
- `create_webhook` unwraps before extracting fields, so the signing secret surfaces.

The helper returns the inner object only when `data` is a mapping, so it is a no-op for the already-unwrapped list paths and a safe fallback if a response is not enveloped. `list_webhooks`, `list_webhook_deliveries`, and `rotate_webhook_secret` already handled their responses correctly and are unchanged.

## Tests

New tests cover the enveloped `create` / `get` / `update` responses (asserting the signing secret surfaces on create) plus a flat-response no-regression test. Full local gate green (`ruff`, `mypy`, `pytest` with the coverage floor).