### PR TITLE
chore(release): 2.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.9] - 2026-07-21
+
 ### Changed
 
 - **The MCPB bundle's support link now points to `https://docs.automox.com/`.** The previous target (`https://help.automox.com`) sits behind bot protection that can return HTTP 403 to automated reachability checks and to users behind similar network filtering; the documentation site resolves cleanly without an interstitial.
+- **Bumped the resolved `mcp` runtime to 1.28.1** in the lockfile. The declared floor (`mcp>=1.27.2`) is unchanged; this is a lockfile-only refresh of the transitive resolution.
 
 ### Fixed
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "automox-mcp",
   "display_name": "Automox",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "Talk to your Automox console in natural language. Manage devices, patches, and policies.",
   "long_description": "The official Automox MCP server, packaged as a Claude Desktop Extension. Connects Claude to your Automox environment so you can manage devices, check compliance posture, run policies, prepare for Patch Tuesday, browse the worklet catalog, drive Splashtop remote-control sessions, and more \u2014 all by asking. Exposes 133 MCP tools across 18 domains (devices, policies, patches, groups, webhooks, worklets, vulnerability sync, audit, reports, Splashtop remote control, and more), 14 MCP resources (including interactive MCP App UIs for compliance triage, patch-approval review, policy blast-radius review, remediation-apply review, and RBAC access certification), and 6 workflow prompts (audit_policy, investigate_device, onboard_group, patch_tuesday, security_posture, triage_failure). Read-only mode and modular tool loading are supported via optional configuration.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "automox-mcp-bundle"
-version = "2.2.8"
+version = "2.2.9"
 description = "MCPB Desktop Extension wrapper for the official Automox MCP server"
 requires-python = ">=3.11"
 dependencies = [
-  "automox-mcp>=2.2.8",
+  "automox-mcp>=2.2.9",
 ]
 
 # This pyproject.toml is consumed by `uv run` inside the MCPB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automox-mcp"
-version = "2.2.8"
+version = "2.2.9"
 description = "Official MCP server for Automox"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/AutomoxCommunity/automox-mcp",
     "source": "github"
   },
-  "version": "2.2.8",
+  "version": "2.2.9",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "automox-mcp",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "transport": {
         "type": "stdio"
       },

--- a/tests/smoke_production.py
+++ b/tests/smoke_production.py
@@ -1388,7 +1388,9 @@ async def run_readonly_tools() -> None:
         # 75–78. Saved-search detail tools (need a saved search to exist)
         resp = await _safe_call(session, "list_saved_searches", {})
         saved = _extract_list(resp.get("data")) if resp else []
-        saved_id = _extract_id(saved[0], "id", "saved_search_id") if saved else None
+        # The saved-search id is a UUID *string*; read it directly (don't use
+        # _extract_id, which coerces to int and would raise on a UUID).
+        saved_id = (saved[0].get("id") or saved[0].get("saved_search_id")) if saved else None
         saved_uuid = None
         if saved:
             saved_uuid = (

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "automox-mcp"
-version = "2.2.8"
+version = "2.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release 2.2.9

Cuts the changes merged since 2.2.8 into a release.

### Version bump (all sync'd — enforced by the `manifests` CI job)
`pyproject.toml`, `server.json` (top-level + `packages[].version`), `mcpb/manifest.json`, `mcpb/pyproject.toml` (version **and** the `automox-mcp>=2.2.9` floor), and `uv.lock` (automox-mcp editable version only — no other resolution changes).

### CHANGELOG → `[2.2.9] - 2026-07-21`
- **Changed** — MCPB bundle support link now points to `docs.automox.com` (#242); resolved `mcp` runtime bumped to 1.28.1 in the lockfile (floor `mcp>=1.27.2` unchanged) (#243)
- **Fixed** — `.mcpb` bundle now ships `LICENSE`, `README.md`, `SECURITY.md`, `PRIVACY.md`, with a release-time verification step (#242)

CI-only changes (#241 actions-group bumps, #244 zizmor suppression) are intentionally omitted from the CHANGELOG — they don't ship in the package.

### Smoke-harness fix (test-only, not shipped)
The saved-search read path routed a UUID `id` through `_extract_id` (which int-coerces), crashing the smoke run on this tenant. Now reads the id directly, matching the pattern the write path already used. No product change — `get_saved_search` already expects `saved_search_id: str`.

### Verification
- `ruff format --check` / `ruff check` / `mypy .` — clean
- `pytest --cov` — **1720 passed, 92.67%** (≥90 floor)
- `uv sync --frozen` + `uv export --locked` — both pass (lock consistent)
- **Live smoke suite: 104 passed, 0 failed** (manual pre-tag gate)

After merge, the release is cut by pushing the `v2.2.9` tag — **awaiting your explicit go-ahead** for that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)