### PR TITLE
ci(zizmor): suppress adhoc-packages on mcpb CLI install steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
           PY
 
       - name: Install MCPB CLI
+        # zizmor: ignore[adhoc-packages] — mcpb CLI is a one-off global install with
+        # no lockfile; pinning is tracked by the supply-chain TODO in release.yml.
         run: npm install -g @anthropic-ai/mcpb
 
       - name: Validate MCPB manifest schema

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
       # TODO(supply chain): pin @anthropic-ai/mcpb once we settle a version.
       # ---------------------------------------------------------------
       - name: Install MCPB CLI
+        # zizmor: ignore[adhoc-packages] — mcpb CLI is a one-off global install with
+        # no lockfile; pinning is tracked by the supply-chain TODO above.
         run: |
           node --version
           npm install -g @anthropic-ai/mcpb


### PR DESCRIPTION
## Why

Merging #241 bumped `zizmorcore/zizmor-action` **0.5.6 → 0.5.7**, whose newer zizmor binary (v1.26/1.27) promoted the `adhoc-packages` audit to a **failing** finding. This turned main's **Security Scans** workflow red on two *pre-existing* unpinned installs:

- `ci.yml:190` — `npm install -g @anthropic-ai/mcpb`
- `release.yml:90` — same, inside the MCPB CLI install step

Neither line was touched by the dependency bumps; only the audit's severity behavior changed.

## Fix

Add scoped `# zizmor: ignore[adhoc-packages]` comments to those two known steps. The audit stays active everywhere else, so any *new* ad-hoc package install still fails CI.

Pinning the mcpb CLI to a lockfile-backed version is the real supply-chain fix and remains tracked by the existing `TODO(supply chain)` in `release.yml` — out of scope here.

## Verification

`uvx zizmor --offline .github/` → **No findings to report** (exit 0; 2 ignored, 13 suppressed). No behavior change — comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)