### PR TITLE
Resolve account_id from the client identity before the environment

### DIFF
--- a/src/automox_mcp/tools/account_tools.py
+++ b/src/automox_mcp/tools/account_tools.py
@@ -55,6 +55,9 @@ def register(server: FastMCP, *, read_only: bool = False, client: AutomoxClient)
     def _resolve_account_id(explicit: str | None = None) -> str:
         if explicit:
             return explicit
+        client_value = client.account_uuid
+        if client_value:
+            return client_value
         env_value = os.environ.get("AUTOMOX_ACCOUNT_UUID")
         if not env_value:
             raise ToolError(

--- a/tests/test_tool_defaults.py
+++ b/tests/test_tool_defaults.py
@@ -110,7 +110,7 @@ async def test_account_tools_use_env_fallback(monkeypatch):
     monkeypatch.setattr(account_tools.workflows, "invite_user_to_account", fake_invite)
 
     server = StubServer()
-    account_tools.register(server, client=FakeClient())
+    account_tools.register(server, client=FakeClient(account_uuid=""))
     tool_fn = server.tools["invite_user_to_account"]
 
     await tool_fn(email="user@example.com", account_rbac_role="global-admin")
@@ -121,7 +121,7 @@ async def test_account_tools_error_when_env_missing(monkeypatch):
     monkeypatch.delenv("AUTOMOX_ACCOUNT_UUID", raising=False)
 
     server = StubServer()
-    account_tools.register(server, client=FakeClient())
+    account_tools.register(server, client=FakeClient(account_uuid=""))
     tool_fn = server.tools["remove_user_from_account"]
 
     with pytest.raises(ToolError):

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -1634,12 +1634,40 @@ class TestAccountToolsErrorHandling:
         monkeypatch.delenv("AUTOMOX_ACCOUNT_UUID", raising=False)
 
         server = StubServer()
-        account_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+        account_tools.register(
+            server, read_only=False, client=FakeClient(org_id=42, account_uuid="")
+        )
 
         with pytest.raises(ToolError):
             await server.tools["invite_user_to_account"](
                 email="test@example.com", account_rbac_role="global-admin"
             )
+
+    @pytest.mark.asyncio
+    async def test_account_id_prefers_client_identity_over_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from automox_mcp.tools import account_tools
+
+        recorded: dict[str, Any] = {}
+
+        async def fake_invite(client, **kwargs):
+            recorded.update(kwargs)
+            return _success()
+
+        monkeypatch.setattr(account_tools.workflows, "invite_user_to_account", fake_invite)
+        monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", "cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+        server = StubServer()
+        account_tools.register(server, read_only=False, client=FakeClient(org_id=42))
+
+        await server.tools["invite_user_to_account"](
+            email="test@example.com", account_rbac_role="global-admin"
+        )
+
+        # The client's identity (per-request in embedding deployments) wins over
+        # process env.
+        assert str(recorded.get("account_id")) == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
 
 # ---------------------------------------------------------------------------
@@ -2243,13 +2271,12 @@ class TestAccountWriteToolsDispatch:
 
     @pytest.mark.asyncio
     async def test_create_zone(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("AUTOMOX_ACCOUNT_UUID", _ACCT_UUID)
         recorded = self._wire(monkeypatch, "create_zone")
         server = StubServer()
         account_tools.register(server, read_only=False, client=FakeClient(org_id=42))
         await server.tools["create_zone"](name="EU Zone")
         assert recorded["name"] == "EU Zone"
-        assert str(recorded["account_id"]) == _ACCT_UUID
+        assert str(recorded["account_id"]) == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
     @pytest.mark.asyncio
     async def test_update_user(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

`_resolve_account_id()` in `tools/account_tools.py` re-reads `AUTOMOX_ACCOUNT_UUID` from the process environment on every call, ignoring the `client` instance the tools were registered with. The docstring contract elsewhere in the codebase treats the client as the identity carrier, and `AutomoxClient.__init__` already validates `account_uuid` from that same env var — so for plain stdio usage the two always agree and this change is behavior-preserving.

But deployments that embed the server with a custom client carrying per-request identity (e.g. a contextvar-backed `account_uuid`, as in the hosted Lambda shim) are silently bypassed: ~10 account/zone tools (invite/remove user, get_account, RBAC roles, zones, keys) interpolate whatever the process env holds instead of the caller's identity.

## Change

Prefer, in order: the explicit `account_id` argument → `client.account_uuid` → the env fallback with the existing `ToolError`. One added lookup, no signature or error-contract changes.

## Tests

- New `test_account_id_prefers_client_identity_over_env` pins the preference order.
- Four existing tests asserted env-first resolution and are updated to keep exercising their original intent: the two env-fallback/error tests now register with `FakeClient(account_uuid="")` so the fallback path is still what's covered; `test_create_zone` and `test_missing_account_uuid_raises_tool_error` are adjusted for client-first resolution.

Local: `ruff check .` clean; full suite `pytest --cov=automox_mcp --cov-fail-under=90` → 1720 passed, 92.67% coverage.