### PR TITLE
Depend on fastmcp-slim[server] instead of the fastmcp metapackage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,14 @@ classifiers = [
 dependencies = [
   "click>=8.3.3",  # PYSEC-2026-2132: click.edit() command injection; transitive via typer/fastmcp
   "cryptography>=48.0.1",  # GHSA-537c-gmf6-5ccf: bundled-OpenSSL fix in wheels
-  "fastmcp>=3.4.2",
+  # fastmcp-slim[server], not the fastmcp metapackage: fastmcp is a code-less
+  # shell whose sole dependency is fastmcp-slim[client,server] -- depending on it
+  # adds one more PyPI package to the supply chain for zero code. [server] is the
+  # extra the deployed http_app/create_server path actually needs. NOTE: the
+  # desktop conveniences (keyring, pyperclip, watchfiles, websockets) still ship
+  # -- they are declared inside fastmcp-slim's server extra itself; pruning them
+  # requires an upstream fastmcp split, not a change here.
+  "fastmcp-slim[server]>=3.4.2",
   "httpx>=0.28",
   "joserfc>=1.6.7",  # CVE-2026-48990: JWS payload-size-limit bypass; transitive via fastmcp
   "pydantic>=2.12",
@@ -88,7 +95,7 @@ exclude_dirs = ["tests", ".venv"]
 constraint-dependencies = [
   "authlib>=1.6.11",      # CVE-2025-68158, GHSA-jj8c-mmj3-mmgv: CSRF in cache-backed state storage
   "cryptography>=48.0.1", # CVE-2026-26007, CVE-2026-34073; GHSA-537c-gmf6-5ccf (bundled-OpenSSL fix in wheels)
-  "fastmcp>=3.4.2",       # >=3.2.0: CVE-2025-69196, CVE-2025-64340, CVE-2026-27124, GHSA-rcfx-77hg-w2wv; >=3.4.2: OAuth-proxy/cache/header-forwarding hardening (3.2.4/3.3.0)
+  "fastmcp-slim>=3.4.2",  # >=3.2.0: CVE-2025-69196, CVE-2025-64340, CVE-2026-27124, GHSA-rcfx-77hg-w2wv; >=3.4.2: OAuth-proxy/cache/header-forwarding hardening (3.2.4/3.3.0). Floor moved from the fastmcp metapackage to fastmcp-slim (where the code lives).
   "idna>=3.15",           # CVE-2026-45409 (DoS via crafted IDN encoding; supersedes CVE-2024-3651 fix)
   "jaraco-context>=6.1.0",# CVE-2026-23949
   "mcp>=1.27.2",          # >=1.23.0: CVE-2025-66416; >=1.27.2: GHSA-jpw9-pfvf-9f58 (CVSS 7.1, transport session principal binding), GHSA-hvrp-rf83-w775 (CVSS 7.6, experimental-task isolation)

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 constraints = [
     { name = "authlib", specifier = ">=1.6.11" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastmcp", specifier = ">=3.4.2" },
+    { name = "fastmcp-slim", specifier = ">=3.4.2" },
     { name = "idna", specifier = ">=3.15" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "mcp", specifier = ">=1.27.2" },
@@ -130,7 +130,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
-    { name = "fastmcp" },
+    { name = "fastmcp-slim", extra = ["server"] },
     { name = "httpx" },
     { name = "joserfc" },
     { name = "pydantic" },
@@ -157,7 +157,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastmcp", specifier = ">=3.4.2" },
+    { name = "fastmcp-slim", extras = ["server"], specifier = ">=3.4.2" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "joserfc", specifier = ">=1.6.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9" },
@@ -689,18 +689,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastmcp"
-version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastmcp-slim", extra = ["client", "server"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
-]
-
-[[package]]
 name = "fastmcp-slim"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -718,15 +706,6 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-client = [
-    { name = "authlib" },
-    { name = "exceptiongroup" },
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "opentelemetry-api" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "starlette" },
-]
 server = [
     { name = "authlib" },
     { name = "cyclopts" },


### PR DESCRIPTION
## What

Swaps the runtime dependency `fastmcp>=3.4.2` → `fastmcp-slim[server]>=3.4.2`, and moves the `[tool.uv]` security constraint floor accordingly. Lockfile regenerated (`uv lock`): the only change is the removal of `fastmcp` itself.

## Why

`fastmcp` is a code-less metapackage (6-file RECORD) whose sole dependency is `fastmcp-slim[client,server]` — the actual `fastmcp` module code ships in `fastmcp-slim`. Depending on the shell:

- adds one more PyPI package to the supply chain for zero code (one more name that can be hijacked/typosquatted between releases), and
- pulls the `client` extra, which a deployed server doesn't use.

`[server]` is the extra the `create_server()`/`http_app()` path actually needs (mcp, starlette, sse-starlette, auth providers).

## What this deliberately does NOT claim

The desktop conveniences (`keyring`, `pyperclip`, `watchfiles`, `websockets`, uvicorn's self-serve path) **still ship** — they are declared inside `fastmcp-slim`'s own `server` extra, so no dependency choice in this repo can drop them. Verified empirically: resolving with `fastmcp` vs `fastmcp-slim[server]` differs by exactly one package (the metapackage shell). Pruning them for real needs an upstream `fastmcp` split of the server extra (server-core vs CLI conveniences); a comment in pyproject.toml now records this so the next person doesn't re-derive it.

Context: this closes out finding I2 of the 2026-07 automox-mcp-infra security review (INDE-1732) — deployment-side mitigation (exact-version, hash-verified, wheels-only lockfile) already landed there.

## Verification

- Full test suite: **1719/1719 pass** on the new resolution
- `ruff` clean, `mypy` clean (75 files)
- `from fastmcp import FastMCP` + auth-provider imports verified resolving from `fastmcp-slim`
- `uv lock` diff: removes `fastmcp==3.4.2`, nothing else changes